### PR TITLE
Add incremental scanner rebuild with full fallback

### DIFF
--- a/backend/src/services/indexer/indexStore.ts
+++ b/backend/src/services/indexer/indexStore.ts
@@ -74,7 +74,7 @@ export class IndexStore {
     }
 
     this.rebuildPromise = (async () => {
-      const rebuilt = await scanFilesystemLibrary();
+      const rebuilt = await scanFilesystemLibrary({ previousIndex: this.snapshot });
       await writeJsonAtomic(indexFilePath, rebuilt);
       await pruneTrackMetadataOverrides(rebuilt.tracks.map((track) => track.id));
       return this.updateSnapshot(rebuilt);

--- a/backend/src/services/scanner/scannerService.test.ts
+++ b/backend/src/services/scanner/scannerService.test.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LibraryIndex } from "../../types/library";
+
+const {
+  mockReadTrackMetadataOverrides,
+  mockExtractAudioMetadata,
+  mockEnsureTrackCover,
+  mockScanFilesystemPlaylists,
+  mockEnsureDirectoryMetadata,
+  mockFetchAlbumCoverPath,
+  mockFetchArtistPhotoPath,
+  mockWriteEmbeddedCoverToDirectory
+} = vi.hoisted(() => ({
+  mockReadTrackMetadataOverrides: vi.fn(),
+  mockExtractAudioMetadata: vi.fn(),
+  mockEnsureTrackCover: vi.fn(),
+  mockScanFilesystemPlaylists: vi.fn(),
+  mockEnsureDirectoryMetadata: vi.fn(),
+  mockFetchAlbumCoverPath: vi.fn(),
+  mockFetchArtistPhotoPath: vi.fn(),
+  mockWriteEmbeddedCoverToDirectory: vi.fn()
+}));
+
+vi.mock("../indexer/metadataOverrideStore", () => ({
+  readTrackMetadataOverrides: mockReadTrackMetadataOverrides
+}));
+
+vi.mock("./audioProbe", () => ({
+  extractAudioMetadata: mockExtractAudioMetadata
+}));
+
+vi.mock("../storage/coverService", () => ({
+  ensureTrackCover: mockEnsureTrackCover
+}));
+
+vi.mock("../playlists/playlistStore", () => ({
+  scanFilesystemPlaylists: mockScanFilesystemPlaylists
+}));
+
+vi.mock("../media/mediaMetadataService", () => ({
+  ensureDirectoryMetadata: mockEnsureDirectoryMetadata,
+  fetchAlbumCoverPath: mockFetchAlbumCoverPath,
+  fetchArtistPhotoPath: mockFetchArtistPhotoPath,
+  normalizeDirectorySegment: (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "_"),
+  writeEmbeddedCoverToDirectory: mockWriteEmbeddedCoverToDirectory
+}));
+
+let dataRoot = "";
+
+function getOwnerUploadsRoot(ownerId: string): string {
+  return path.join(dataRoot, "storage", "users", ownerId, "uploads");
+}
+
+async function writeAudioFile(ownerId: string, relativePath: string, content: string): Promise<string> {
+  const absolutePath = path.join(getOwnerUploadsRoot(ownerId), relativePath);
+  await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+  await fs.writeFile(absolutePath, content, "utf8");
+  return absolutePath;
+}
+
+function normalizeSnapshot(snapshot: LibraryIndex) {
+  return {
+    totalTracks: snapshot.totalTracks,
+    tracks: snapshot.tracks,
+    playlists: snapshot.playlists ?? []
+  };
+}
+
+beforeEach(async () => {
+  dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "flaque-scanner-service-"));
+  process.env.DATA_ROOT = dataRoot;
+
+  mockReadTrackMetadataOverrides.mockReset();
+  mockExtractAudioMetadata.mockReset();
+  mockEnsureTrackCover.mockReset();
+  mockScanFilesystemPlaylists.mockReset();
+  mockEnsureDirectoryMetadata.mockReset();
+  mockFetchAlbumCoverPath.mockReset();
+  mockFetchArtistPhotoPath.mockReset();
+  mockWriteEmbeddedCoverToDirectory.mockReset();
+
+  mockReadTrackMetadataOverrides.mockResolvedValue({});
+  mockEnsureTrackCover.mockResolvedValue(undefined);
+  mockScanFilesystemPlaylists.mockResolvedValue([]);
+  mockEnsureDirectoryMetadata.mockResolvedValue(undefined);
+  mockFetchAlbumCoverPath.mockResolvedValue(undefined);
+  mockFetchArtistPhotoPath.mockResolvedValue(undefined);
+  mockWriteEmbeddedCoverToDirectory.mockResolvedValue(undefined);
+
+  mockExtractAudioMetadata.mockImplementation(async (filePath: string) => {
+    const stats = await fs.stat(filePath);
+    const title = path.basename(filePath, path.extname(filePath));
+    const album = path.basename(path.dirname(filePath));
+    const artist = path.basename(path.dirname(path.dirname(filePath)));
+
+    return {
+      duration: stats.size,
+      codec: "mock-codec",
+      bitrate: 192000,
+      sampleRate: 44100,
+      tags: {
+        title,
+        artist,
+        album
+      }
+    };
+  });
+});
+
+afterEach(async () => {
+  await fs.rm(dataRoot, { recursive: true, force: true });
+  delete process.env.DATA_ROOT;
+  delete process.env.SCANNER_REBUILD_MODE;
+  vi.resetModules();
+});
+
+describe("scanFilesystemLibrary incremental mode", () => {
+  it("probes only newly added files", async () => {
+    const ownerId = "owner-1";
+    await writeAudioFile(ownerId, "artist_a/album_a/track-a.mp3", "aaa");
+
+    const { scanFilesystemLibrary } = await import("./scannerService");
+    const first = await scanFilesystemLibrary({ mode: "full" });
+
+    mockExtractAudioMetadata.mockClear();
+    await writeAudioFile(ownerId, "artist_a/album_a/track-b.mp3", "bbbb");
+
+    const incremental = await scanFilesystemLibrary({ previousIndex: first });
+
+    expect(mockExtractAudioMetadata).toHaveBeenCalledTimes(1);
+    expect(mockExtractAudioMetadata).toHaveBeenCalledWith(
+      expect.stringContaining(path.join("artist_a", "album_a", "track-b.mp3"))
+    );
+    expect(incremental.totalTracks).toBe(2);
+    expect(incremental.tracks.map((track) => track.tags.title)).toEqual(["track-a", "track-b"]);
+  });
+
+  it("re-probes modified files and matches full rebuild truth", async () => {
+    const ownerId = "owner-1";
+    const trackPath = await writeAudioFile(ownerId, "artist_a/album_a/track-a.mp3", "aaa");
+
+    const { scanFilesystemLibrary } = await import("./scannerService");
+    const first = await scanFilesystemLibrary({ mode: "full" });
+
+    mockExtractAudioMetadata.mockClear();
+    await fs.writeFile(trackPath, "aaaaaa", "utf8");
+
+    const incremental = await scanFilesystemLibrary({ previousIndex: first });
+    expect(mockExtractAudioMetadata).toHaveBeenCalledTimes(1);
+    expect(incremental.tracks[0]?.duration).toBe(6);
+
+    mockExtractAudioMetadata.mockClear();
+    const full = await scanFilesystemLibrary({ mode: "full" });
+    expect(mockExtractAudioMetadata).toHaveBeenCalledTimes(1);
+    expect(normalizeSnapshot(incremental)).toEqual(normalizeSnapshot(full));
+  });
+
+  it("removes deleted files from index", async () => {
+    const ownerId = "owner-1";
+    const trackA = await writeAudioFile(ownerId, "artist_a/album_a/track-a.mp3", "aaa");
+    await writeAudioFile(ownerId, "artist_a/album_a/track-b.mp3", "bbbb");
+
+    const { scanFilesystemLibrary } = await import("./scannerService");
+    const first = await scanFilesystemLibrary({ mode: "full" });
+
+    mockExtractAudioMetadata.mockClear();
+    await fs.unlink(trackA);
+
+    const incremental = await scanFilesystemLibrary({ previousIndex: first });
+
+    expect(mockExtractAudioMetadata).toHaveBeenCalledTimes(0);
+    expect(incremental.totalTracks).toBe(1);
+    expect(incremental.tracks.map((track) => track.tags.title)).toEqual(["track-b"]);
+  });
+
+  it("does zero probe when filesystem is unchanged", async () => {
+    const ownerId = "owner-1";
+    await writeAudioFile(ownerId, "artist_b/album_b/z-track.mp3", "zzzz");
+    await writeAudioFile(ownerId, "artist_a/album_a/a-track.mp3", "aa");
+
+    const { scanFilesystemLibrary } = await import("./scannerService");
+    const first = await scanFilesystemLibrary({ mode: "full" });
+    expect(first.totalTracks).toBe(2);
+
+    mockExtractAudioMetadata.mockClear();
+    const second = await scanFilesystemLibrary({ previousIndex: first });
+
+    expect(mockExtractAudioMetadata).toHaveBeenCalledTimes(0);
+    expect(second.totalTracks).toBe(2);
+    expect(second.tracks.map((track) => track.tags.title)).toEqual(["a-track", "z-track"]);
+  });
+});

