### PR TITLE
Fix version check reading stale cached version

### DIFF
--- a/backend/src/services/versionCheck.ts
+++ b/backend/src/services/versionCheck.ts
@@ -20,7 +20,7 @@ export type VersionCheckResult = {
 
 function readCurrentVersion(): string {
   try {
-    const pkgPath = path.resolve(__dirname, "../../package.json");
+    const pkgPath = path.resolve(process.cwd(), "package.json");
     const raw = fs.readFileSync(pkgPath, "utf8");
     const pkg = JSON.parse(raw) as { version?: string };
     return pkg.version ?? "0.0.0";
@@ -52,10 +52,8 @@ function isNewerVersion(latest: string, current: string): boolean {
   return false;
 }
 
-const currentVersion = readCurrentVersion();
-
 let cachedResult: VersionCheckResult = {
-  currentVersion,
+  currentVersion: readCurrentVersion(),
   latestVersion: null,
   isUpdateAvailable: false,
   releaseUrl: null,
@@ -67,6 +65,8 @@ let cachedResult: VersionCheckResult = {
 let hasLoggedError = false;
 
 async function fetchLatestRelease(): Promise<void> {
+  const currentVersion = readCurrentVersion();
+
   try {
     const response = await fetch(GITHUB_API_URL, {
       headers: {


### PR DESCRIPTION
## Problem
After updating the server, the admin panel still shows "Update available: v0.2.0" while reporting "You are running v0.1.3".

## Root Cause
The `currentVersion` was read once at module load time and cached as a constant. The path used `__dirname` which points to the compiled `dist/` directory, and due to Docker layer caching or build issues, this value could become stale.

## Fix
- Read `package.json` using `process.cwd()` instead of `__dirname` to ensure it reads from the current working directory
- Read `currentVersion` dynamically in `fetchLatestRelease()` instead of caching it at module initialization

This ensures the version check always reflects the actual deployed version.