### PR TITLE
Fix storage stats reporting container overlay instead of host volume

### DIFF
--- a/backend/src/api/logRoutes.ts
+++ b/backend/src/api/logRoutes.ts
@@ -155,7 +155,7 @@ export function createLogRouter(): Router {
 
   router.get("/logs/storage", requireAuth, requireAdmin, async (_req, res, next) => {
     try {
-      const fsStats = await fs.statfs(dataRoot);
+      const fsStats = await fs.statfs(storageRoot);
       const blockSize = fsStats.bsize;
       const diskTotal = fsStats.blocks * blockSize;
       const diskFree = fsStats.bavail * blockSize;


### PR DESCRIPTION
## Summary
- `statfs` was called on `dataRoot` (`/app/data`), which resolves to the container's overlay filesystem (~12 GB), not the bind-mounted host volume
- Changed to `storageRoot` (`/app/data/storage`) so disk usage in the admin panel reflects the actual host volume (~425 GB)

## Test plan
- [ ] Deploy and verify the admin Storage section shows the correct disk total/free/used matching `df -h /srv` on the host

🤖 Generated with [Claude Code](https://claude.com/claude-code)