### PR TITLE
Display "Unknown Track" placeholder for untitled tracks

### DIFF
--- a/frontend/src/utils/tracks.ts
+++ b/frontend/src/utils/tracks.ts
@@ -12,7 +12,7 @@ export function getTrackDisplayTitle(track: Pick<Track, "path" | "tags">): strin
     return title;
   }
 
-  return fileNameFromPath(track.path);
+  return "Unknown Track";
 }
 
 function normalizeTagText(value: unknown): string | undefined {


### PR DESCRIPTION
## Summary
- `getTrackDisplayTitle()` now returns "Unknown Track" instead of the raw filename when a track has no title tag

## Test plan
- [ ] Upload a file with no title metadata — verify it displays as "Unknown Track" in library, player, and queue
- [ ] Verify tracks with title tags still display normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)