### PR TITLE
Improve production auth recovery scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ npm run prod:up
 npm run prod:down
 ```
 
+Operational helpers:
+
+```bash
+# Reset (or create) an admin password
+npm run prod:admin:reset-password -- <username>
+
+# Delete and recreate auth DB (users + sessions), then bootstrap admin from .env.production
+npm run prod:authdb:reset
+```
+
 ## Technical Choices
 
 - **npm workspaces monorepo** (`backend`, `frontend`) to keep product/API/UI changes aligned.

--- a/backend/src/auth/session.ts
+++ b/backend/src/auth/session.ts
@@ -4,6 +4,31 @@ export const SESSION_COOKIE_NAME = "flaque_session";
 
 const DEFAULT_SESSION_TTL_HOURS = 24 * 7;
 
+function parseBooleanEnv(value: string | undefined): boolean | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+
+  return null;
+}
+
+function useSecureSessionCookie(): boolean {
+  const fromEnv = parseBooleanEnv(process.env.SESSION_COOKIE_SECURE);
+  if (fromEnv !== null) {
+    return fromEnv;
+  }
+  return process.env.NODE_ENV === "production";
+}
+
 export function getSessionTtlMs(): number {
   const fromEnv = Number(process.env.SESSION_TTL_HOURS ?? DEFAULT_SESSION_TTL_HOURS);
   const ttlHours = Number.isFinite(fromEnv) && fromEnv > 0 ? fromEnv : DEFAULT_SESSION_TTL_HOURS;
@@ -14,7 +39,7 @@ export function setSessionCookie(res: Response, sessionId: string, expiresAt: nu
   res.cookie(SESSION_COOKIE_NAME, sessionId, {
     httpOnly: true,
     sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
+    secure: useSecureSessionCookie(),
     expires: new Date(expiresAt)
   });
 }
@@ -23,6 +48,6 @@ export function clearSessionCookie(res: Response): void {
   res.clearCookie(SESSION_COOKIE_NAME, {
     httpOnly: true,
     sameSite: "lax",
-    secure: process.env.NODE_ENV === "production"
+    secure: useSecureSessionCookie()
   });
 }

--- a/backend/src/scripts/resetAdminPassword.ts
+++ b/backend/src/scripts/resetAdminPassword.ts
@@ -1,0 +1,84 @@
+import "dotenv/config";
+
+import { createUser, findUserByUsername, initializeAuthDatabase, updateUserPassword } from "../auth/db";
+
+function getArgValue(flag: string): string | null {
+  const index = process.argv.indexOf(flag);
+  if (index < 0) {
+    return null;
+  }
+
+  return process.argv[index + 1] ?? null;
+}
+
+function requireNonEmpty(input: string | null | undefined, label: string): string {
+  const value = (input ?? "").trim();
+  if (!value) {
+    throw new Error(`${label} is required`);
+  }
+  return value;
+}
+
+function getPasswordArg(): string {
+  const value = getArgValue("--password");
+  if (value !== null) {
+    if (!value) {
+      throw new Error("password cannot be empty");
+    }
+    return value;
+  }
+
+  const fromEnv = process.env.NEW_ADMIN_PASSWORD;
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  throw new Error("missing --password (or NEW_ADMIN_PASSWORD env var)");
+}
+
+function getUsernameArg(): string {
+  return requireNonEmpty(getArgValue("--username") ?? process.env.ADMIN_USERNAME ?? "admin", "username");
+}
+
+function printUsage(): void {
+  console.log("Usage: node backend/dist/scripts/resetAdminPassword.js [--username <admin>] --password <new-password>");
+  console.log("Alternative: set NEW_ADMIN_PASSWORD in env.");
+}
+
+function run(): void {
+  if (process.argv.includes("--help") || process.argv.includes("-h")) {
+    printUsage();
+    return;
+  }
+
+  const username = getUsernameArg();
+  const password = getPasswordArg();
+
+  initializeAuthDatabase();
+
+  const existing = findUserByUsername(username);
+  if (!existing) {
+    const created = createUser(username, password, "admin");
+    console.log(`Admin user created: ${created.username}`);
+    return;
+  }
+
+  if (existing.role !== "admin") {
+    throw new Error(`user '${username}' exists but is not an admin`);
+  }
+
+  const updated = updateUserPassword(existing.id, password);
+  if (!updated) {
+    throw new Error("failed to update admin password");
+  }
+
+  console.log(`Admin password updated for: ${username}`);
+}
+
+try {
+  run();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Admin password reset failed: ${message}`);
+  process.exit(1);
+}

