### PR TITLE
Fix coverflow broken visuals for albums without cover

### DIFF
--- a/frontend/src/components/Coverflow.tsx
+++ b/frontend/src/components/Coverflow.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 
+import defaultCoverImage from "../assets/default-cover.png";
 import type { AlbumListProps } from "./AlbumList";
 import { getAlbumKey } from "../utils/appUtils";
 
@@ -198,6 +199,7 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverS
           display: block;
           width: var(--cover-size);
           height: var(--cover-size);
+          object-fit: cover;
           border: 1px solid rgb(var(--flaque-clay-rgb) / 0.65);
           border-radius: 0.6rem;
           position: relative;
@@ -306,6 +308,13 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverS
                       width={1200}
                       height={1200}
                       alt={`Cover for ${albumTitle}`}
+                      onError={(e) => {
+                        e.currentTarget.src = defaultCoverImage;
+                        const reflection = e.currentTarget.nextElementSibling as HTMLElement | null;
+                        if (reflection) {
+                          reflection.style.backgroundImage = `url("${defaultCoverImage}")`;
+                        }
+                      }}
                       onClick={(e) => {
                         const li = (e.currentTarget as HTMLElement).closest("li");
                         const wrapper = wrapperRef.current;


### PR DESCRIPTION
## Summary
- Add `onError` fallback on coverflow `<img>` elements to swap in the default cover image when a cover fails to load
- Also update the reflection `backgroundImage` to match the fallback
- Add `object-fit: cover` to prevent sizing issues with the placeholder

The `AlbumList` grid view already had this fallback; the `Coverflow` was missing it.

## Test plan
- [x] Upload or add an album with no embedded cover art
- [x] Open the albums view in coverflow mode — verify the default cover placeholder displays correctly with proper sizing and reflection
- [x] Verify albums with real covers still display normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)