### PR TITLE
Add low storage warning email to admins after upload

### DIFF
--- a/backend/src/api/uploadRoutes.ts
+++ b/backend/src/api/uploadRoutes.ts
@@ -14,6 +14,7 @@ import { fileExists } from "../utils/fs";
 import { getAudioMimeType, getSupportedAudioExtensions, isSupportedAudioFile } from "../utils/mime";
 import { tmpUploadsRoot } from "../utils/paths";
 import { ensureSharedMusicDir } from "../services/storage/storageService";
+import { checkStorageAndWarnAdmins } from "../services/storage/storageWarningService";
 import { createLogger } from "../utils/logger";
 import { normalizeOptionalString, parseBooleanField } from "../utils/validation";
 
@@ -255,6 +256,7 @@ export function createUploadRouter(indexStore: IndexStore): Router {
             album: manualAlbum
           }
         });
+        void checkStorageAndWarnAdmins();
       } catch (error) {
         await cleanupTemporaryFiles(tempFilePaths);
         next(error);

--- a/backend/src/auth/db.ts
+++ b/backend/src/auth/db.ts
@@ -87,6 +87,15 @@ export function listUsers(): AuthUser[] {
     .all() as AuthUser[];
 }
 
+export function listAdminUsersWithEmail(): AuthUser[] {
+  const database = requireDb();
+  return database
+    .prepare(
+      "SELECT id, username, COALESCE(email, '') AS email, role FROM users WHERE role = 'admin' AND email IS NOT NULL AND TRIM(email) != ''"
+    )
+    .all() as AuthUser[];
+}
+
 export function countUsersByRole(role: UserRole): number {
   const database = requireDb();
   const row = database

--- a/backend/src/auth/passwordResetEmail.ts
+++ b/backend/src/auth/passwordResetEmail.ts
@@ -1,6 +1,5 @@
-import nodemailer from "nodemailer";
 import { createLogger } from "../utils/logger";
-import { parseBooleanField } from "../utils/validation";
+import { getTransporter, resolveSenderAddress } from "../utils/email";
 
 const log = createLogger("auth");
 
@@ -10,49 +9,6 @@ type PasswordResetEmailInput = {
   resetUrl: string;
   expiresAt: number;
 };
-
-let cachedTransporter: nodemailer.Transporter | null | undefined;
-
-function getTransporter(): nodemailer.Transporter | null {
-  if (cachedTransporter !== undefined) {
-    return cachedTransporter;
-  }
-
-  const host = (process.env.SMTP_HOST ?? "").trim();
-  if (!host) {
-    cachedTransporter = null;
-    return cachedTransporter;
-  }
-
-  const parsedPort = Number(process.env.SMTP_PORT ?? 587);
-  const port = Number.isFinite(parsedPort) && parsedPort > 0 ? Math.floor(parsedPort) : 587;
-  const secure = process.env.SMTP_SECURE !== undefined ? parseBooleanField(process.env.SMTP_SECURE) : port === 465;
-  const user = (process.env.SMTP_USER ?? "").trim();
-  const pass = process.env.SMTP_PASS ?? "";
-
-  cachedTransporter = nodemailer.createTransport({
-    host,
-    port,
-    secure,
-    auth: user
-      ? {
-          user,
-          pass
-        }
-      : undefined
-  });
-
-  return cachedTransporter;
-}
-
-function resolveSenderAddress(): string {
-  const configured = (process.env.SMTP_FROM ?? "").trim();
-  if (configured) {
-    return configured;
-  }
-
-  return "Flaque <no-reply@flaque.local>";
-}
 
 export async function sendPasswordResetEmail(input: PasswordResetEmailInput): Promise<boolean> {
   const transporter = getTransporter();

--- a/backend/src/services/storage/storageWarningService.ts
+++ b/backend/src/services/storage/storageWarningService.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs/promises";
+
+import { storageRoot } from "../../utils/paths";
+import { getTransporter, resolveSenderAddress } from "../../utils/email";
+import { listAdminUsersWithEmail } from "../../auth/db";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("storage-warning");
+
+const DEFAULT_THRESHOLD_PERCENT = 80;
+const DEFAULT_COOLDOWN_MINUTES = 360;
+
+let lastWarningSentAt = 0;
+
+function getThresholdPercent(): number {
+  const raw = Number(process.env.STORAGE_WARNING_THRESHOLD_PERCENT ?? DEFAULT_THRESHOLD_PERCENT);
+  if (!Number.isFinite(raw) || raw < 1 || raw > 99) {
+    return DEFAULT_THRESHOLD_PERCENT;
+  }
+  return Math.floor(raw);
+}
+
+function getCooldownMs(): number {
+  const raw = Number(process.env.STORAGE_WARNING_COOLDOWN_MINUTES ?? DEFAULT_COOLDOWN_MINUTES);
+  if (!Number.isFinite(raw) || raw < 0) {
+    return DEFAULT_COOLDOWN_MINUTES * 60_000;
+  }
+  return Math.floor(raw) * 60_000;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1_073_741_824) {
+    return `${(bytes / 1_073_741_824).toFixed(2)} GB`;
+  }
+  if (bytes >= 1_048_576) {
+    return `${(bytes / 1_048_576).toFixed(2)} MB`;
+  }
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+export async function checkStorageAndWarnAdmins(): Promise<void> {
+  try {
+    const cooldownMs = getCooldownMs();
+    if (Date.now() - lastWarningSentAt < cooldownMs) {
+      return;
+    }
+
+    const fsStats = await fs.statfs(storageRoot);
+    const blockSize = fsStats.bsize;
+    const diskTotal = fsStats.blocks * blockSize;
+    const diskFree = fsStats.bavail * blockSize;
+    const diskUsed = diskTotal - diskFree;
+
+    if (diskTotal <= 0) {
+      return;
+    }
+
+    const usedPercent = (diskUsed / diskTotal) * 100;
+    const threshold = getThresholdPercent();
+
+    if (usedPercent < threshold) {
+      return;
+    }
+
+    const transporter = getTransporter();
+    if (!transporter) {
+      log.warn("SMTP not configured, cannot send storage warning email");
+      return;
+    }
+
+    const admins = listAdminUsersWithEmail();
+    if (admins.length === 0) {
+      log.warn("No admin users with email addresses found, cannot send storage warning");
+      return;
+    }
+
+    const adminEmails = admins.map((a) => a.email);
+
+    await transporter.sendMail({
+      from: resolveSenderAddress(),
+      to: adminEmails[0],
+      bcc: adminEmails.slice(1),
+      subject: `Flaque: Low disk storage warning (${usedPercent.toFixed(1)}% used)`,
+      text: [
+        "Disk storage on your Flaque server is running low.",
+        "",
+        `Current usage: ${usedPercent.toFixed(1)}% (${formatBytes(diskUsed)} used of ${formatBytes(diskTotal)} total)`,
+        `Free space remaining: ${formatBytes(diskFree)}`,
+        `Warning threshold: ${threshold}%`,
+        "",
+        "Consider freeing up disk space or expanding storage to avoid disruption."
+      ].join("\n")
+    });
+
+    lastWarningSentAt = Date.now();
+    log.info("Storage warning email sent to admins", {
+      usedPercent: usedPercent.toFixed(1),
+      diskFree: formatBytes(diskFree),
+      recipients: adminEmails.length
+    });
+  } catch (error) {
+    log.error("Failed to check storage or send warning email", { error: String(error) });
+  }
+}

--- a/backend/src/utils/email.ts
+++ b/backend/src/utils/email.ts
@@ -1,0 +1,45 @@
+import nodemailer from "nodemailer";
+import { parseBooleanField } from "./validation";
+
+let cachedTransporter: nodemailer.Transporter | null | undefined;
+
+export function getTransporter(): nodemailer.Transporter | null {
+  if (cachedTransporter !== undefined) {
+    return cachedTransporter;
+  }
+
+  const host = (process.env.SMTP_HOST ?? "").trim();
+  if (!host) {
+    cachedTransporter = null;
+    return cachedTransporter;
+  }
+
+  const parsedPort = Number(process.env.SMTP_PORT ?? 587);
+  const port = Number.isFinite(parsedPort) && parsedPort > 0 ? Math.floor(parsedPort) : 587;
+  const secure = process.env.SMTP_SECURE !== undefined ? parseBooleanField(process.env.SMTP_SECURE) : port === 465;
+  const user = (process.env.SMTP_USER ?? "").trim();
+  const pass = process.env.SMTP_PASS ?? "";
+
+  cachedTransporter = nodemailer.createTransport({
+    host,
+    port,
+    secure,
+    auth: user
+      ? {
+          user,
+          pass
+        }
+      : undefined
+  });
+
+  return cachedTransporter;
+}
+
+export function resolveSenderAddress(): string {
+  const configured = (process.env.SMTP_FROM ?? "").trim();
+  if (configured) {
+    return configured;
+  }
+
+  return "Flaque <no-reply@flaque.local>";
+}


### PR DESCRIPTION
## Summary
- After a successful file upload, checks disk usage against a configurable threshold (default 80%)
- Sends a warning email to all admin users (with email addresses) when storage is running low
- Uses a 6-hour cooldown (configurable) to prevent email spam
- Extracts shared nodemailer transporter into `utils/email.ts` for reuse across email features

### New env vars
- `STORAGE_WARNING_THRESHOLD_PERCENT` — disk usage % to trigger warning (default: 80)
- `STORAGE_WARNING_COOLDOWN_MINUTES` — minimum interval between warning emails (default: 360)

## Test plan
- [ ] Set `STORAGE_WARNING_THRESHOLD_PERCENT=1`, configure SMTP, upload a file — verify admin receives warning email
- [ ] Upload again immediately — verify cooldown prevents duplicate email
- [ ] Verify forgot-password email still works after the nodemailer refactor
- [ ] Build passes, existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)