--- a/backend/src/scripts/resetAuthDatabase.ts
+++ b/backend/src/scripts/resetAuthDatabase.ts
@@ -1,0 +1,44 @@
+import "dotenv/config";
+
+import { promises as fs } from "node:fs";
+
+import { ensureDefaultAdmin, initializeAuthDatabase } from "../auth/db";
+import { ensureBaseDirectories } from "../utils/fs";
+import { usersDbPath } from "../utils/paths";
+
+async function removeIfExists(filePath: string): Promise<void> {
+  try {
+    await fs.unlink(filePath);
+    console.log(`Deleted: ${filePath}`);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+async function run(): Promise<void> {
+  console.log("[1/3] Ensuring base directories...");
+  await ensureBaseDirectories();
+
+  console.log("[2/3] Deleting auth database files...");
+  await removeIfExists(usersDbPath);
+  await removeIfExists(`${usersDbPath}-wal`);
+  await removeIfExists(`${usersDbPath}-shm`);
+
+  console.log("[3/3] Recreating auth database and bootstrap admin...");
+  initializeAuthDatabase();
+  const admin = ensureDefaultAdmin();
+
+  if (admin) {
+    console.log(`Bootstrap admin ready: ${admin.username}`);
+  }
+
+  console.log("Auth database reset complete.");
+}
+
+run().catch((error: unknown) => {
+  console.error("Auth database reset failed", error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "prod:setup": "bash scripts/setup-production.sh",
     "prod:up": "docker compose -f docker-compose.prod.yml --env-file .env.production up -d",
     "prod:down": "docker compose -f docker-compose.prod.yml --env-file .env.production down",
+    "prod:admin:reset-password": "bash scripts/prod-reset-admin-password.sh",
+    "prod:authdb:reset": "bash scripts/prod-reset-auth-db.sh",
     "docs:api": "docker run --rm -p 8080:8080 -e SWAGGER_JSON=/spec/openapi.yaml -v \"$(pwd)/docs:/spec\" swaggerapi/swagger-ui"
   },
   "devDependencies": {

--- a/scripts/prod-reset-admin-password.sh
+++ b/scripts/prod-reset-admin-password.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${ROOT_DIR}/docker-compose.prod.yml"
+ENV_FILE="${ROOT_DIR}/.env.production"
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  printf "Missing env file: %s\n" "${ENV_FILE}" >&2
+  exit 1
+fi
+
+USERNAME="${1:-${ADMIN_USERNAME:-admin}}"
+
+if [[ -z "${USERNAME}" ]]; then
+  printf "Username cannot be empty.\n" >&2
+  exit 1
+fi
+
+read -r -s -p "New password for '${USERNAME}': " PASSWORD
+printf "\n"
+read -r -s -p "Confirm password: " CONFIRM
+printf "\n"
+
+if [[ -z "${PASSWORD}" ]]; then
+  printf "Password cannot be empty.\n" >&2
+  exit 1
+fi
+
+if [[ "${PASSWORD}" != "${CONFIRM}" ]]; then
+  printf "Passwords do not match.\n" >&2
+  exit 1
+fi
+
+docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" run --rm \
+  -e NEW_ADMIN_PASSWORD="${PASSWORD}" \
+  backend node backend/dist/scripts/resetAdminPassword.js --username "${USERNAME}"
+
+printf "Admin password reset completed for '%s'.\n" "${USERNAME}"

--- a/scripts/prod-reset-auth-db.sh
+++ b/scripts/prod-reset-auth-db.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${ROOT_DIR}/docker-compose.prod.yml"
+ENV_FILE="${ROOT_DIR}/.env.production"
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  printf "Missing env file: %s\n" "${ENV_FILE}" >&2
+  exit 1
+fi
+
+printf "This will delete and recreate the auth database (users + sessions).\n"
+read -r -p "Type 'reset-auth-db' to continue: " CONFIRM
+
+if [[ "${CONFIRM}" != "reset-auth-db" ]]; then
+  printf "Aborted.\n"
+  exit 1
+fi
+
+docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" run --rm \
+  backend node backend/dist/scripts/resetAuthDatabase.js
+
+printf "Auth database reset completed.\n"

--- a/scripts/setup-production.sh
+++ b/scripts/setup-production.sh
@@ -81,6 +81,21 @@ quote_env_literal() {
   printf "'%s'" "$value"
 }
 
+validate_single_line_value() {
+  local name="$1"
+  local value="$2"
+
+  if [[ -z "$value" ]]; then
+    printf "Invalid %s: value cannot be empty.\n" "$name" >&2
+    exit 1
+  fi
+
+  if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
+    printf "Invalid %s: multiline values are not supported in .env.production.\n" "$name" >&2
+    exit 1
+  fi
+}
+
 print_title "Flaque Production Setup"
 printf "This script configures env vars, creates mount folders, builds images, initializes DB, and starts containers.\n\n"
 
@@ -107,6 +122,9 @@ DEFAULT_CORS_ORIGIN="http://localhost:${FRONTEND_PORT}"
 CORS_ORIGIN="$(prompt_with_default "CORS origin for frontend" "${DEFAULT_CORS_ORIGIN}")"
 ADMIN_USERNAME="$(prompt_with_default "Bootstrap admin username" "admin")"
 ADMIN_PASSWORD="$(prompt_secret "Bootstrap admin password")"
+
+validate_single_line_value "ADMIN_USERNAME" "$ADMIN_USERNAME"
+validate_single_line_value "ADMIN_PASSWORD" "$ADMIN_PASSWORD"
 
 if [[ -f "$ENV_FILE" ]]; then
   print_warn ".env.production already exists: ${ENV_FILE}"


### PR DESCRIPTION
## Summary
- add backend maintenance scripts to reset an admin password and to fully reset/reinitialize the auth database with bootstrap admin recreation
- add production wrapper scripts and npm commands so these maintenance operations can be executed directly against the Docker production stack
- harden production env generation and cookie/session behavior for local prod-like HTTP deployments to prevent broken login/session flows

## Validation
- npm run build --workspace backend
- node backend/dist/scripts/resetAdminPassword.js --help
- bash -n scripts/prod-reset-admin-password.sh
- bash -n scripts/prod-reset-auth-db.sh