--- a/backend/src/services/scanner/scannerService.ts
+++ b/backend/src/services/scanner/scannerService.ts
@@ -6,7 +6,7 @@ import type { LibraryIndex, Track } from "../../types/library";
 import { fileExists, readJsonFile, writeJsonAtomic } from "../../utils/fs";
 import { createAlbumId, createTrackId } from "../../utils/hash";
 import { getAudioMimeType, isSupportedAudioFile } from "../../utils/mime";
-import { getOwnerUploadsDir, resolveDataRelativePath } from "../../utils/paths";
+import { getOwnerUploadsDir, indexFilePath, resolveDataRelativePath, scannerStateFilePath } from "../../utils/paths";
 import { readTrackMetadataOverrides } from "../indexer/metadataOverrideStore";
 import {
   ensureDirectoryMetadata,
@@ -49,6 +49,47 @@ type AlbumAggregate = {
   coverPath?: string;
   tracks: Track[];
 };
+
+type ScanMode = "incremental" | "full";
+
+type ScanFilesystemLibraryOptions = {
+  mode?: ScanMode;
+  previousIndex?: LibraryIndex;
+};
+
+type FileSystemTrackState = {
+  ownerId: string;
+  filePath: string;
+  relativePath: string;
+  trackId: string;
+  size: number;
+  mtimeMs: number;
+  identity: string;
+};
+
+type ScannerTrackState = {
+  trackId: string;
+  path: string;
+  size: number;
+  mtimeMs: number;
+  identity: string;
+};
+
+type ScannerStateSnapshot = {
+  version: 1;
+  tracks: ScannerTrackState[];
+};
+
+type ClassifiedTracks = {
+  changed: FileSystemTrackState[];
+  unchanged: Array<{
+    state: FileSystemTrackState;
+    track: Track;
+  }>;
+  deletedTrackIds: string[];
+};
+
+const SCANNER_STATE_VERSION = 1;
 
 function getTrackArtist(track: Track): string {
   return track.tags.artist ?? track.tags.albumArtist ?? track.tags.artists?.[0] ?? "";
@@ -279,6 +320,303 @@ async function collectAudioFiles(rootDir: string): Promise<string[]> {
   return files;
 }
 
+function createTrackIdentity(relativePath: string, mtimeMs: number, size: number): string {
+  return `${relativePath}:${mtimeMs}:${size}`;
+}
+
+async function collectFilesystemState(
+  ownerIds: string[],
+  metadataOverrides: Record<string, { artist?: string; album?: string }>
+): Promise<FileSystemTrackState[]> {
+  const states: FileSystemTrackState[] = [];
+
+  for (const ownerId of ownerIds) {
+    const uploadsDir = getOwnerUploadsDir(ownerId);
+    await sortRootUploadFiles(ownerId, uploadsDir, metadataOverrides);
+    const files = await collectAudioFiles(uploadsDir);
+
+    for (const filePath of files) {
+      let stats;
+      try {
+        stats = await fs.stat(filePath);
+      } catch {
+        continue;
+      }
+
+      const relativePath = toDataRelativePath(filePath);
+      const trackId = createTrackId(ownerId, relativePath);
+      const identity = createTrackIdentity(relativePath, stats.mtimeMs, stats.size);
+
+      states.push({
+        ownerId,
+        filePath,
+        relativePath,
+        trackId,
+        size: stats.size,
+        mtimeMs: stats.mtimeMs,
+        identity
+      });
+    }
+  }
+
+  return states;
+}
+
+function normalizeScannerState(raw: unknown): ScannerStateSnapshot {
+  if (!raw || typeof raw !== "object") {
+    return { version: SCANNER_STATE_VERSION, tracks: [] };
+  }
+
+  const source = raw as {
+    version?: unknown;
+    tracks?: unknown;
+  };
+
+  if (source.version !== SCANNER_STATE_VERSION || !Array.isArray(source.tracks)) {
+    return { version: SCANNER_STATE_VERSION, tracks: [] };
+  }
+
+  const tracks: ScannerTrackState[] = [];
+  for (const item of source.tracks) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+
+    const candidate = item as Partial<ScannerTrackState>;
+    if (
+      typeof candidate.trackId !== "string" ||
+      typeof candidate.path !== "string" ||
+      typeof candidate.identity !== "string" ||
+      typeof candidate.size !== "number" ||
+      typeof candidate.mtimeMs !== "number"
+    ) {
+      continue;
+    }
+
+    tracks.push({
+      trackId: candidate.trackId,
+      path: candidate.path,
+      identity: candidate.identity,
+      size: candidate.size,
+      mtimeMs: candidate.mtimeMs
+    });
+  }
+
+  return {
+    version: SCANNER_STATE_VERSION,
+    tracks
+  };
+}
+
+async function readScannerState(): Promise<ScannerStateSnapshot> {
+  const raw = await readJsonFile<unknown>(scannerStateFilePath, {
+    version: SCANNER_STATE_VERSION,
+    tracks: []
+  });
+
+  return normalizeScannerState(raw);
+}
+
+async function writeScannerState(states: FileSystemTrackState[]): Promise<void> {
+  const snapshot: ScannerStateSnapshot = {
+    version: SCANNER_STATE_VERSION,
+    tracks: states.map((state) => ({
+      trackId: state.trackId,
+      path: state.relativePath,
+      size: state.size,
+      mtimeMs: state.mtimeMs,
+      identity: state.identity
+    }))
+  };
+
+  await fs.mkdir(path.dirname(scannerStateFilePath), { recursive: true });
+  await writeJsonAtomic(scannerStateFilePath, snapshot);
+}
+
+function classifyTrackChanges(
+  filesystemState: FileSystemTrackState[],
+  previousTracks: Track[],
+  previousScannerState: ScannerStateSnapshot
+): ClassifiedTracks {
+  const currentTrackIds = new Set<string>();
+  const previousTracksById = new Map(previousTracks.map((track) => [track.id, track]));
+  const previousStateByTrackId = new Map(previousScannerState.tracks.map((state) => [state.trackId, state]));
+
+  const changed: FileSystemTrackState[] = [];
+  const unchanged: ClassifiedTracks["unchanged"] = [];
+
+  for (const state of filesystemState) {
+    currentTrackIds.add(state.trackId);
+    const previousState = previousStateByTrackId.get(state.trackId);
+    const previousTrack = previousTracksById.get(state.trackId);
+
+    if (previousState && previousTrack && previousState.identity === state.identity) {
+      unchanged.push({ state, track: previousTrack });
+      continue;
+    }
+
+    changed.push(state);
+  }
+
+  const deletedTrackIds: string[] = [];
+  for (const previousTrack of previousTracks) {
+    if (!currentTrackIds.has(previousTrack.id)) {
+      deletedTrackIds.push(previousTrack.id);
+    }
+  }
+
+  return {
+    changed,
+    unchanged,
+    deletedTrackIds
+  };
+}
+
+function applyTrackMetadataOverride(
+  track: Track,
+  metadataOverride?: { title?: string; artist?: string; album?: string }
+): Track {
+  if (!metadataOverride) {
+    return track;
+  }
+
+  return {
+    ...track,
+    tags: {
+      ...track.tags,
+      title: metadataOverride.title ?? track.tags.title,
+      artist: metadataOverride.artist ?? track.tags.artist,
+      album: metadataOverride.album ?? track.tags.album
+    }
+  };
+}
+
+async function ensureTrackMediaMetadata(
+  track: Track,
+  ownerId: string,
+  trackCover: { data: Buffer; format?: string } | undefined,
+  processedArtists: Set<string>,
+  processedAlbums: Set<string>
+): Promise<void> {
+  const artistName = track.tags.artist ?? track.tags.albumArtist ?? track.tags.artists?.[0];
+  if (artistName) {
+    const artistKey = `${ownerId}:${artistName.toLocaleLowerCase()}`;
+    if (!processedArtists.has(artistKey)) {
+      processedArtists.add(artistKey);
+      await ensureArtistPhotoForTrack(ownerId, artistName);
+    }
+  }
+
+  const albumArtistName = artistName ?? UNKNOWN_ARTIST;
+  const albumName = track.tags.album ?? UNKNOWN_ALBUM;
+  const albumKey = `${ownerId}:${albumArtistName.toLocaleLowerCase()}:${albumName.toLocaleLowerCase()}`;
+  if (!processedAlbums.has(albumKey)) {
+    processedAlbums.add(albumKey);
+    await ensureAlbumCoverForTrack(ownerId, albumArtistName, albumName, trackCover);
+  }
+}
+
+async function addTrackToAlbumAggregate(
+  track: Track,
+  filePath: string,
+  ownerId: string,
+  fallbackAlbumName: string,
+  albumsByDirectory: Map<string, AlbumAggregate>
+): Promise<void> {
+  const albumDir = path.dirname(filePath);
+  const currentAlbum = albumsByDirectory.get(albumDir);
+
+  if (currentAlbum) {
+    currentAlbum.tracks.push(track);
+    return;
+  }
+
+  const metadataPath = path.join(albumDir, ALBUM_METADATA_FILE);
+  const albumMetadata = await readJsonFile<AlbumMetadata | null>(metadataPath, null);
+  const currentName = albumMetadata?.name?.trim() ? albumMetadata.name : fallbackAlbumName;
+
+  albumsByDirectory.set(albumDir, {
+    ownerId,
+    albumDir,
+    id: albumMetadata?.id,
+    name: currentName,
+    coverPath: albumMetadata?.cover?.path,
+    tracks: [track]
+  });
+}
+
+async function probeChangedTracks(
+  changedTracks: FileSystemTrackState[],
+  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string }>,
+  albumsByDirectory: Map<string, AlbumAggregate>,
+  processedArtists: Set<string>,
+  processedAlbums: Set<string>
+): Promise<Track[]> {
+  const tracks: Track[] = [];
+
+  for (const state of changedTracks) {
+    const metadata = await extractAudioMetadata(state.filePath);
+    const metadataOverride = metadataOverrides[state.trackId];
+    const cover = await ensureTrackCover(state.trackId, metadata.cover);
+    const tags = {
+      ...metadata.tags,
+      title: metadataOverride?.title ?? metadata.tags.title,
+      artist: metadataOverride?.artist ?? metadata.tags.artist,
+      album: metadataOverride?.album ?? metadata.tags.album
+    };
+
+    const track: Track = {
+      id: state.trackId,
+      owner: state.ownerId,
+      path: state.relativePath,
+      duration: metadata.duration,
+      mimeType: getAudioMimeType(state.filePath),
+      codec: metadata.codec,
+      bitrate: metadata.bitrate,
+      sampleRate: metadata.sampleRate,
+      tags,
+      cover
+    };
+
+    await ensureTrackMediaMetadata(track, state.ownerId, metadata.cover, processedArtists, processedAlbums);
+    await addTrackToAlbumAggregate(track, state.filePath, state.ownerId, tags.album ?? UNKNOWN_ALBUM, albumsByDirectory);
+    tracks.push(track);
+  }
+
+  return tracks;
+}
+
+async function mergeFinalTracks(
+  unchangedTracks: ClassifiedTracks["unchanged"],
+  changedTracks: Track[],
+  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string }>,
+  albumsByDirectory: Map<string, AlbumAggregate>,
+  processedArtists: Set<string>,
+  processedAlbums: Set<string>
+): Promise<Track[]> {
+  const mergedTracks: Track[] = [];
+
+  for (const unchanged of unchangedTracks) {
+    const withOverrides = applyTrackMetadataOverride(
+      unchanged.track,
+      metadataOverrides[unchanged.state.trackId]
+    );
+    await ensureTrackMediaMetadata(withOverrides, unchanged.state.ownerId, undefined, processedArtists, processedAlbums);
+    await addTrackToAlbumAggregate(
+      withOverrides,
+      unchanged.state.filePath,
+      unchanged.state.ownerId,
+      withOverrides.tags.album ?? UNKNOWN_ALBUM,
+      albumsByDirectory
+    );
+    mergedTracks.push(withOverrides);
+  }
+
+  mergedTracks.push(...changedTracks);
+  mergedTracks.sort(compareTrackOrder);
+  return mergedTracks;
+}
+
 function compareTrackOrder(a: Track, b: Track): number {
   const byArtist = getTrackArtist(a).localeCompare(getTrackArtist(b));
   if (byArtist !== 0) {
@@ -293,86 +631,41 @@ function compareTrackOrder(a: Track, b: Track): number {
   return getTrackTitle(a).localeCompare(getTrackTitle(b));
 }
 
-export async function scanFilesystemLibrary(): Promise<LibraryIndex> {
+async function performScan(
+  mode: ScanMode,
+  previousIndex: LibraryIndex | undefined,
+  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string }>
+): Promise<LibraryIndex> {
   const ownerIds = await listOwnerIds();
-  const metadataOverrides = await readTrackMetadataOverrides();
-  const tracks: Track[] = [];
+  const filesystemState = await collectFilesystemState(ownerIds, metadataOverrides);
+  const previousTracks = previousIndex?.tracks ?? [];
+  const previousScannerState: ScannerStateSnapshot = mode === "incremental" ? await readScannerState() : {
+    version: SCANNER_STATE_VERSION,
+    tracks: []
+  };
+  const classified = classifyTrackChanges(filesystemState, previousTracks, previousScannerState);
   const albumsByDirectory = new Map<string, AlbumAggregate>();
   const processedArtists = new Set<string>();
   const processedAlbums = new Set<string>();
 
-  for (const ownerId of ownerIds) {
-    const uploadsDir = getOwnerUploadsDir(ownerId);
-    await sortRootUploadFiles(ownerId, uploadsDir, metadataOverrides);
-    const files = await collectAudioFiles(uploadsDir);
-
-    for (const filePath of files) {
-      const relativePath = toDataRelativePath(filePath);
-      const metadata = await extractAudioMetadata(filePath);
-      const trackId = createTrackId(ownerId, relativePath);
-      const cover = await ensureTrackCover(trackId, metadata.cover);
-      const metadataOverride = metadataOverrides[trackId];
-      const tags = {
-        ...metadata.tags,
-        title: metadataOverride?.title ?? metadata.tags.title,
-        artist: metadataOverride?.artist ?? metadata.tags.artist,
-        album: metadataOverride?.album ?? metadata.tags.album
-      };
-
-      const artistName = tags.artist ?? tags.albumArtist ?? tags.artists?.[0];
-      if (artistName) {
-        const artistKey = `${ownerId}:${artistName.toLocaleLowerCase()}`;
-        if (!processedArtists.has(artistKey)) {
-          processedArtists.add(artistKey);
-          await ensureArtistPhotoForTrack(ownerId, artistName);
-        }
-      }
-
-      const albumArtistName = artistName ?? UNKNOWN_ARTIST;
-      const albumName = tags.album ?? UNKNOWN_ALBUM;
-      const albumKey = `${ownerId}:${albumArtistName.toLocaleLowerCase()}:${albumName.toLocaleLowerCase()}`;
-      if (!processedAlbums.has(albumKey)) {
-        processedAlbums.add(albumKey);
-        await ensureAlbumCoverForTrack(ownerId, albumArtistName, albumName, metadata.cover);
-      }
-
-      const track: Track = {
-        id: trackId,
-        owner: ownerId,
-        path: relativePath,
-        duration: metadata.duration,
-        mimeType: getAudioMimeType(filePath),
-        codec: metadata.codec,
-        bitrate: metadata.bitrate,
-        sampleRate: metadata.sampleRate,
-        tags,
-        cover
-      };
-
-      tracks.push(track);
-
-      const albumDir = path.dirname(filePath);
-      const currentAlbum = albumsByDirectory.get(albumDir);
-      if (currentAlbum) {
-        currentAlbum.tracks.push(track);
-      } else {
-        const metadataPath = path.join(albumDir, ALBUM_METADATA_FILE);
-        const albumMetadata = await readJsonFile<AlbumMetadata | null>(metadataPath, null);
-        const currentName = albumMetadata?.name?.trim() ? albumMetadata.name : albumName;
-        albumsByDirectory.set(albumDir, {
-          ownerId,
-          albumDir,
-          id: albumMetadata?.id,
-          name: currentName,
-          coverPath: albumMetadata?.cover?.path,
-          tracks: [track]
-        });
-      }
-    }
-  }
+  const changedTracks = await probeChangedTracks(
+    classified.changed,
+    metadataOverrides,
+    albumsByDirectory,
+    processedArtists,
+    processedAlbums
+  );
+  const tracks = await mergeFinalTracks(
+    classified.unchanged,
+    changedTracks,
+    metadataOverrides,
+    albumsByDirectory,
+    processedArtists,
+    processedAlbums
+  );
 
   await flushAlbumMetadata(albumsByDirectory);
-  tracks.sort(compareTrackOrder);
+  await writeScannerState(filesystemState);
   const playlists = await scanFilesystemPlaylists(tracks);
 
   return {
@@ -381,4 +674,28 @@ export async function scanFilesystemLibrary(): Promise<LibraryIndex> {
     tracks,
     playlists
   };
+}
+
+export async function scanFilesystemLibrary(options: ScanFilesystemLibraryOptions = {}): Promise<LibraryIndex> {
+  const metadataOverrides = await readTrackMetadataOverrides();
+  const modeFromEnvironment = process.env.SCANNER_REBUILD_MODE === "full" ? "full" : "incremental";
+  const requestedMode = options.mode ?? modeFromEnvironment;
+  const previousIndex =
+    options.previousIndex ??
+    (await readJsonFile<LibraryIndex>(indexFilePath, {
+      generatedAt: "",
+      totalTracks: 0,
+      tracks: [],
+      playlists: []
+    }));
+
+  if (requestedMode === "full") {
+    return performScan("full", previousIndex, metadataOverrides);
+  }
+
+  try {
+    return await performScan("incremental", previousIndex, metadataOverrides);
+  } catch {
+    return performScan("full", previousIndex, metadataOverrides);
+  }
 }

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -16,6 +16,7 @@ export const transcodesRoot = path.join(cacheRoot, "transcodes");
 export const tmpUploadsRoot = path.join(cacheRoot, "tmp-uploads");
 export const indexRoot = path.join(dataRoot, "index");
 export const indexFilePath = path.join(indexRoot, "library-index.json");
+export const scannerStateFilePath = path.join(indexRoot, "scanner-state.json");
 export const metadataOverridesFilePath = path.join(indexRoot, "track-metadata-overrides.json");
 export const trackActivityLogFilePath = path.join(indexRoot, "track-activity-log.json");
 export const usersDbPath = path.join(configRoot, "users.db");


### PR DESCRIPTION
## Summary
- switch scanner rebuilds from unconditional full probe to an incremental pipeline split into filesystem-state collection, changed/unchanged/deleted classification, changed-file probe, and final track merge.
- add a persisted scanner state (`index/scanner-state.json`) keyed by `path + mtime + size`, reuse previous track metadata for unchanged files, re-probe only changed/new files, and drop deleted files from the merged index.
- keep a full rebuild path for recovery/debug via `scanFilesystemLibrary({ mode: \"full\" })` or `SCANNER_REBUILD_MODE=full`, and keep `IndexStore.rebuild()` wired with the current snapshot as incremental baseline.

## Validation
- added scanner tests covering file add, file modify, file delete, and unchanged filesystem (zero probe calls).
- incremental vs full equivalence assertion included for modified-file scenario to confirm identical functional index output.
- ran full backend test suite and TypeScript build successfully.

## Complexity / Expected Gains
- Full rebuild remains `O(N * probe)` where `N` is total audio files.
- Incremental rebuild becomes `O(N)` lightweight fs scan + `O(K * probe)` where `K` is changed/new files; unchanged files are reused from previous index metadata.
- In steady state (`K=0`), expensive probe cost is eliminated while preserving `totalTracks`, sorting, and filtering behavior.