### PR TITLE
Add path-based routing for all pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ export default function App(): JSX.Element {
     sessionChecked,
     activeView, setActiveView,
     activeLibrarySection, setActiveLibrarySection,
+    activeConfigSection, setActiveConfigSection,
     handleLogin, notifyAuthStateChanged
   } = useSessionRoutingState();
 
@@ -34,6 +35,8 @@ export default function App(): JSX.Element {
       setActiveView={setActiveView}
       activeLibrarySection={activeLibrarySection}
       setActiveLibrarySection={setActiveLibrarySection}
+      activeConfigSection={activeConfigSection}
+      setActiveConfigSection={setActiveConfigSection}
       notifyAuthStateChanged={notifyAuthStateChanged}
     />
   );

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -27,6 +27,8 @@ type AuthenticatedAppProps = {
   setActiveView: Dispatch<SetStateAction<ViewName>>;
   activeLibrarySection: LibrarySection;
   setActiveLibrarySection: Dispatch<SetStateAction<LibrarySection>>;
+  activeConfigSection: ConfigSection;
+  setActiveConfigSection: Dispatch<SetStateAction<ConfigSection>>;
   notifyAuthStateChanged: (kind: "login" | "logout" | "session-change") => void;
 };
 
@@ -37,11 +39,12 @@ export function AuthenticatedApp({
   setActiveView,
   activeLibrarySection,
   setActiveLibrarySection,
+  activeConfigSection,
+  setActiveConfigSection,
   notifyAuthStateChanged
 }: AuthenticatedAppProps): JSX.Element {
   // ── UI state ──────────────────────────────────────────────────────────
   const [rebuilding, setRebuilding] = useState(false);
-  const [activeConfigSection, setActiveConfigSection] = useState<ConfigSection>("index");
   const [playerStatusMessage, setPlayerStatusMessage] = useState<string | null>(null);
   const { appNotice, setAppNotice } = useAppNotice();
   const [playerReturnView, setPlayerReturnView] = useState<ViewName>("library");
@@ -220,6 +223,7 @@ export function AuthenticatedApp({
     notifyAuthStateChanged("logout");
     resetAfterLogout();
     setActiveLibrarySection("home");
+    setActiveConfigSection("index");
     setPlayerReturnView("library");
     setAvatarVersion(0);
     setFilters({});

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 import type { User } from "../types";
-import type { ViewName } from "../utils/appUtils";
+import { navigateTo, type ViewName } from "../utils/appUtils";
 import { Acronym } from "./HeaderAcronym";
 
 type AppHeaderProps = {
@@ -42,7 +42,7 @@ export function AppHeader({ activeView, user, avatarUrl, onViewChange, children 
             type="button"
             aria-label="Go to library"
             title="Library"
-            onClick={() => onViewChange("library")}
+            onClick={() => { navigateTo("library"); onViewChange("library"); }}
           >
             <img
               className="header-logo-light absolute inset-0 h-full w-full object-contain"
@@ -83,7 +83,7 @@ export function AppHeader({ activeView, user, avatarUrl, onViewChange, children 
             type="button"
             aria-label="Library"
             title="Library"
-            onClick={() => onViewChange("library")}
+            onClick={() => { navigateTo("library"); onViewChange("library"); }}
           >
             <span className="relative block h-10 w-10" aria-hidden="true">
               <img className="nav-icon-light absolute inset-0 h-full w-full" src="/library-light.png" alt="" />
@@ -96,7 +96,7 @@ export function AppHeader({ activeView, user, avatarUrl, onViewChange, children 
             type="button"
             aria-label="Upload"
             title="Upload"
-            onClick={() => onViewChange("upload")}
+            onClick={() => { navigateTo("upload"); onViewChange("upload"); }}
           >
             <span className="relative block h-10 w-10" aria-hidden="true">
               <img className="nav-icon-light absolute inset-0 h-full w-full" src="/upload-light.png" alt="" />
@@ -110,7 +110,7 @@ export function AppHeader({ activeView, user, avatarUrl, onViewChange, children 
               type="button"
               aria-label="Configuration"
               title="Configuration"
-              onClick={() => onViewChange("config")}
+              onClick={() => { navigateTo("config"); onViewChange("config"); }}
             >
               <span className="relative block h-10 w-10" aria-hidden="true">
                 <img className="nav-icon-light absolute inset-0 h-full w-full" src="/settings-light.png" alt="" />
@@ -128,7 +128,7 @@ export function AppHeader({ activeView, user, avatarUrl, onViewChange, children 
             type="button"
             aria-label="Account"
             title={user.username}
-            onClick={() => onViewChange("account")}
+            onClick={() => { navigateTo("account"); onViewChange("account"); }}
           >
             {avatarLoadFailed ? (
               <span className="font-display text-sm text-flaque-ink">{userInitial}</span>

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import type { User } from "../types";
-import type { ViewName } from "../utils/appUtils";
+import { navigateTo, type ViewName } from "../utils/appUtils";
 import { AccountView } from "./AccountView";
 import { AdminBackupView } from "./AdminBackupView";
 import { AdminServerView } from "./AdminServerView";
@@ -85,7 +85,7 @@ export function AppShell({
           key={key}
           className={sectionButtonClassName(configViewProps.activeSection === key)}
           type="button"
-          onClick={() => configViewProps.onSectionChange(key)}
+          onClick={() => { navigateTo("config", key); configViewProps.onSectionChange(key); }}
         >
           {label}
         </button>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import type { User } from "../types";
 import type { LibrarySection } from "../types/library";
-import type { ViewName } from "../utils/appUtils";
+import { navigateTo, type ViewName } from "../utils/appUtils";
 import { Acronym } from "./HeaderAcronym";
 
 type AppSidebarProps = {
@@ -93,12 +93,14 @@ export function AppSidebar({
     }`;
 
   const handleLibraryEntryClick = (section: LibrarySection): void => {
+    navigateTo("library", section);
     onViewChange("library");
     onLibrarySectionChange(section);
     setMobileMenuOpen(false);
   };
 
   const handleViewEntryClick = (view: ViewName): void => {
+    navigateTo(view);
     onViewChange(view);
     setMobileMenuOpen(false);
   };

--- a/frontend/src/components/LibrarySectionSwitcher.tsx
+++ b/frontend/src/components/LibrarySectionSwitcher.tsx
@@ -1,4 +1,5 @@
 import type { LibrarySection } from "../types/library";
+import { navigateTo } from "../utils/appUtils";
 
 type LibrarySectionSwitcherProps = {
   activeSection: LibrarySection;
@@ -30,7 +31,7 @@ export function LibrarySectionSwitcher({
                   : "border border-flaque-clay bg-white text-flaque-ink hover:bg-flaque-cream"
               }`}
               type="button"
-              onClick={() => onSectionChange(sectionKey)}
+              onClick={() => { navigateTo("library", sectionKey); onSectionChange(sectionKey); }}
             >
               {sectionLabel}
             </button>

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -5,6 +5,7 @@ import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
 import { PaginatedLibrary } from "./PaginatedLibrary";
 import type { AlbumEntry, ArtistEntry, LibraryResponse, Playlist, PlaylistVisibility, Track } from "../types";
 import type { LibraryFilters, LibrarySection } from "../types/library";
+import { navigateTo } from "../utils/appUtils";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
 
 type LibraryWorkspaceProps = {
@@ -194,7 +195,7 @@ export function LibraryWorkspace({
             onRecentlyUploadedPeriodChange={onRecentlyUploadedPeriodChange}
             onRecentlyUploadedTrackSelect={onLibraryTrackSelect}
             ownerNameById={ownerNameById}
-            onNavigateToLibrary={() => onSectionChange("music")}
+            onNavigateToLibrary={() => { navigateTo("library", "music"); onSectionChange("music"); }}
           />
 
         </>

--- a/frontend/src/hooks/useAdminCommands.ts
+++ b/frontend/src/hooks/useAdminCommands.ts
@@ -7,7 +7,7 @@ import {
   resetUserPassword
 } from "../api";
 import type { User } from "../types";
-import type { ViewName } from "../utils/appUtils";
+import { navigateTo, type ViewName } from "../utils/appUtils";
 
 type UseAdminCommandsArgs = {
   user: User | null;
@@ -79,6 +79,7 @@ export function useAdminCommands({
       setUser(patchedUser);
 
       if (patchedUser.role !== "admin") {
+        navigateTo("library");
         setActiveView("library");
         clearAdminState();
         return;

--- a/frontend/src/hooks/useSessionRoutingState.ts
+++ b/frontend/src/hooks/useSessionRoutingState.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from "react";
 
 import { getCurrentUser, login } from "../api";
+import type { ConfigSection } from "../components/ConfigView";
 import type { User } from "../types";
 import type { LibrarySection } from "../types/library";
-import { getViewFromLocation, syncViewToLocation, type ViewName } from "../utils/appUtils";
+import { getRouteFromLocation, syncRouteToLocation, type ViewName } from "../utils/appUtils";
 
-const VIEW_QUERY_PARAM = "view";
 const AUTH_SYNC_CHANNEL = "flaque-auth-sync-v1";
 const AUTH_SYNC_STORAGE_KEY = "flaque_auth_sync_v1";
 
@@ -23,6 +23,8 @@ type UseSessionRoutingStateResult = {
   setActiveView: Dispatch<SetStateAction<ViewName>>;
   activeLibrarySection: LibrarySection;
   setActiveLibrarySection: Dispatch<SetStateAction<LibrarySection>>;
+  activeConfigSection: ConfigSection;
+  setActiveConfigSection: Dispatch<SetStateAction<ConfigSection>>;
   handleLogin: (login: string, password: string) => Promise<void>;
   notifyAuthStateChanged: (kind: AuthSyncEvent["kind"]) => void;
 };
@@ -38,8 +40,19 @@ function createTabId(): string {
 export function useSessionRoutingState(): UseSessionRoutingStateResult {
   const [user, setUser] = useState<User | null>(null);
   const [sessionChecked, setSessionChecked] = useState(false);
-  const [activeView, setActiveView] = useState<ViewName>(() => getViewFromLocation(VIEW_QUERY_PARAM));
-  const [activeLibrarySection, setActiveLibrarySection] = useState<LibrarySection>("home");
+  const [activeView, setActiveView] = useState<ViewName>(() => getRouteFromLocation().view);
+  const [activeLibrarySection, setActiveLibrarySection] = useState<LibrarySection>(() => {
+    const route = getRouteFromLocation();
+    return route.view === "library" && route.section
+      ? (route.section as LibrarySection)
+      : "home";
+  });
+  const [activeConfigSection, setActiveConfigSection] = useState<ConfigSection>(() => {
+    const route = getRouteFromLocation();
+    return route.view === "config" && route.section
+      ? (route.section as ConfigSection)
+      : "index";
+  });
 
   const sourceIdRef = useRef(createTabId());
   const channelRef = useRef<BroadcastChannel | null>(null);
@@ -127,13 +140,21 @@ export function useSessionRoutingState(): UseSessionRoutingStateResult {
 
   useEffect(() => {
     const onPopState = () => {
-      const requestedView = getViewFromLocation(VIEW_QUERY_PARAM);
-      if (requestedView === "config" && user?.role !== "admin") {
+      const route = getRouteFromLocation();
+
+      if (route.view === "config" && user?.role !== "admin") {
         setActiveView("library");
         return;
       }
 
-      setActiveView(requestedView);
+      setActiveView(route.view);
+
+      if (route.view === "library" && route.section) {
+        setActiveLibrarySection(route.section as LibrarySection);
+      }
+      if (route.view === "config" && route.section) {
+        setActiveConfigSection(route.section as ConfigSection);
+      }
     };
 
     window.addEventListener("popstate", onPopState);
@@ -153,8 +174,13 @@ export function useSessionRoutingState(): UseSessionRoutingStateResult {
       return;
     }
 
-    syncViewToLocation(resolvedView, VIEW_QUERY_PARAM);
-  }, [activeView, sessionChecked, user?.role]);
+    const section = resolvedView === "library"
+      ? activeLibrarySection
+      : resolvedView === "config"
+        ? activeConfigSection
+        : null;
+    syncRouteToLocation(resolvedView, section);
+  }, [activeView, activeLibrarySection, activeConfigSection, sessionChecked, user?.role]);
 
   async function handleLogin(loginValue: string, password: string): Promise<void> {
     const authenticatedUser = await login(loginValue, password);
@@ -172,6 +198,8 @@ export function useSessionRoutingState(): UseSessionRoutingStateResult {
     setActiveView,
     activeLibrarySection,
     setActiveLibrarySection,
+    activeConfigSection,
+    setActiveConfigSection,
     handleLogin,
     notifyAuthStateChanged
   };

--- a/frontend/src/utils/appUtils.test.ts
+++ b/frontend/src/utils/appUtils.test.ts
@@ -1,12 +1,15 @@
+/* @vitest-environment happy-dom */
+
 import { describe, expect, it } from "vitest";
 
 import type { Track } from "../types";
 import {
+  buildPathForRoute,
   getAdjacentTrackInQueue,
   getAlbumKey,
+  getRouteFromLocation,
   isTrackLike,
   parseStoredQueueSnapshot,
-  parseViewParam,
   sortAlbumTracksByNumber
 } from "./appUtils";
 
@@ -67,11 +70,42 @@ describe("appUtils", () => {
     expect(getAdjacentTrackInQueue(queue, "a", "previous", true)?.id).toBe("c");
   });
 
-  it("parses supported view params", () => {
-    expect(parseViewParam("library")).toBe("library");
-    expect(parseViewParam("upload")).toBe("upload");
-    expect(parseViewParam("config")).toBe("config");
-    expect(parseViewParam("invalid")).toBeNull();
+  it("builds path for route from view and section", () => {
+    expect(buildPathForRoute("library", "home")).toBe("/");
+    expect(buildPathForRoute("library", "music")).toBe("/library/music");
+    expect(buildPathForRoute("library", "artists")).toBe("/library/artists");
+    expect(buildPathForRoute("library")).toBe("/");
+    expect(buildPathForRoute("config", "index")).toBe("/settings");
+    expect(buildPathForRoute("config", "server")).toBe("/settings/server");
+    expect(buildPathForRoute("config")).toBe("/settings");
+    expect(buildPathForRoute("upload")).toBe("/upload");
+    expect(buildPathForRoute("player")).toBe("/player");
+    expect(buildPathForRoute("account")).toBe("/account");
+  });
+
+  it("reads route from location pathname", () => {
+    window.history.replaceState({}, "", "/settings/server");
+    expect(getRouteFromLocation()).toEqual({ view: "config", section: "server" });
+
+    window.history.replaceState({}, "", "/library/artists");
+    expect(getRouteFromLocation()).toEqual({ view: "library", section: "artists" });
+
+    window.history.replaceState({}, "", "/upload");
+    expect(getRouteFromLocation()).toEqual({ view: "upload", section: null });
+
+    window.history.replaceState({}, "", "/");
+    expect(getRouteFromLocation()).toEqual({ view: "library", section: "home" });
+
+    window.history.replaceState({}, "", "/unknown-path");
+    expect(getRouteFromLocation()).toEqual({ view: "library", section: "home" });
+  });
+
+  it("redirects legacy view query param to path", () => {
+    window.history.replaceState({}, "", "/?view=config");
+    const route = getRouteFromLocation();
+    expect(route).toEqual({ view: "config", section: "index" });
+    expect(window.location.pathname).toBe("/settings");
+    expect(window.location.search).toBe("");
   });
 
   it("builds album keys with id fallback", () => {

--- a/frontend/src/utils/appUtils.ts
+++ b/frontend/src/utils/appUtils.ts
@@ -3,6 +3,11 @@ import { getTrackDisplayTitle } from "./tracks";
 
 export type ViewName = "library" | "upload" | "player" | "config" | "account";
 
+export type AppRoute = {
+  view: ViewName;
+  section: string | null;
+};
+
 export type StoredQueueSnapshot = {
   userId: string;
   trackIds: string[];
@@ -153,44 +158,100 @@ export function getAdjacentTrackInQueue(
   return queue[targetIndex] ?? null;
 }
 
-/**
- * Parse and validate the URL `view` query parameter.
- */
-export function parseViewParam(rawValue: string | null): ViewName | null {
-  if (rawValue === "library" || rawValue === "upload" || rawValue === "player" || rawValue === "config" || rawValue === "account") {
-    return rawValue;
-  }
+const PATH_MAP: Record<string, AppRoute> = {
+  "": { view: "library", section: "home" },
+  "library": { view: "library", section: "home" },
+  "library/home": { view: "library", section: "home" },
+  "library/music": { view: "library", section: "music" },
+  "library/artists": { view: "library", section: "artists" },
+  "library/albums": { view: "library", section: "albums" },
+  "library/playlists": { view: "library", section: "playlists" },
+  "upload": { view: "upload", section: null },
+  "player": { view: "player", section: null },
+  "account": { view: "account", section: null },
+  "settings": { view: "config", section: "index" },
+  "settings/index": { view: "config", section: "index" },
+  "settings/files": { view: "config", section: "files" },
+  "settings/users": { view: "config", section: "users" },
+  "settings/server": { view: "config", section: "server" },
+  "settings/backup": { view: "config", section: "backup" }
+};
 
-  return null;
+const VALID_VIEWS = new Set<string>(["library", "upload", "player", "config", "account"]);
+
+/**
+ * Build a URL path for a given view and optional section.
+ */
+export function buildPathForRoute(view: ViewName, section?: string | null): string {
+  if (view === "library") {
+    const s = section ?? "home";
+    return s === "home" ? "/" : `/library/${s}`;
+  }
+  if (view === "config") {
+    const s = section ?? "index";
+    return s === "index" ? "/settings" : `/settings/${s}`;
+  }
+  return `/${view}`;
 }
 
 /**
- * Read the current app view from location query params.
+ * Read the current app route from the URL pathname.
+ * Handles legacy `?view=` query params by redirecting to the path equivalent.
  */
-export function getViewFromLocation(queryParam: string): ViewName {
+export function getRouteFromLocation(): AppRoute {
   if (typeof window === "undefined") {
-    return "library";
+    return { view: "library", section: "home" };
   }
 
-  const view = parseViewParam(new URLSearchParams(window.location.search).get(queryParam));
-  return view ?? "library";
+  const params = new URLSearchParams(window.location.search);
+  const legacyView = params.get("view");
+  if (legacyView && VALID_VIEWS.has(legacyView)) {
+    params.delete("view");
+    const search = params.toString() ? `?${params.toString()}` : "";
+    const path = buildPathForRoute(legacyView as ViewName);
+    window.history.replaceState(null, "", `${path}${search}${window.location.hash}`);
+    return {
+      view: legacyView as ViewName,
+      section: legacyView === "config" ? "index" : legacyView === "library" ? "home" : null
+    };
+  }
+
+  const raw = window.location.pathname.replace(/^\/+/, "").replace(/\/+$/, "");
+  return PATH_MAP[raw] ?? { view: "library", section: "home" };
 }
 
 /**
- * Synchronize app view state to the location query params.
+ * Synchronize app route state to the URL pathname via replaceState.
+ * Preserves existing query params and hash.
  */
-export function syncViewToLocation(view: ViewName, queryParam: string): void {
+export function syncRouteToLocation(view: ViewName, section?: string | null): void {
   if (typeof window === "undefined") {
     return;
   }
 
-  const url = new URL(window.location.href);
-  if (url.searchParams.get(queryParam) === view) {
+  const targetPath = buildPathForRoute(view, section);
+  if (window.location.pathname === targetPath) {
     return;
   }
 
-  url.searchParams.set(queryParam, view);
-  window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
+  window.history.replaceState(null, "", `${targetPath}${window.location.search}${window.location.hash}`);
+}
+
+/**
+ * Navigate to a route via pushState (adds a history entry for back/forward).
+ * Preserves existing query params and hash.
+ */
+export function navigateTo(view: ViewName, section?: string | null): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const targetPath = buildPathForRoute(view, section);
+  if (window.location.pathname === targetPath) {
+    return;
+  }
+
+  window.history.pushState(null, "", `${targetPath}${window.location.search}${window.location.hash}`);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace `?view=config` query param navigation with clean URL paths: `/settings/server`, `/library/artists`, `/upload`, `/account`, etc.
- Library sub-sections and settings tabs are now persisted in the URL — refreshing on Settings > Server stays on Server
- Browser back/forward works across all page navigations
- Legacy `?view=` bookmarks are automatically redirected to path equivalents

### URL structure
| Path | Page |
|------|------|
| `/` | Library Home |
| `/library/music` | Library |
| `/library/artists` | Artists |
| `/library/albums` | Albums |
| `/library/playlists` | Playlists |
| `/upload` | Upload |
| `/player` | Player |
| `/account` | Account |
| `/settings` | Settings Index |
| `/settings/server` | Settings Server |
| `/settings/users` | Settings Users |
| `/settings/files` | Settings Files |
| `/settings/backup` | Settings Backup |

## Test plan
- [ ] Navigate to `/settings/server`, refresh — stays on Server tab
- [ ] Navigate to `/library/artists`, refresh — stays on Artists
- [ ] Browser back/forward between pages works
- [ ] `?resetToken=XXX` still works on login page
- [ ] Old `?view=config` bookmark redirects to `/settings`
- [ ] Non-admin accessing `/settings/*` is redirected to library

🤖 Generated with [Claude Code](https://claude.com/claude-code)