### PR TITLE
Improve expanded player layout and lyrics UX

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -962,8 +962,12 @@ export default function App(): JSX.Element {
 
   return (
     <main
-      className={`mx-auto min-h-screen w-full max-w-7xl px-4 pt-6 md:px-6 ${
-        hasStickyPlayer ? "pb-[calc(18rem+env(safe-area-inset-bottom))]" : "pb-[calc(2.5rem+env(safe-area-inset-bottom))]"
+      className={`mx-auto flex min-h-[100dvh] w-full max-w-7xl flex-col px-4 pt-6 md:px-6 ${
+        hasStickyPlayer
+          ? "pb-[calc(18rem+env(safe-area-inset-bottom))]"
+          : activeView === "player"
+            ? "pb-0"
+            : "pb-[calc(2.5rem+env(safe-area-inset-bottom))]"
       }`}
     >
       <header className="mb-4 rounded-3xl border border-flaque-clay/60 bg-white/80 px-5 py-4 shadow-panel backdrop-blur-sm">
@@ -1296,11 +1300,15 @@ export default function App(): JSX.Element {
         <div
           className={
             activeView === "player"
-              ? "mt-4"
+              ? "flex min-h-0 flex-1 pb-[env(safe-area-inset-bottom)]"
               : "fixed bottom-0 left-0 right-0 z-40 px-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pt-2"
           }
         >
-          <div className="mx-auto max-w-7xl">
+          <div
+            className={
+              activeView === "player" ? "mx-auto flex h-full min-h-0 w-full max-w-7xl flex-col" : "mx-auto max-w-7xl"
+            }
+          >
             {playerStatusMessage ? (
               <p className="mb-2 rounded-xl border border-flaque-clay/60 bg-white/85 px-3 py-2 text-sm text-flaque-steel" role="status">
                 {playerStatusMessage}

--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -6,6 +6,7 @@ import type { Playlist, Track } from "../types";
 import {
   getTrackDisplayAlbumWithYear,
   getTrackDisplayArtist,
+  getTrackDisplayLyrics,
   getTrackDisplayTitle
 } from "../utils/tracks";
 
@@ -112,6 +113,7 @@ export function AudioPlayer({
   const [playlistSubmitStatus, setPlaylistSubmitStatus] = useState<string | null>(null);
   const [playlistSubmitLoading, setPlaylistSubmitLoading] = useState(false);
   const [showQueuePanel, setShowQueuePanel] = useState(false);
+  const [showLyricsOverlay, setShowLyricsOverlay] = useState(false);
   const [volume, setVolume] = useState<number>(() => readStoredVolume());
   const [muted, setMuted] = useState(false);
 
@@ -234,6 +236,16 @@ export function AudioPlayer({
     window.localStorage.setItem(PLAYER_VOLUME_STORAGE_KEY, String(volume));
   }, [volume]);
 
+  useEffect(() => {
+    setShowLyricsOverlay(false);
+  }, [track?.id]);
+
+  useEffect(() => {
+    if (!expanded) {
+      setShowLyricsOverlay(false);
+    }
+  }, [expanded]);
+
   function onTogglePlayback(): void {
     const audioElement = audioRef.current;
     if (!audioElement || !track) {
@@ -334,7 +346,7 @@ export function AudioPlayer({
     ? "flex items-center justify-end gap-2"
     : "flex min-w-0 flex-1 items-center justify-end gap-2";
   const sectionClassName = expanded
-    ? "rounded-3xl border border-flaque-clay/50 bg-white/75 p-6 shadow-panel backdrop-blur-sm md:p-8"
+    ? "flex h-full min-h-0 flex-col rounded-3xl border border-flaque-clay/50 bg-white/75 p-6 shadow-panel backdrop-blur-sm md:p-8"
     : "rounded-3xl border border-flaque-clay/60 bg-white/90 p-4 shadow-panel backdrop-blur-sm md:p-6";
   const artworkClassName = expanded
     ? `${artworkSize} shrink-0 rounded-2xl object-cover shadow-md`
@@ -357,6 +369,8 @@ export function AudioPlayer({
   const displayTitle = getTrackDisplayTitle(track);
   const displayArtist = getTrackDisplayArtist(track) ?? "Unknown artist";
   const displayAlbumWithYear = getTrackDisplayAlbumWithYear(track);
+  const displayLyrics = getTrackDisplayLyrics(track);
+  const hasLyrics = Boolean(displayLyrics);
 
   const hasPlayablePlaylists = playlists.length > 0;
   const activePlaylistId = selectedPlaylistId || playlists[0]?.id || "";
@@ -425,8 +439,47 @@ export function AudioPlayer({
         }}
       />
 
-      <div className={`flex min-w-0 ${expanded ? "flex-col items-center gap-7" : "flex-col gap-4 md:flex-row md:items-center"}`}>
-        {onArtworkClick && !expanded ? (
+      <div
+        className={`flex min-w-0 ${
+          expanded ? "min-h-0 flex-1 flex-col items-center justify-between gap-6" : "flex-col gap-4 md:flex-row md:items-center"
+        }`}
+      >
+        {expanded ? (
+          <div className="flex w-full items-start justify-center gap-3">
+            {hasLyrics ? (
+              <button
+                className={`rounded-xl border px-3 py-2 text-xs font-medium uppercase tracking-[0.12em] transition ${
+                  showLyricsOverlay
+                    ? "border-flaque-ink bg-flaque-ink text-flaque-cream"
+                    : "border-flaque-clay bg-white text-flaque-ink hover:bg-flaque-cream"
+                }`}
+                type="button"
+                onClick={() => setShowLyricsOverlay((current) => !current)}
+                aria-pressed={showLyricsOverlay}
+                aria-label={showLyricsOverlay ? "Hide lyrics" : "Show lyrics"}
+              >
+                Lyrics
+              </button>
+            ) : null}
+
+            <div className="relative shrink-0 overflow-hidden rounded-2xl">
+              <img
+                className={artworkClassName}
+                src={coverUrl(track.id, track.cover)}
+                alt={displayAlbumWithYear ? `Cover for ${displayAlbumWithYear}` : "Track cover"}
+                onError={(event) => {
+                  event.currentTarget.src = defaultCoverImage;
+                }}
+              />
+
+              {showLyricsOverlay && displayLyrics ? (
+                <div className="absolute inset-0 bg-black/60 p-4 text-left text-sm leading-relaxed text-flaque-cream">
+                  <div className="h-full overflow-auto whitespace-pre-wrap">{displayLyrics}</div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ) : onArtworkClick ? (
           <button
             className="shrink-0 rounded-2xl"
             type="button"

--- a/frontend/src/utils/tracks.ts
+++ b/frontend/src/utils/tracks.ts
@@ -1,4 +1,4 @@
-import type { Track } from "../types";
+import type { Track, TrackTagExtraValue } from "../types";
 
 export function fileNameFromPath(filePath: string): string {
   const normalized = filePath.replace(/\\/g, "/");
@@ -31,6 +31,63 @@ function extractYearFromDate(value?: string): string | undefined {
 
   const match = value.match(/(?:^|\D)(\d{4})(?:\D|$)/);
   return match?.[1];
+}
+
+function normalizeLyricsText(value: string): string | undefined {
+  const normalized = value
+    .replace(/\r\n?/g, "\n")
+    .replace(/\\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  return normalized ? normalized : undefined;
+}
+
+function extractLyricsFromExtraValue(value: TrackTagExtraValue | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (typeof value === "string") {
+    return normalizeLyricsText(value);
+  }
+
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const joined = value
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .join("\n");
+
+  return joined ? normalizeLyricsText(joined) : undefined;
+}
+
+function extractLyricsFromExtra(extra: Record<string, TrackTagExtraValue> | undefined): string | undefined {
+  if (!extra) {
+    return undefined;
+  }
+
+  for (const [key, rawValue] of Object.entries(extra)) {
+    const normalizedKey = key.toLowerCase();
+    const looksLikeLyricsKey =
+      (normalizedKey.includes("lyric") && !normalizedKey.includes("lyricist")) ||
+      normalizedKey === "uslt" ||
+      normalizedKey === "lyrics";
+
+    if (!looksLikeLyricsKey) {
+      continue;
+    }
+
+    const lyrics = extractLyricsFromExtraValue(rawValue);
+    if (lyrics) {
+      return lyrics;
+    }
+  }
+
+  return undefined;
 }
 
 export function getTrackDisplayArtist(track: Pick<Track, "tags">): string | undefined {
@@ -77,4 +134,21 @@ export function getTrackDisplayAlbumWithYear(track: Pick<Track, "tags">): string
 
   const year = getTrackDisplayYear(track);
   return year ? `${album} (${year})` : album;
+}
+
+export function getTrackDisplayLyrics(track: Pick<Track, "tags">): string | undefined {
+  const extraLyrics = extractLyricsFromExtra(track.tags.extra);
+  if (extraLyrics) {
+    return extraLyrics;
+  }
+
+  if (!Array.isArray(track.tags.comment)) {
+    return undefined;
+  }
+
+  const commentLyricsCandidate = track.tags.comment
+    .map((entry) => normalizeLyricsText(entry))
+    .find((entry): entry is string => Boolean(entry && entry.includes("\n")));
+
+  return commentLyricsCandidate;
 }


### PR DESCRIPTION
## Summary
- make the dedicated Player view fill the remaining viewport height so the reader/player surface reaches the bottom of the screen
- add a contextual Lyrics toggle in expanded player mode and display lyrics over the artwork with a readable overlay when metadata includes lyrics
- tighten compact player alignment so title/metadata, transport buttons, and utility controls sit on a cleaner shared baseline

## Validation
- npm run build --workspace frontend