### PR TITLE
Fix N+1 album metadata lookups in GET /album/:albumId

### DIFF
--- a/backend/src/api/libraryRoutes.ts
+++ b/backend/src/api/libraryRoutes.ts
@@ -379,18 +379,32 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       }
 
       const tracksWithOwnerNames = mapTrackOwners(indexStore.getTracks(), ownerNamesById);
+
+      // Group tracks by album directory so we only resolve metadata once per directory
+      const tracksByDir = new Map<string, Track[]>();
+      for (const track of tracksWithOwnerNames) {
+        const trackAbsolutePath = resolveDataRelativePath(track.path);
+        const dir = path.dirname(trackAbsolutePath);
+        const existing = tracksByDir.get(dir);
+        if (existing) {
+          existing.push(track);
+        } else {
+          tracksByDir.set(dir, [track]);
+        }
+      }
+
       const metadataCache = new Map<string, ResolvedAlbumMetadata | undefined>();
       const albumTracks: Track[] = [];
       let albumName: string | undefined;
       let cover: string | undefined;
 
-      for (const track of tracksWithOwnerNames) {
-        const metadata = await resolveAlbumMetadataForTrack(track, metadataCache);
+      for (const [, dirTracks] of tracksByDir) {
+        const metadata = await resolveAlbumMetadataForTrack(dirTracks[0], metadataCache);
         if (metadata?.id !== albumId) {
           continue;
         }
-        albumTracks.push(track);
-        albumName = albumName ?? metadata.name ?? track.tags.album;
+        albumTracks.push(...dirTracks);
+        albumName = albumName ?? metadata.name ?? dirTracks[0].tags.album;
         cover = cover ?? metadata.coverPath;
       }
 

--- a/backend/src/api/libraryRoutes.ts
+++ b/backend/src/api/libraryRoutes.ts
@@ -399,12 +399,13 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       let cover: string | undefined;
 
       for (const [, dirTracks] of tracksByDir) {
-        const metadata = await resolveAlbumMetadataForTrack(dirTracks[0], metadataCache);
+        const representative = dirTracks[0]!;
+        const metadata = await resolveAlbumMetadataForTrack(representative, metadataCache);
         if (metadata?.id !== albumId) {
           continue;
         }
         albumTracks.push(...dirTracks);
-        albumName = albumName ?? metadata.name ?? dirTracks[0].tags.album;
+        albumName = albumName ?? metadata.name ?? representative.tags.album;
         cover = cover ?? metadata.coverPath;
       }
 


### PR DESCRIPTION
## Summary
- The `GET /album/:albumId` endpoint was calling `resolveAlbumMetadataForTrack` (async disk I/O) for **every track** in the library to find which ones belong to the requested album
- Fix: group tracks by album directory first (sync string operation), then resolve metadata **once per unique directory** instead of once per track
- This reduces async disk reads from O(N total tracks) to O(M unique album directories), where M << N

## Test plan
- [x] Existing test "returns album track list by album id" passes
- [x] All 220 backend unit tests pass
- [x] All 31 frontend tests pass

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)