### PR TITLE
Add CPU and RAM monitoring to admin server panel

### DIFF
--- a/backend/src/api/logRoutes.ts
+++ b/backend/src/api/logRoutes.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { cpus, totalmem, freemem } from "node:os";
 
 import { Router } from "express";
 
@@ -153,36 +154,69 @@ export function createLogRouter(): Router {
     }
   });
 
-  router.get("/logs/storage", requireAuth, requireAdmin, async (_req, res, next) => {
-    try {
-      const fsStats = await fs.statfs(storageRoot);
-      const blockSize = fsStats.bsize;
-      const diskTotal = fsStats.blocks * blockSize;
-      const diskFree = fsStats.bavail * blockSize;
+   router.get("/logs/storage", requireAuth, requireAdmin, async (_req, res, next) => {
+     try {
+       const fsStats = await fs.statfs(storageRoot);
+       const blockSize = fsStats.bsize;
+       const diskTotal = fsStats.blocks * blockSize;
+       const diskFree = fsStats.bavail * blockSize;
 
-      const directories = await Promise.all(
-        STORAGE_DIRECTORIES.map(async (dir) => ({
-          name: dir.name,
-          path: dir.path,
-          size: await getDirectorySize(dir.root)
-        }))
-      );
+       const directories = await Promise.all(
+         STORAGE_DIRECTORIES.map(async (dir) => ({
+           name: dir.name,
+           path: dir.path,
+           size: await getDirectorySize(dir.root)
+         }))
+       );
 
-      const totalDataSize = directories.reduce((sum, d) => sum + d.size, 0);
+       const totalDataSize = directories.reduce((sum, d) => sum + d.size, 0);
 
-      res.json({
-        disk: {
-          total: diskTotal,
-          free: diskFree,
-          used: diskTotal - diskFree
-        },
-        directories,
-        totalDataSize
-      });
-    } catch (error) {
-      next(error);
-    }
-  });
+       res.json({
+         disk: {
+           total: diskTotal,
+           free: diskFree,
+           used: diskTotal - diskFree
+         },
+         directories,
+         totalDataSize
+       });
+     } catch (error) {
+       next(error);
+     }
+   });
 
