### PR TITLE
Mobile UI polish and cross-browser fixes

### DIFF
--- a/backend/src/api/serverRoutes.ts
+++ b/backend/src/api/serverRoutes.ts
@@ -1,13 +1,22 @@
 import { Router } from "express";
 
 import { requireAdmin, requireAuth } from "../auth/middleware";
-import { getVersionCheckResult } from "../services/versionCheck";
+import { getVersionCheckResult, forceVersionCheck } from "../services/versionCheck";
 
 export function createServerRouter(): Router {
   const router = Router();
 
   router.get("/server/version", requireAuth, requireAdmin, (_req, res) => {
     res.json(getVersionCheckResult());
+  });
+
+  router.post("/server/version/check", requireAuth, requireAdmin, async (_req, res, next) => {
+    try {
+      const result = await forceVersionCheck();
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
   });
 
   router.post("/server/update", requireAuth, requireAdmin, async (_req, res, next) => {

--- a/backend/src/services/versionCheck.ts
+++ b/backend/src/services/versionCheck.ts
@@ -154,3 +154,8 @@ export function startVersionCheckSchedule(): void {
 export function getVersionCheckResult(): VersionCheckResult {
   return { ...cachedResult };
 }
+
+export async function forceVersionCheck(): Promise<VersionCheckResult> {
+  await fetchLatestRelease();
+  return { ...cachedResult };
+}

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -105,7 +105,7 @@ export function AuthenticatedApp({
 
   const {
     versionInfo, loadingVersion,
-    updateStatus, onTriggerUpdate,
+    updateStatus, onTriggerUpdate, onCheckForUpdates,
     storageUsage, loadingStorage,
     logFiles, loadingFiles: loadingLogFiles,
     selectedFile: selectedLogFile, setSelectedFile: setSelectedLogFile,
@@ -330,6 +330,7 @@ export function AuthenticatedApp({
         loadingVersion,
         updateStatus,
         onTriggerUpdate,
+        onCheckForUpdates,
         storageUsage,
         loadingStorage,
         logFiles,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -722,6 +722,10 @@ export async function getVersionInfo(): Promise<VersionInfo> {
   return requestJson<VersionInfo>("/api/server/version");
 }
 
+export async function checkForUpdates(): Promise<VersionInfo> {
+  return requestJson<VersionInfo>("/api/server/version/check", { method: "POST" });
+}
+
 export type UpdateStatus = {
   status: "idle" | "updating" | "complete" | "failed" | "unavailable";
   message?: string;

--- a/frontend/src/components/AdminServerView.tsx
+++ b/frontend/src/components/AdminServerView.tsx
@@ -8,6 +8,7 @@ type AdminServerViewProps = {
   loadingVersion: boolean;
   updateStatus: UpdateStatus | null;
   onTriggerUpdate: () => Promise<void>;
+  onCheckForUpdates: () => Promise<void>;
   storageUsage: StorageUsage | null;
   loadingStorage: boolean;
   logFiles: LogFile[];
@@ -163,9 +164,10 @@ type VersionSectionProps = {
   loading: boolean;
   updateStatus: UpdateStatus | null;
   onTriggerUpdate: () => Promise<void>;
+  onCheckForUpdates: () => Promise<void>;
 };
 
-function VersionSection({ versionInfo, loading, updateStatus, onTriggerUpdate }: VersionSectionProps): JSX.Element | null {
+function VersionSection({ versionInfo, loading, updateStatus, onTriggerUpdate, onCheckForUpdates }: VersionSectionProps): JSX.Element | null {
   const isUpdating = updateStatus?.status === "updating";
 
   if (loading && !versionInfo) {
@@ -269,12 +271,22 @@ function VersionSection({ versionInfo, loading, updateStatus, onTriggerUpdate }:
 
   return (
     <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 px-5 py-3 shadow-panel backdrop-blur-sm">
-      <p className="text-sm text-flaque-steel">
-        Running v{versionInfo.currentVersion}
-        {versionInfo.checkedAt
-          ? ` — last checked ${new Date(versionInfo.checkedAt).toLocaleString()}`
-          : ""}
-      </p>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-sm text-flaque-steel">
+          Running v{versionInfo.currentVersion}
+          {versionInfo.checkedAt
+            ? ` — last checked ${new Date(versionInfo.checkedAt).toLocaleString()}`
+            : ""}
+        </p>
+        <button
+          type="button"
+          className="rounded-lg border border-flaque-clay/60 bg-flaque-cream/80 px-3 py-1.5 text-xs font-medium text-flaque-ink transition hover:bg-flaque-cream disabled:opacity-50"
+          disabled={loading}
+          onClick={() => { void onCheckForUpdates(); }}
+        >
+          {loading ? "Checking..." : "Check for updates"}
+        </button>
+      </div>
     </section>
   );
 }
@@ -284,6 +296,7 @@ export function AdminServerView({
   loadingVersion,
   updateStatus,
   onTriggerUpdate,
+  onCheckForUpdates,
   storageUsage,
   loadingStorage,
   logFiles,
@@ -313,6 +326,7 @@ export function AdminServerView({
         loading={loadingVersion}
         updateStatus={updateStatus}
         onTriggerUpdate={onTriggerUpdate}
+        onCheckForUpdates={onCheckForUpdates}
       />
       <StorageSection storageUsage={storageUsage} loading={loadingStorage} />
 

--- a/frontend/src/components/AdminServerView.tsx
+++ b/frontend/src/components/AdminServerView.tsx
@@ -25,13 +25,13 @@ type AdminServerViewProps = {
   hasMore: boolean;
 };
 
-function formatLogTime(epochMs: number): string {
+function formatLogTime(epochMs: number): { hm: string; s: string; ms: string } {
   const d = new Date(epochMs);
   const h = String(d.getHours()).padStart(2, "0");
   const m = String(d.getMinutes()).padStart(2, "0");
   const s = String(d.getSeconds()).padStart(2, "0");
   const ms = String(d.getMilliseconds()).padStart(3, "0");
-  return `${h}:${m}:${s}.${ms}`;
+  return { hm: `${h}:${m}`, s: `:${s}`, ms: `.${ms}` };
 }
 
 function formatLogDate(epochMs: number): string {
@@ -389,34 +389,50 @@ export function AdminServerView({
             const extra = extractExtraFields(entry);
             const isExpanded = expandedIndex === index;
             const level = typeof entry.level === "number" ? entry.level : 30;
+            const time = typeof entry.time === "number" ? formatLogTime(entry.time) : null;
+
+            const currentDate = typeof entry.time === "number" ? formatLogDate(entry.time) : "";
+            const prevEntry = index > 0 ? entries[index - 1] : undefined;
+            const prevDate = prevEntry && typeof prevEntry.time === "number" ? formatLogDate(prevEntry.time) : "";
+            const showDateSeparator = currentDate !== "" && currentDate !== prevDate;
 
             return (
-              <div key={index} className="border-b border-flaque-clay/20 last:border-b-0">
-                <button
-                  type="button"
-                  className={`flex w-full items-start gap-2 px-3 py-1.5 text-left font-mono text-xs transition hover:bg-flaque-cream/60 ${levelTextClassName(level)}`}
-                  onClick={() => toggleExpanded(index)}
-                >
-                  <span className="shrink-0 text-flaque-steel/60">
-                    {typeof entry.time === "number" ? formatLogDate(entry.time) : ""}{" "}
-                    {typeof entry.time === "number" ? formatLogTime(entry.time) : ""}
-                  </span>
-                  <span
-                    className={`inline-block shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold leading-tight ${levelBadgeClassName(level)}`}
-                  >
-                    {formatLevelLabel(level)}
-                  </span>
-                  {entry.context ? (
-                    <span className="shrink-0 text-flaque-steel">[{entry.context}]</span>
-                  ) : null}
-                  <span className="min-w-0 break-all">{entry.msg}</span>
-                </button>
-
-                {isExpanded && extra ? (
-                  <pre className="mx-3 mb-2 overflow-auto rounded-lg bg-flaque-ink/5 px-3 py-2 font-mono text-[11px] text-flaque-steel">
-                    {JSON.stringify(extra, null, 2)}
-                  </pre>
+              <div key={index}>
+                {showDateSeparator ? (
+                  <div className="sticky top-0 z-10 flex justify-center py-1.5 md:hidden">
+                    <span className="rounded-full bg-flaque-clay/70 px-3 py-0.5 text-[10px] font-medium text-white shadow-sm">
+                      {currentDate}
+                    </span>
+                  </div>
                 ) : null}
+                <div className="border-b border-flaque-clay/20 last:border-b-0">
+                  <button
+                    type="button"
+                    className={`flex w-full items-start gap-2 px-3 py-1.5 text-left font-mono text-xs transition hover:bg-flaque-cream/60 ${levelTextClassName(level)}`}
+                    onClick={() => toggleExpanded(index)}
+                  >
+                    <span className="shrink-0 text-flaque-steel/60">
+                      <span className="hidden md:inline">{currentDate} </span>
+                      {time ? time.hm : ""}
+                      <span className="hidden md:inline">{time ? `${time.s}${time.ms}` : ""}</span>
+                    </span>
+                    <span
+                      className={`inline-block shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold leading-tight ${levelBadgeClassName(level)}`}
+                    >
+                      {formatLevelLabel(level)}
+                    </span>
+                    {entry.context ? (
+                      <span className="hidden shrink-0 text-flaque-steel sm:inline">[{entry.context}]</span>
+                    ) : null}
+                    <span className="min-w-0 break-all">{entry.msg}</span>
+                  </button>
+
+                  {isExpanded && extra ? (
+                    <pre className="mx-3 mb-2 overflow-auto rounded-lg bg-flaque-ink/5 px-3 py-2 font-mono text-[11px] text-flaque-steel">
+                      {JSON.stringify(extra, null, 2)}
+                    </pre>
+                  ) : null}
+                </div>
               </div>
             );
           })}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -166,6 +166,7 @@ export function AppShell({
               {...audioPlayerProps}
               expanded={activeView === "player"}
               onArtworkClick={activeView === "player" ? undefined : () => onViewChange("player")}
+              onNavigateToLibrary={() => onViewChange("library")}
             />
           </PlayerShell>
         ) : null}

--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -41,6 +41,7 @@ type AudioPlayerProps = {
   currentQueueTrackId?: string | null;
   onQueueTrackSelect?: (track: Track) => void;
   onArtworkClick?: () => void;
+  onNavigateToLibrary?: () => void;
 };
 
 export function AudioPlayer({
@@ -61,7 +62,8 @@ export function AudioPlayer({
   queueTracks = [],
   currentQueueTrackId = null,
   onQueueTrackSelect,
-  onArtworkClick
+  onArtworkClick,
+  onNavigateToLibrary
 }: AudioPlayerProps): JSX.Element {
   const {
     audioRef, streamSource,
@@ -96,15 +98,29 @@ export function AudioPlayer({
 
   if (!track) {
     return (
-      <section className="rounded-3xl border border-flaque-clay/60 bg-white/85 p-6 shadow-panel backdrop-blur-sm">
+      <section className={expanded
+        ? "flex min-h-0 flex-1 flex-col items-center justify-center rounded-xl m-4 border border-flaque-clay/50 bg-white/75 p-6 shadow-panel backdrop-blur-sm"
+        : "rounded-3xl border border-flaque-clay/60 bg-white/85 p-6 shadow-panel backdrop-blur-sm"
+      }>
         <h2 className="font-display text-xl text-flaque-ink">Player</h2>
-        <p className="mt-2 text-sm text-flaque-steel">Select a track from the library to start streaming.</p>
+        <p className="mt-2 text-sm text-flaque-steel">
+          Select a track from the library to start streaming.
+        </p>
+        {onNavigateToLibrary ? (
+          <button
+            className="mt-4 rounded-xl border border-flaque-clay/60 bg-flaque-cream/80 px-4 py-2 text-sm font-medium text-flaque-ink transition hover:bg-flaque-cream"
+            type="button"
+            onClick={onNavigateToLibrary}
+          >
+            Browse library
+          </button>
+        ) : null}
       </section>
     );
   }
 
   const artworkSize = expanded ? "h-80 w-80 md:h-96 md:w-96" : "h-16 w-16 md:h-20 md:w-20";
-  const contentLayoutClass = expanded ? "w-full max-w-4xl space-y-4" : "min-w-0 flex-1 space-y-1";
+  const contentLayoutClass = expanded ? "w-full space-y-4" : "min-w-0 flex-1 space-y-1";
   const controlsLayoutClass = expanded
     ? "grid w-full grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-end gap-3"
     : "grid w-full grid-cols-[1fr_auto_1fr] items-center justify-items-center";
@@ -118,7 +134,7 @@ export function AudioPlayer({
     ? "flex items-center justify-end gap-2"
     : "flex justify-self-end items-center gap-1";
   const sectionClassName = expanded
-    ? "flex min-h-0 flex-1 flex-col overflow-y-auto rounded-xl m-4 border border-flaque-clay/50 bg-white/75 p-6 shadow-panel backdrop-blur-sm md:p-8"
+    ? "flex min-h-0 flex-1 flex-col overflow-y-auto rounded-xl mx-4 my-4 xl:mx-2 xl:my-2 border border-flaque-clay/50 bg-white/75 p-6 shadow-panel backdrop-blur-sm md:p-8"
     : "rounded-3xl border border-flaque-clay/60 bg-white/90 p-4 shadow-panel backdrop-blur-sm md:p-6";
   const artworkClassName = expanded
     ? `${artworkSize} shrink-0 rounded-2xl object-cover shadow-md`

--- a/frontend/src/components/ConfigView.tsx
+++ b/frontend/src/components/ConfigView.tsx
@@ -44,6 +44,8 @@ export function ConfigView({
   activeSection
 }: ConfigViewProps): JSX.Element {
   const [searchText, setSearchText] = useState("");
+  const [page, setPage] = useState(0);
+  const PAGE_SIZE = 50;
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [activeTrackActionId, setActiveTrackActionId] = useState<string | null>(null);
   const [deleteTrackCandidate, setDeleteTrackCandidate] = useState<Track | null>(null);
@@ -77,6 +79,10 @@ export function ConfigView({
       return searchable.includes(query);
     });
   }, [tracks, searchText, ownerNameById]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredTracks.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages - 1);
+  const paginatedTracks = filteredTracks.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
 
   function openDeleteTrackModal(track: Track): void {
     setDeleteTrackCandidate(track);
@@ -198,7 +204,7 @@ export function ConfigView({
       ) : null}
 
       {activeSection === "files" ? (
-        <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <section className="flex flex-col rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm lg:h-[calc(100vh-6rem)]">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h3 className="font-display text-xl text-flaque-ink">Global file management</h3>
@@ -212,12 +218,12 @@ export function ConfigView({
             type="search"
             placeholder="Search by title, file name, artist, path"
             value={searchText}
-            onChange={(event) => setSearchText(event.target.value)}
+            onChange={(event) => { setSearchText(event.target.value); setPage(0); }}
           />
         </div>
 
         <div className="mt-4 space-y-3 lg:hidden">
-          {filteredTracks.map((track) => {
+          {paginatedTracks.map((track) => {
             const runningAction = activeTrackActionId === track.id;
             const title = getTrackDisplayTitle(track);
 
@@ -259,7 +265,7 @@ export function ConfigView({
           {filteredTracks.length === 0 ? <p className="text-sm text-flaque-steel">No tracks match this search.</p> : null}
         </div>
 
-        <div className="mt-4 hidden max-h-[48vh] overflow-auto rounded-2xl border border-flaque-clay/40 lg:block">
+        <div className="mt-4 hidden min-h-0 flex-1 overflow-auto rounded-2xl border border-flaque-clay/40 lg:block">
           <table className="w-full min-w-[980px] border-collapse text-left text-sm">
             <thead className="sticky top-0 bg-flaque-cream/95 text-flaque-ink">
               <tr>
@@ -272,7 +278,7 @@ export function ConfigView({
               </tr>
             </thead>
             <tbody>
-              {filteredTracks.map((track) => {
+              {paginatedTracks.map((track) => {
                 const runningAction = activeTrackActionId === track.id;
                 const title = getTrackDisplayTitle(track);
 
@@ -323,6 +329,35 @@ export function ConfigView({
             </tbody>
           </table>
         </div>
+
+        {totalPages > 1 ? (
+          <div className="mt-3 flex shrink-0 items-center justify-between text-sm text-flaque-steel">
+            <span>
+              {safePage * PAGE_SIZE + 1}–{Math.min((safePage + 1) * PAGE_SIZE, filteredTracks.length)} of {filteredTracks.length}
+            </span>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                className="rounded-lg border border-flaque-clay/60 bg-flaque-cream/80 px-3 py-1 text-xs font-medium text-flaque-ink transition hover:bg-flaque-cream disabled:opacity-40"
+                disabled={safePage === 0}
+                onClick={() => setPage(safePage - 1)}
+              >
+                Previous
+              </button>
+              <span className="px-2 text-xs">
+                {safePage + 1} / {totalPages}
+              </span>
+              <button
+                type="button"
+                className="rounded-lg border border-flaque-clay/60 bg-flaque-cream/80 px-3 py-1 text-xs font-medium text-flaque-ink transition hover:bg-flaque-cream disabled:opacity-40"
+                disabled={safePage >= totalPages - 1}
+                onClick={() => setPage(safePage + 1)}
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        ) : null}
         </section>
       ) : null}
 

--- a/frontend/src/components/Coverflow.tsx
+++ b/frontend/src/components/Coverflow.tsx
@@ -57,32 +57,50 @@ function coverTransform(progress: number): string {
 export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverSrc }: AlbumListProps): JSX.Element {
   const selectedKey = selectedAlbum ? getAlbumKey(selectedAlbum) : null;
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const labelRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number>(0);
 
   const updateTransforms = useCallback(() => {
     const wrapper = wrapperRef.current;
     if (!wrapper) return;
 
-    const covers = wrapper.querySelectorAll<HTMLElement>(".cover-transform");
+    const items = wrapper.querySelectorAll<HTMLElement>(".cards li");
     const scrollLeft = wrapper.scrollLeft;
     const viewWidth = wrapper.clientWidth;
     const centerX = scrollLeft + viewWidth / 2;
 
-    for (const cover of covers) {
-      const li = cover.closest("li");
-      if (!li) continue;
+    let closestIdx = 0;
+    let closestDist = Infinity;
+
+    for (let i = 0; i < items.length; i++) {
+      const li = items[i];
+      const cover = li.querySelector<HTMLElement>(".cover-transform");
+      if (!cover) continue;
 
       const liCenter = li.offsetLeft + li.offsetWidth / 2;
       const halfRange = viewWidth / 2 + li.offsetWidth / 2;
       const offset = liCenter - centerX;
 
-      // Invert: element to the right (positive offset) → low progress (entering),
-      // element to the left (negative offset) → high progress (exiting)
-      const progress = 0.5 - (offset / halfRange) * 0.5;
+      const dist = Math.abs(offset);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closestIdx = i;
+      }
 
+      const progress = 0.5 - (offset / halfRange) * 0.5;
       cover.style.transform = coverTransform(progress);
     }
-  }, []);
+
+    // Update the label with the centered album info
+    const label = labelRef.current;
+    if (label && albums[closestIdx]) {
+      const album = albums[closestIdx];
+      const titleEl = label.querySelector<HTMLElement>(".coverflow-title");
+      const artistEl = label.querySelector<HTMLElement>(".coverflow-artist");
+      if (titleEl) titleEl.textContent = album.name;
+      if (artistEl) artistEl.textContent = album.artist ?? "";
+    }
+  }, [albums]);
 
   useEffect(() => {
     const wrapper = wrapperRef.current;
@@ -226,6 +244,43 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverS
           margin-right: calc(50% - (var(--cover-size) / 2));
         }
 
+        .coverflow {
+          position: relative;
+        }
+
+        .coverflow-label {
+          position: absolute;
+          top: calc(0.25rem + var(--cover-size) * 1.667);
+          left: 0;
+          right: 0;
+          text-align: center;
+          line-height: 1.3;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          pointer-events: none;
+          z-index: 1;
+        }
+
+        .coverflow-title {
+          font-size: 0.95rem;
+          font-weight: 600;
+          color: rgb(var(--flaque-ink-rgb));
+          max-width: 20rem;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .coverflow-artist {
+          font-size: 0.8rem;
+          color: rgb(var(--flaque-steel-rgb));
+          max-width: 20rem;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
         @media (prefers-reduced-motion: reduce) {
           .cover-transform {
             transform: none !important;
@@ -273,6 +328,10 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverS
               );
             })}
           </ul>
+        </div>
+        <div className="coverflow-label" ref={labelRef}>
+          <span className="coverflow-title">{albums[0]?.name ?? ""}</span>
+          <span className="coverflow-artist">{albums[0]?.artist ?? ""}</span>
         </div>
       </section>
     </>

--- a/frontend/src/components/Coverflow.tsx
+++ b/frontend/src/components/Coverflow.tsx
@@ -251,7 +251,17 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverS
                       width={1200}
                       height={1200}
                       alt={`Cover for ${albumTitle}`}
-                      onClick={() => onAlbumSelect(album)}
+                      onClick={(e) => {
+                        const li = (e.currentTarget as HTMLElement).closest("li");
+                        const wrapper = wrapperRef.current;
+                        if (li && wrapper) {
+                          wrapper.scrollTo({
+                            left: li.offsetLeft - wrapper.clientWidth / 2 + li.offsetWidth / 2,
+                            behavior: "smooth",
+                          });
+                        }
+                        onAlbumSelect(album);
+                      }}
                     />
                     <div
                       className="cover-reflection"

--- a/frontend/src/components/Coverflow.tsx
+++ b/frontend/src/components/Coverflow.tsx
@@ -117,9 +117,16 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverS
           font-family: "IBM Plex Sans", sans-serif;
           display: flex;
           flex-direction: column;
+          align-items: center;
           gap: 1em;
           padding: 0.25rem 0;
           overscroll-behavior: contain;
+        }
+
+        @media (min-width: 1280px) {
+          .coverflow {
+            --cover-size: 14rem;
+          }
         }
 
         @media (max-width: 1024px) {
@@ -136,13 +143,11 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverS
 
         .cards-wrapper {
           overflow-x: scroll;
-          --size: 6;
           min-height: calc(var(--cover-size) * 2.6);
-          width: calc(var(--cover-size) * var(--size));
-          margin: 0;
+          width: 100%;
+          margin: 0 auto;
           padding: calc(var(--cover-size) / 2.4) 0;
           position: relative;
-          max-width: 100%;
           perspective: 40em;
           scroll-snap-type: x mandatory;
           scrollbar-width: thin;

--- a/frontend/src/components/Coverflow.tsx
+++ b/frontend/src/components/Coverflow.tsx
@@ -1,8 +1,106 @@
+import { useCallback, useEffect, useRef } from "react";
+
 import type { AlbumListProps } from "./AlbumList";
 import { getAlbumKey } from "../utils/appUtils";
 
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+/**
+ * Map a scroll-based progress value (0..1) to the coverflow transform.
+ *
+ * Matches the original CSS animation-timeline keyframes:
+ *   0%  → translateX(-100%) rotateY(-45deg)          (entering from right)
+ *  35%  → translateX(0)     rotateY(-45deg)
+ *  50%  → rotateY(0)        translateZ(1em) scale(1.5) (center)
+ *  65%  → translateX(0)     rotateY(45deg)
+ * 100%  → translateX(100%)  rotateY(45deg)            (exiting to left)
+ */
+function coverTransform(progress: number): string {
+  const p = Math.max(0, Math.min(1, progress));
+
+  let tx: number;
+  let ry: number;
+  let tz: number;
+  let s: number;
+
+  if (p <= 0.35) {
+    const t = p / 0.35;
+    tx = lerp(-100, 0, t);
+    ry = -45;
+    tz = 0;
+    s = 1;
+  } else if (p <= 0.5) {
+    const t = (p - 0.35) / 0.15;
+    tx = 0;
+    ry = lerp(-45, 0, t);
+    tz = lerp(0, 1, t);
+    s = lerp(1, 1.5, t);
+  } else if (p <= 0.65) {
+    const t = (p - 0.5) / 0.15;
+    tx = 0;
+    ry = lerp(0, 45, t);
+    tz = lerp(1, 0, t);
+    s = lerp(1.5, 1, t);
+  } else {
+    const t = (p - 0.65) / 0.35;
+    tx = lerp(0, 100, t);
+    ry = 45;
+    tz = 0;
+    s = 1;
+  }
+
+  return `translateX(${tx.toFixed(1)}%) rotateY(${ry.toFixed(1)}deg) translateZ(${tz.toFixed(2)}em) scale(${s.toFixed(3)})`;
+}
+
 export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverSrc }: AlbumListProps): JSX.Element {
   const selectedKey = selectedAlbum ? getAlbumKey(selectedAlbum) : null;
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number>(0);
+
+  const updateTransforms = useCallback(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+
+    const covers = wrapper.querySelectorAll<HTMLElement>(".cover-transform");
+    const scrollLeft = wrapper.scrollLeft;
+    const viewWidth = wrapper.clientWidth;
+    const centerX = scrollLeft + viewWidth / 2;
+
+    for (const cover of covers) {
+      const li = cover.closest("li");
+      if (!li) continue;
+
+      const liCenter = li.offsetLeft + li.offsetWidth / 2;
+      const halfRange = viewWidth / 2 + li.offsetWidth / 2;
+      const offset = liCenter - centerX;
+
+      // Invert: element to the right (positive offset) → low progress (entering),
+      // element to the left (negative offset) → high progress (exiting)
+      const progress = 0.5 - (offset / halfRange) * 0.5;
+
+      cover.style.transform = coverTransform(progress);
+    }
+  }, []);
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+
+    function onScroll() {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(updateTransforms);
+    }
+
+    wrapper.addEventListener("scroll", onScroll, { passive: true });
+    updateTransforms();
+
+    return () => {
+      wrapper.removeEventListener("scroll", onScroll);
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [updateTransforms, albums]);
 
   return (
     <>
@@ -39,7 +137,7 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverS
         .cards-wrapper {
           overflow-x: scroll;
           --size: 6;
-          min-height: calc(var(--cover-size) * 2.35);
+          min-height: calc(var(--cover-size) * 2.6);
           width: calc(var(--cover-size) * var(--size));
           margin: 0;
           padding: calc(var(--cover-size) / 2.4) 0;
@@ -67,21 +165,35 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverS
           transform-style: preserve-3d;
         }
 
-        .cards li img {
+        .cover-transform {
+          transform-style: preserve-3d;
+          will-change: transform;
+          transform: translateX(-100%) rotateY(-45deg);
+        }
+
+        .cover-transform img {
           display: block;
           width: var(--cover-size);
           height: var(--cover-size);
           border: 1px solid rgb(var(--flaque-clay-rgb) / 0.65);
           border-radius: 0.6rem;
-          -webkit-box-reflect: below 0.5em linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.25));
-          animation: linear rotate-cover both;
-          animation-timeline: view(inline);
-          transform: translateX(-100%) rotateY(-45deg);
-          transform-style: preserve-3d;
-          will-change: transform;
           position: relative;
           user-select: none;
           transition: border-color 160ms ease;
+          cursor: pointer;
+        }
+
+        .cover-reflection {
+          width: var(--cover-size);
+          height: calc(var(--cover-size) * 0.45);
+          margin-top: 0.5em;
+          background-size: var(--cover-size) var(--cover-size);
+          background-position: bottom;
+          transform: scaleY(-1);
+          -webkit-mask-image: linear-gradient(to top, rgba(0,0,0,0.22), transparent);
+          mask-image: linear-gradient(to top, rgba(0,0,0,0.22), transparent);
+          border-radius: 0.6rem;
+          pointer-events: none;
         }
 
         .cards li button {
@@ -109,50 +221,39 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverS
           margin-right: calc(50% - (var(--cover-size) / 2));
         }
 
-        @keyframes rotate-cover {
-          0% {
-            transform: translateX(-100%) rotateY(-45deg);
-          }
-          35% {
-            transform: translateX(0) rotateY(-45deg);
-          }
-          50% {
-            transform: rotateY(0deg) translateZ(1em) scale(1.5);
-          }
-          65% {
-            transform: translateX(0) rotateY(45deg);
-          }
-          100% {
-            transform: translateX(100%) rotateY(45deg);
-          }
-        }
-
         @media (prefers-reduced-motion: reduce) {
-          .cards li img {
-            animation: none;
-            transform: none;
+          .cover-transform {
+            transform: none !important;
           }
         }
       `}</style>
 
       <section className="coverflow">
-        <div className="cards-wrapper">
+        <div className="cards-wrapper" ref={wrapperRef}>
           <ul className="cards">
             {albums.map((album) => {
               const albumKey = getAlbumKey(album);
               const isSelected = selectedKey === albumKey;
               const albumTitle = album.artist ? `${album.artist} - ${album.name}` : album.name;
+              const coverSrc = getAlbumCoverSrc(album);
 
               return (
                 <li key={albumKey} className={isSelected ? "selected" : undefined}>
-                  {/* <button
-                    type="button"
-                    onClick={() => onAlbumSelect(album)}
-                    title={albumTitle}
-                    aria-pressed={isSelected}
-                  > */}
-                    <img draggable={false} src={getAlbumCoverSrc(album)} width={1200} height={1200} alt={`Cover for ${albumTitle}`} onClick={() => onAlbumSelect(album)} />
-                  {/* </button> */}
+                  <div className="cover-transform">
+                    <img
+                      draggable={false}
+                      src={coverSrc}
+                      width={1200}
+                      height={1200}
+                      alt={`Cover for ${albumTitle}`}
+                      onClick={() => onAlbumSelect(album)}
+                    />
+                    <div
+                      className="cover-reflection"
+                      style={{ backgroundImage: `url("${coverSrc}")` }}
+                      aria-hidden="true"
+                    />
+                  </div>
                 </li>
               );
             })}

--- a/frontend/src/components/HomePanels.tsx
+++ b/frontend/src/components/HomePanels.tsx
@@ -12,6 +12,7 @@ type HomePanelsProps = {
   onRecentlyUploadedPeriodChange: (period: UploadPeriod) => void;
   onRecentlyUploadedTrackSelect: (track: Track) => void;
   ownerNameById?: Record<string, string>;
+  onNavigateToLibrary?: () => void;
 };
 
 /**
@@ -26,13 +27,30 @@ export function HomePanels({
   recentlyUploadedPeriod,
   onRecentlyUploadedPeriodChange,
   onRecentlyUploadedTrackSelect,
-  ownerNameById
+  ownerNameById,
+  onNavigateToLibrary
 }: HomePanelsProps): JSX.Element | null {
   const hasRecent = recentTracks.length > 0;
   const hasUploaded = recentlyUploadedTracks.length > 0 || recentlyUploadedLoading;
 
   if (!hasRecent && !hasUploaded) {
-    return null;
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
+        <div className="text-sm text-flaque-steel">
+          <p className="font-bold text-flaque-ink">Oh flaque !</p>
+          <p className="mt-1">Nothing to play here at the moment, maybe you should browse your library ?</p>
+        </div>
+        {onNavigateToLibrary ? (
+          <button
+            className="rounded-xl border border-flaque-clay/60 bg-flaque-cream/80 px-4 py-2 text-sm font-medium text-flaque-ink transition hover:bg-flaque-cream"
+            type="button"
+            onClick={onNavigateToLibrary}
+          >
+            Browse library
+          </button>
+        ) : null}
+      </div>
+    );
   }
 
   const cardGridClass = "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4";

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -194,6 +194,7 @@ export function LibraryWorkspace({
             onRecentlyUploadedPeriodChange={onRecentlyUploadedPeriodChange}
             onRecentlyUploadedTrackSelect={onLibraryTrackSelect}
             ownerNameById={ownerNameById}
+            onNavigateToLibrary={() => onSectionChange("music")}
           />
 
         </>

--- a/frontend/src/components/PlayerShell.tsx
+++ b/frontend/src/components/PlayerShell.tsx
@@ -45,7 +45,7 @@ export function PlayerShell({
           {children}
 
           {activeView !== "player" ? (
-            <div className="pointer-events-none absolute inset-x-0 top-2 flex justify-center">
+            <div className="pointer-events-none absolute inset-x-0 top-2 flex justify-end pr-2 md:justify-center md:pr-0">
               <button
                 className="pointer-events-auto flex h-8 w-10 items-center justify-center rounded-full border border-flaque-clay/60 bg-white/90 text-flaque-steel transition hover:bg-flaque-cream"
                 type="button"

--- a/frontend/src/components/PlayerShell.tsx
+++ b/frontend/src/components/PlayerShell.tsx
@@ -31,7 +31,7 @@ export function PlayerShell({
       <div
         className={
           activeView === "player"
-            ? "relative mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col"
+            ? "relative mx-auto flex min-h-0 w-full flex-1 flex-col"
             : "w-full"
         }
       >

--- a/frontend/src/components/TrackCardGrid.tsx
+++ b/frontend/src/components/TrackCardGrid.tsx
@@ -15,7 +15,7 @@ type TrackCardGridProps = {
   showOwner?: boolean;
 };
 
-const DEFAULT_GRID = "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4";
+const DEFAULT_GRID = "grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4";
 
 export function TrackCardGrid({
   tracks,
@@ -26,7 +26,7 @@ export function TrackCardGrid({
 }: TrackCardGridProps): JSX.Element {
   const resolveOwnerLabel = (owner: string): string => ownerNameById?.[owner] ?? owner;
   return (
-    <div className={`mt-3 grid gap-2 ${gridClassName ?? DEFAULT_GRID}`}>
+    <div className={`mt-3 grid gap-2.5 ${gridClassName ?? DEFAULT_GRID}`}>
       {tracks.map((track) => {
         const title = getTrackDisplayTitle(track);
         const artist = getTrackDisplayArtist(track) ?? "Unknown artist";
@@ -35,38 +35,29 @@ export function TrackCardGrid({
         return (
           <button
             key={track.id}
-            className="w-full justify-self-start rounded-xl border border-flaque-clay/60 bg-flaque-cream/50 px-2.5 py-2 text-left transition hover:bg-flaque-cream sm:max-w-[18.5rem]"
+            className="w-full rounded-xl border border-flaque-clay/60 bg-flaque-cream/50 p-2.5 text-left transition hover:bg-flaque-cream"
             type="button"
             onClick={() => onTrackSelect(track)}
             title={title}
           >
-            <div className="flex items-center gap-2.5">
+            <div className="flex items-start gap-3">
               <img
-                className="h-10 w-10 shrink-0 rounded-lg border border-flaque-clay/50 object-cover"
+                className="h-14 w-14 shrink-0 rounded-lg border border-flaque-clay/50 object-cover"
                 src={coverUrl(track.id, track.cover)}
                 alt={albumWithYear ? `Cover for ${albumWithYear}` : `Cover for ${title}`}
                 onError={(event) => {
                   event.currentTarget.src = defaultCoverImage;
                 }}
               />
-              <div className="min-w-0">
+              <div className="min-w-0 pt-0.5">
                 <p className="truncate text-sm font-medium text-flaque-ink">{title}</p>
+                <p className="mt-0.5 truncate text-xs text-flaque-steel">{artist}</p>
+                {albumWithYear ? (
+                  <p className="truncate text-[11px] text-flaque-steel/70">{albumWithYear}</p>
+                ) : null}
                 {showOwner ? (
-                  <>
-                    <p className="truncate text-xs text-flaque-steel">
-                      {artist}
-                      {albumWithYear ? ` - ${albumWithYear}` : ""}
-                    </p>
-                    <p className="truncate text-[11px] text-flaque-steel/70">{resolveOwnerLabel(track.owner)}</p>
-                  </>
-                ) : (
-                  <>
-                    <p className="truncate text-xs text-flaque-steel">{artist}</p>
-                    {albumWithYear ? (
-                      <p className="truncate text-[11px] text-flaque-steel/70">{albumWithYear}</p>
-                    ) : null}
-                  </>
-                )}
+                  <p className="truncate text-[11px] text-flaque-steel/50">{resolveOwnerLabel(track.owner)}</p>
+                ) : null}
               </div>
             </div>
           </button>

--- a/frontend/src/hooks/useAdminServer.ts
+++ b/frontend/src/hooks/useAdminServer.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
-  getLogFiles, getLogEntries, getStorageUsage, getVersionInfo, triggerUpdate, getUpdateStatus,
+  getLogFiles, getLogEntries, getStorageUsage, getVersionInfo, checkForUpdates as apiCheckForUpdates, triggerUpdate, getUpdateStatus,
   type LogFile, type LogEntry, type StorageUsage, type VersionInfo, type UpdateStatus
 } from "../api";
 import type { User } from "../types";
@@ -21,6 +21,7 @@ type UseAdminServerResult = {
   loadingVersion: boolean;
   updateStatus: UpdateStatus | null;
   onTriggerUpdate: () => Promise<void>;
+  onCheckForUpdates: () => Promise<void>;
   logFiles: LogFile[];
   loadingFiles: boolean;
   selectedFile: string | null;
@@ -186,6 +187,18 @@ export function useAdminServer({ user }: UseAdminServerArgs): UseAdminServerResu
     }
   }
 
+  async function checkForUpdates(): Promise<void> {
+    setLoadingVersion(true);
+    try {
+      const info = await apiCheckForUpdates();
+      setVersionInfo(info);
+    } catch {
+      // ignore
+    } finally {
+      setLoadingVersion(false);
+    }
+  }
+
   async function refreshServer(): Promise<void> {
     setLoadingFiles(true);
     setLoadingStorage(true);
@@ -279,6 +292,7 @@ export function useAdminServer({ user }: UseAdminServerArgs): UseAdminServerResu
     loadingVersion,
     updateStatus,
     onTriggerUpdate: handleTriggerUpdate,
+    onCheckForUpdates: checkForUpdates,
     logFiles,
     loadingFiles,
     selectedFile,

--- a/frontend/src/hooks/useLibraryData.ts
+++ b/frontend/src/hooks/useLibraryData.ts
@@ -534,6 +534,7 @@ export function useLibraryData({
   }
 
   function selectAlbum(album: AlbumEntry): void {
+    if (selectedAlbum && getAlbumKey(album) === getAlbumKey(selectedAlbum)) return;
     setSelectedAlbum(album);
     setSelectedAlbumTracks([]);
     setSelectedAlbumTracksError(null);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,22 +4,8 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
 
-async function bootstrap() {
-  const supports =
-    typeof CSS !== "undefined" &&
-    typeof CSS.supports === "function" &&
-    (CSS.supports("animation-timeline: view()") ||
-      CSS.supports("scroll-timeline-name: --timeline"));
-
-  // Do not load polyfill: rely on native Scroll Timelines; render falls back gracefully
-
-  const { default: App } = await import("./App");
-
-  ReactDOM.createRoot(document.getElementById("root")!).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
-  );
-}
-
-bootstrap();
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,3 +1,1 @@
 /// <reference types="vite/client" />
-
-declare module "/scroll-timeline.js";


### PR DESCRIPTION
## Summary
- **Mobile UI**: reposition mini-player expand button to the right, compact log timestamps with WhatsApp-style date bubbles, improved track cards with larger artwork and separate artist/album lines
- **Coverflow**: rewrite scroll-driven animations in JS for Firefox support, add reflections, scroll-to-center on click, show album title and artist below the central cover
- **Player**: widen expanded player on big screens, improve empty state with "Browse library" button
- **Home**: show friendly empty state message with library link when no recent tracks

## Test plan
- [x] Verify coverflow works in both Chrome and Firefox with 3D transforms and reflections
- [x] Click an album cover and confirm it scrolls to center
- [x] Double-click an album and confirm tracks list is not emptied
- [x] Check expanded player fills width on large screens
- [x] Verify empty player and empty home states show "Browse library" button
- [x] Test mini-player expand button is right-aligned on mobile, centered on desktop
- [x] Check log timestamps are compact on mobile with sticky date bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)