### PR TITLE
Add FFmpeg concurrency limit and graceful shutdown

### DIFF
--- a/backend/src/services/streaming/transcodeService.test.ts
+++ b/backend/src/services/streaming/transcodeService.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseTranscodeFormat } from "./transcodeService";
+import { getTranscodeCapacity, parseTranscodeFormat } from "./transcodeService";
 
 describe("parseTranscodeFormat", () => {
   it("parses supported values", () => {
@@ -19,5 +19,18 @@ describe("parseTranscodeFormat", () => {
     expect(parseTranscodeFormat("flac")).toBeNull();
     expect(parseTranscodeFormat("aac")).toBeNull();
     expect(parseTranscodeFormat(123)).toBeNull();
+  });
+});
+
+describe("getTranscodeCapacity", () => {
+  it("reports capacity status", () => {
+    const capacity = getTranscodeCapacity();
+    expect(capacity).toHaveProperty("active");
+    expect(capacity).toHaveProperty("max");
+    expect(capacity).toHaveProperty("available");
+    expect(typeof capacity.active).toBe("number");
+    expect(typeof capacity.max).toBe("number");
+    expect(capacity.max).toBeGreaterThanOrEqual(1);
+    expect(capacity.available).toBe(capacity.active < capacity.max);
   });
 });

--- a/backend/src/services/streaming/transcodeService.ts
+++ b/backend/src/services/streaming/transcodeService.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 
 import type { Request, Response } from "express";
 
@@ -26,6 +26,48 @@ const TRANSCODE_PROFILE: Record<
     mimeType: "audio/mpeg"
   }
 };
+
+// ── Concurrency control ─────────────────────────────────────────────────
+
+const DEFAULT_MAX_CONCURRENT_TRANSCODES = 4;
+const GRACEFUL_KILL_TIMEOUT_MS = 2000;
+
+const maxConcurrent = Math.max(
+  1,
+  Number(process.env.MAX_CONCURRENT_TRANSCODES ?? DEFAULT_MAX_CONCURRENT_TRANSCODES) || DEFAULT_MAX_CONCURRENT_TRANSCODES
+);
+
+let activeCount = 0;
+
+export function getTranscodeCapacity(): { active: number; max: number; available: boolean } {
+  return { active: activeCount, max: maxConcurrent, available: activeCount < maxConcurrent };
+}
+
+function acquireSlot(): boolean {
+  if (activeCount >= maxConcurrent) {
+    return false;
+  }
+  activeCount++;
+  return true;
+}
+
+function releaseSlot(): void {
+  activeCount = Math.max(0, activeCount - 1);
+}
+
+function gracefulKill(process: ChildProcess): void {
+  if (process.killed) {
+    return;
+  }
+
+  process.kill("SIGTERM");
+
+  setTimeout(() => {
+    if (!process.killed) {
+      process.kill("SIGKILL");
+    }
+  }, GRACEFUL_KILL_TIMEOUT_MS);
+}
 
 export function parseTranscodeFormat(value: unknown): TranscodeFormat | null | undefined {
   if (value === undefined || value === null) {
@@ -58,6 +100,13 @@ export async function streamTranscodedAudio(
   sourceFilePath: string,
   format: TranscodeFormat
 ): Promise<void> {
+  if (!acquireSlot()) {
+    res.status(503);
+    res.setHeader("Retry-After", "5");
+    res.json({ error: "Transcoding capacity reached, please retry shortly" });
+    return;
+  }
+
   const profile = TRANSCODE_PROFILE[format];
   const ffmpegArgs = [
     "-v",
@@ -95,55 +144,57 @@ export async function streamTranscodedAudio(
   res.setHeader("X-Flaque-Transcode", format);
 
   const cleanup = (): void => {
-    if (!ffmpeg.killed) {
-      ffmpeg.kill("SIGKILL");
-    }
+    gracefulKill(ffmpeg);
   };
 
   req.on("close", cleanup);
   res.on("close", cleanup);
 
-  await new Promise<void>((resolve, reject) => {
-    let settled = false;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
 
-    const finish = (error?: Error): void => {
-      if (settled) {
-        return;
-      }
-      settled = true;
+      const finish = (error?: Error): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
 
-      req.off("close", cleanup);
-      res.off("close", cleanup);
+        req.off("close", cleanup);
+        res.off("close", cleanup);
 
-      if (error) {
-        reject(error);
-        return;
-      }
+        if (error) {
+          reject(error);
+          return;
+        }
 
-      resolve();
-    };
+        resolve();
+      };
 
-    ffmpeg.on("error", (error) => {
-      finish(new Error(`Unable to start ffmpeg transcoding process: ${error.message}`));
-    });
+      ffmpeg.on("error", (error) => {
+        finish(new Error(`Unable to start ffmpeg transcoding process: ${error.message}`));
+      });
 
-    ffmpeg.on("close", (code, signal) => {
-      if (code === 0 || res.writableEnded || req.destroyed || signal === "SIGKILL") {
+      ffmpeg.on("close", (code, signal) => {
+        if (code === 0 || res.writableEnded || req.destroyed || signal === "SIGTERM" || signal === "SIGKILL") {
+          finish();
+          return;
+        }
+
+        finish(new Error(`ffmpeg transcoding failed with code ${code ?? "unknown"}: ${stderr.trim()}`));
+      });
+
+      ffmpeg.stdout.on("error", (error) => {
+        finish(new Error(`Transcoded audio stream failed: ${error.message}`));
+      });
+
+      res.on("finish", () => {
         finish();
-        return;
-      }
+      });
 
-      finish(new Error(`ffmpeg transcoding failed with code ${code ?? "unknown"}: ${stderr.trim()}`));
+      ffmpeg.stdout.pipe(res);
     });
-
-    ffmpeg.stdout.on("error", (error) => {
-      finish(new Error(`Transcoded audio stream failed: ${error.message}`));
-    });
-
-    res.on("finish", () => {
-      finish();
-    });
-
-    ffmpeg.stdout.pipe(res);
-  });
+  } finally {
+    releaseSlot();
+  }
 }


### PR DESCRIPTION
## Summary
- Adds a concurrency semaphore (default max 4 simultaneous ffmpeg processes, configurable via `MAX_CONCURRENT_TRANSCODES` env var)
- Returns **503 with `Retry-After: 5`** when transcode capacity is full, so clients can back off and retry
- Replaces immediate `SIGKILL` with graceful shutdown: sends `SIGTERM` first, waits 2 seconds, then `SIGKILL` if the process hasn't exited
- Exports `getTranscodeCapacity()` for resource tracking (`{ active, max, available }`)
- Slot is always released in a `finally` block to prevent leaks on errors
- Accepts `SIGTERM` as a clean exit signal in the close handler (alongside `SIGKILL` and exit code 0)

Closes #48

## Test plan
- [ ] Verify transcoding still works for a single request (opus and mp3)
- [ ] Simulate concurrent transcode requests exceeding the limit and verify 503 + `Retry-After` header
- [ ] Verify the slot is released after a transcode completes or fails
- [ ] Verify `getTranscodeCapacity()` reports correct values
- [ ] Backend compiles cleanly (`tsc --noEmit`) and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)