-  return router;
+   router.get("/logs/system-stats", requireAuth, requireAdmin, async (_req, res, next) => {
+     try {
+       const cpusList = cpus();
+       const cores = cpusList.length;
+       
+       let idle = 0;
+       let total = 0;
+       for (const cpu of cpusList) {
+         for (const type of Object.keys(cpu.times) as Array<keyof typeof cpu.times>) {
+           total += cpu.times[type];
+         }
+         idle += cpu.times.idle;
+       }
+       
+       const memoryUsage = (1 - (freemem() / totalmem())) * 100;
+       
+       res.json({
+         cpu: {
+           usagePercent: parseFloat(((1 - idle / total) * 100).toFixed(2)),
+           cores
+         },
+         memory: {
+           total: totalmem(),
+           used: totalmem() - freemem(),
+           free: freemem(),
+           usagePercent: parseFloat(memoryUsage.toFixed(2))
+         }
+       });
+     } catch (error) {
+       next(error);
+     }
+   });
+
+   return router;
 }

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -110,6 +110,9 @@ export function AuthenticatedApp({
     versionInfo, loadingVersion,
     updateStatus, onTriggerUpdate, onCheckForUpdates,
     storageUsage, loadingStorage,
+    systemStats,
+    systemStatsHistory,
+    loadingSystemStats,
     logFiles, loadingFiles: loadingLogFiles,
     selectedFile: selectedLogFile, setSelectedFile: setSelectedLogFile,
     entries: logEntries, loadingEntries: loadingLogEntries,
@@ -337,6 +340,9 @@ export function AuthenticatedApp({
         onCheckForUpdates,
         storageUsage,
         loadingStorage,
+        systemStats,
+        systemStatsHistory,
+        loadingSystemStats,
         logFiles,
         loadingFiles: loadingLogFiles,
         selectedFile: selectedLogFile,
@@ -348,6 +354,7 @@ export function AuthenticatedApp({
         levelFilter: logLevelFilter,
         onLevelFilterChange: setLogLevelFilter,
         onRefresh: refreshLogs,
+        refreshServer: refreshLogs,
         onLoadMore: loadMoreLogs,
         hasMore: hasMoreLogs
       }}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -704,6 +704,11 @@ export type StorageUsage = {
   totalDataSize: number;
 };
 
+export type SystemStats = {
+  cpu: { usagePercent: number; cores: number };
+  memory: { total: number; used: number; free: number; usagePercent: number };
+};
+
 export type VersionInfo = {
   currentVersion: string;
   latestVersion: string | null;
@@ -716,6 +721,10 @@ export type VersionInfo = {
 
 export async function getStorageUsage(): Promise<StorageUsage> {
   return requestJson<StorageUsage>("/api/logs/storage");
+}
+
+export async function getSystemStats(): Promise<SystemStats> {
+  return requestJson<SystemStats>("/api/logs/system-stats");
 }
 
 export async function getVersionInfo(): Promise<VersionInfo> {

--- a/frontend/src/components/AdminServerView.tsx
+++ b/frontend/src/components/AdminServerView.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
-import type { LogFile, LogEntry, StorageUsage, VersionInfo, UpdateStatus } from "../api";
+import type { LogFile, LogEntry, StorageUsage, SystemStats, VersionInfo, UpdateStatus } from "../api";
+import type { SystemStatsDataPoint } from "../hooks/useAdminServer";
 import { formatSize } from "../utils/format";
 
 type AdminServerViewProps = {
@@ -11,6 +12,9 @@ type AdminServerViewProps = {
   onCheckForUpdates: () => Promise<void>;
   storageUsage: StorageUsage | null;
   loadingStorage: boolean;
+  systemStats: SystemStats | null;
+  systemStatsHistory: SystemStatsDataPoint[];
+  loadingSystemStats: boolean;
   logFiles: LogFile[];
   loadingFiles: boolean;
   selectedFile: string | null;
@@ -24,6 +28,7 @@ type AdminServerViewProps = {
   onRefresh: () => Promise<void>;
   onLoadMore: () => Promise<void>;
   hasMore: boolean;
+  refreshServer: () => Promise<void>;
 };
 
 function formatLogTime(epochMs: number): { hm: string; s: string; ms: string } {
@@ -94,6 +99,116 @@ const DIR_COLORS = [
   "bg-purple-500",
   "bg-rose-400"
 ];
+
+function MiniAreaChart({ data, color, maxValue = 100 }: { data: number[]; color: string; maxValue?: number }): JSX.Element {
+  const w = 200;
+  const h = 50;
+
+  if (data.length < 2) {
+    return (
+      <svg viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" className="h-12 w-full rounded-lg" />
+    );
+  }
+
+  const points = data.map((v, i) => {
+    const x = (i / (data.length - 1)) * w;
+    const y = h - (Math.min(v, maxValue) / maxValue) * h;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+
+  const polylinePoints = points.join(" ");
+  const polygonPoints = `0,${h} ${polylinePoints} ${w},${h}`;
+
+  return (
+    <svg viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" className="h-12 w-full rounded-lg">
+      <polygon points={polygonPoints} fill={color} opacity="0.15" />
+      <polyline points={polylinePoints} fill="none" stroke={color} strokeWidth="2" vectorEffect="non-scaling-stroke" />
+    </svg>
+  );
+}
+
+type SystemStatsSectionProps = {
+  systemStats: SystemStats | null;
+  history: SystemStatsDataPoint[];
+  loading: boolean;
+};
+
+function SystemStatsSection({ systemStats, history, loading }: SystemStatsSectionProps): JSX.Element {
+  if (loading && !systemStats) {
+    return (
+      <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <h3 className="font-display text-xl text-flaque-ink">System</h3>
+        <p className="mt-2 text-sm text-flaque-steel">Loading...</p>
+      </section>
+    );
+  }
+
+  if (!systemStats) {
+    return (
+      <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <h3 className="font-display text-xl text-flaque-ink">System</h3>
+        <p className="mt-2 text-sm text-flaque-steel">System stats unavailable.</p>
+      </section>
+    );
+  }
+
+  const cpuPercent = systemStats.cpu.usagePercent;
+  const memPercent = systemStats.memory.usagePercent;
+  const cpuHistory = history.map((p) => p.cpu);
+  const memHistory = history.map((p) => p.memory);
+
+  function barColor(percent: number): string {
+    if (percent > 90) return "bg-red-500";
+    if (percent > 75) return "bg-amber-500";
+    return "";
+  }
+
+  return (
+    <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+      <h3 className="font-display text-xl text-flaque-ink">System</h3>
+
+      <div className="mt-3 grid grid-cols-1 gap-5 sm:grid-cols-2">
+        {/* CPU */}
+        <div>
+          <div className="flex items-baseline justify-between text-sm">
+            <span className="font-medium text-flaque-ink">CPU</span>
+            <span className="text-flaque-steel">
+              {cpuPercent.toFixed(1)}% &middot; {systemStats.cpu.cores} cores
+            </span>
+          </div>
+          <div className="mt-1.5 h-2.5 overflow-hidden rounded-full bg-flaque-clay/30">
+            <div
+              className={`h-full rounded-full transition-all ${barColor(cpuPercent) || "bg-blue-500"}`}
+              style={{ width: `${Math.min(cpuPercent, 100)}%` }}
+            />
+          </div>
+          <div className="mt-2">
+            <MiniAreaChart data={cpuHistory} color="#3b82f6" />
+          </div>
+        </div>
+
+        {/* Memory */}
+        <div>
+          <div className="flex items-baseline justify-between text-sm">
+            <span className="font-medium text-flaque-ink">Memory</span>
+            <span className="text-flaque-steel">
+              {memPercent.toFixed(1)}% &middot; {formatSize(systemStats.memory.used)} / {formatSize(systemStats.memory.total)}
+            </span>
+          </div>
+          <div className="mt-1.5 h-2.5 overflow-hidden rounded-full bg-flaque-clay/30">
+            <div
+              className={`h-full rounded-full transition-all ${barColor(memPercent) || "bg-emerald-500"}`}
+              style={{ width: `${Math.min(memPercent, 100)}%` }}
+            />
+          </div>
+          <div className="mt-2">
+            <MiniAreaChart data={memHistory} color="#10b981" />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
 
 function StorageSection({ storageUsage, loading }: { storageUsage: StorageUsage | null; loading: boolean }): JSX.Element {
   if (loading && !storageUsage) {
@@ -299,6 +414,9 @@ export function AdminServerView({
   onCheckForUpdates,
   storageUsage,
   loadingStorage,
+  systemStats,
+  systemStatsHistory,
+  loadingSystemStats,
   logFiles,
   loadingFiles,
   selectedFile,
@@ -311,7 +429,8 @@ export function AdminServerView({
   onLevelFilterChange,
   onRefresh,
   onLoadMore,
-  hasMore
+  hasMore,
+  refreshServer
 }: AdminServerViewProps): JSX.Element {
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
 
@@ -328,6 +447,7 @@ export function AdminServerView({
         onTriggerUpdate={onTriggerUpdate}
         onCheckForUpdates={onCheckForUpdates}
       />
+      <SystemStatsSection systemStats={systemStats} history={systemStatsHistory} loading={loadingSystemStats} />
       <StorageSection storageUsage={storageUsage} loading={loadingStorage} />
 
       <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">

--- a/frontend/src/hooks/useAdminServer.ts
+++ b/frontend/src/hooks/useAdminServer.ts
@@ -1,14 +1,22 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
-  getLogFiles, getLogEntries, getStorageUsage, getVersionInfo, checkForUpdates as apiCheckForUpdates, triggerUpdate, getUpdateStatus,
-  type LogFile, type LogEntry, type StorageUsage, type VersionInfo, type UpdateStatus
+  getLogFiles, getLogEntries, getStorageUsage, getVersionInfo, checkForUpdates as apiCheckForUpdates, triggerUpdate, getUpdateStatus, getSystemStats,
+  type LogFile, type LogEntry, type StorageUsage, type VersionInfo, type UpdateStatus, type SystemStats
 } from "../api";
 import type { User } from "../types";
 
 const PAGE_SIZE = 200;
 const UPDATE_POLL_INTERVAL_MS = 3_000;
 const UPDATE_POLL_TIMEOUT_MS = 180_000;
+const SYSTEM_STATS_INTERVAL_MS = 10_000;
+const SYSTEM_STATS_MAX_HISTORY = 30;
+
+export type SystemStatsDataPoint = {
+  cpu: number;
+  memory: number;
+  timestamp: number;
+};
 
 type UseAdminServerArgs = {
   user: User | null;
@@ -17,6 +25,9 @@ type UseAdminServerArgs = {
 type UseAdminServerResult = {
   storageUsage: StorageUsage | null;
   loadingStorage: boolean;
+  systemStats: SystemStats | null;
+  systemStatsHistory: SystemStatsDataPoint[];
+  loadingSystemStats: boolean;
   versionInfo: VersionInfo | null;
   loadingVersion: boolean;
   updateStatus: UpdateStatus | null;
@@ -51,6 +62,9 @@ export function useAdminServer({ user }: UseAdminServerArgs): UseAdminServerResu
   const [serverError, setServerError] = useState<string | null>(null);
   const [total, setTotal] = useState(0);
   const [levelFilter, setLevelFilter] = useState<number | null>(null);
+  const [systemStats, setSystemStats] = useState<SystemStats | null>(null);
+  const [systemStatsHistory, setSystemStatsHistory] = useState<SystemStatsDataPoint[]>([]);
+  const [loadingSystemStats, setLoadingSystemStats] = useState(false);
 
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollStartRef = useRef<number>(0);
@@ -109,6 +123,46 @@ export function useAdminServer({ user }: UseAdminServerArgs): UseAdminServerResu
       .finally(() => {
         setLoadingStorage(false);
       });
+  }, [user]);
+
+  // System stats polling (10s interval)
+  useEffect(() => {
+    if (!user || user.role !== "admin") {
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchStats(): Promise<void> {
+      try {
+        const stats = await getSystemStats();
+        if (cancelled) return;
+        setSystemStats(stats);
+        setSystemStatsHistory((prev) => {
+          const point: SystemStatsDataPoint = {
+            cpu: stats.cpu.usagePercent,
+            memory: stats.memory.usagePercent,
+            timestamp: Date.now()
+          };
+          const next = [...prev, point];
+          return next.length > SYSTEM_STATS_MAX_HISTORY ? next.slice(-SYSTEM_STATS_MAX_HISTORY) : next;
+        });
+      } catch {
+        // ignore fetch errors
+      } finally {
+        if (!cancelled) setLoadingSystemStats(false);
+      }
+    }
+
+    setLoadingSystemStats(true);
+    void fetchStats();
+
+    const timer = setInterval(() => { void fetchStats(); }, SYSTEM_STATS_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
   }, [user]);
 
   useEffect(() => {
@@ -288,6 +342,9 @@ export function useAdminServer({ user }: UseAdminServerArgs): UseAdminServerResu
   return {
     storageUsage,
     loadingStorage,
+    systemStats,
+    systemStatsHistory,
+    loadingSystemStats,
     versionInfo,
     loadingVersion,
     updateStatus,


### PR DESCRIPTION
## Summary
- Add system stats API endpoint returning CPU usage % and cores, memory total/used/free/%
- Add SystemStatsSection component displaying CPU and RAM usage with progressive mini area charts
- Poll system stats every 10 seconds with 30-point history for chart visualization
- Position system stats section above storage section in admin panel

## Changes
- **backend**: New `/api/logs/system-stats` endpoint with CPU (usage + cores) and memory (total/used/free) info
- **frontend**: SystemStatsSection with percentage bars and mini area charts, auto-refreshes every 10 seconds