### PR TITLE
Fix TypeScript build error for scroll-timeline polyfill

### DIFF
--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare module "/scroll-timeline.js";


### PR DESCRIPTION
## Summary
- add a TypeScript module declaration for `/scroll-timeline.js` in `frontend/src/vite-env.d.ts`
- fix TS2307 during frontend build when the polyfill script is referenced from app bootstrap code
- keep runtime behavior unchanged while making the build robust