### PR TITLE
Add chunked upload support for large files

### DIFF
--- a/backend/src/api/uploadRoutes.ts
+++ b/backend/src/api/uploadRoutes.ts
@@ -9,6 +9,14 @@ import { mergeTrackMetadataOverrides } from "../services/indexer/metadataOverrid
 import { IndexStore } from "../services/indexer/indexStore";
 import { extractAudioMetadata } from "../services/scanner/audioProbe";
 import { processUploadedFile, sanitizeExtension, type UploadMetadataOverride } from "../services/upload/uploadService";
+import {
+  initChunkedUpload,
+  getSession,
+  saveChunk,
+  assembleChunks,
+  cancelChunkedUpload,
+  getChunkSize
+} from "../services/upload/chunkedUploadService";
 import type { Track } from "../types/library";
 import { fileExists } from "../utils/fs";
 import { getAudioMimeType, getSupportedAudioExtensions, isSupportedAudioFile } from "../utils/mime";
@@ -113,6 +121,179 @@ export function createUploadRouter(indexStore: IndexStore): Router {
         return;
       }
       callback(new Error("Unsupported audio format"));
+    }
+  });
+
+  router.post("/upload/chunked/init", requireAuth, async (req, res, next) => {
+    try {
+      const fileName = normalizeOptionalString(req.body?.fileName);
+      const fileSize = Number(req.body?.fileSize);
+
+      if (!fileName || !Number.isFinite(fileSize) || fileSize <= 0) {
+        res.status(400).json({ error: "fileName and fileSize are required" });
+        return;
+      }
+
+      if (!isSupportedAudioFile(fileName)) {
+        res.status(400).json({ error: "Unsupported audio format" });
+        return;
+      }
+
+      const session = initChunkedUpload(fileName, fileSize);
+      res.json({
+        sessionId: session.id,
+        chunkSize: session.chunkSize,
+        totalChunks: session.totalChunks
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/upload/chunked/chunk", requireAuth, upload.single("chunk"), async (req, res, next) => {
+    try {
+      const sessionId = normalizeOptionalString(req.body?.sessionId);
+      const chunkIndex = Number(req.body?.chunkIndex);
+
+      if (!sessionId || !Number.isFinite(chunkIndex)) {
+        res.status(400).json({ error: "sessionId and chunkIndex are required" });
+        return;
+      }
+
+      const session = getSession(sessionId);
+      if (!session) {
+        res.status(404).json({ error: "Upload session not found" });
+        return;
+      }
+
+      if (!req.file?.buffer) {
+        res.status(400).json({ error: "Chunk data is required" });
+        return;
+      }
+
+      await saveChunk(sessionId, chunkIndex, req.file.buffer);
+      res.json({ received: chunkIndex, progress: session.receivedChunks.size / session.totalChunks });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/upload/chunked/complete", requireAuth, async (req, res, next) => {
+    try {
+      const sessionId = normalizeOptionalString(req.body?.sessionId);
+
+      if (!sessionId) {
+        res.status(400).json({ error: "sessionId is required" });
+        return;
+      }
+
+      const session = getSession(sessionId);
+      if (!session) {
+        res.status(404).json({ error: "Upload session not found" });
+        return;
+      }
+
+      const assembledPath = await assembleChunks(sessionId);
+      res.json({ tempPath: assembledPath, fileName: session.fileName, size: session.totalSize });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/upload/chunked/cancel", requireAuth, async (req, res, next) => {
+    try {
+      const sessionId = normalizeOptionalString(req.body?.sessionId);
+
+      if (!sessionId) {
+        res.status(400).json({ error: "sessionId is required" });
+        return;
+      }
+
+      await cancelChunkedUpload(sessionId);
+      res.json({ cancelled: true });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/upload/chunk-size", requireAuth, (_req, res) => {
+    res.json({ chunkSize: getChunkSize() });
+  });
+
+  router.post("/upload/finalize", requireAuth, upload.single("file"), async (req, res, next) => {
+    const tempPath = normalizeOptionalString(req.body?.tempPath);
+    let uploadedFile = req.file;
+
+    try {
+      if (tempPath && !uploadedFile) {
+        const exists = await fileExists(tempPath);
+        if (exists) {
+          const stat = await fs.stat(tempPath);
+          uploadedFile = {
+            path: tempPath,
+            originalname: path.basename(tempPath),
+            size: stat.size,
+            mimetype: "audio/flac"
+          } as Express.Multer.File;
+        }
+      }
+
+      if (!uploadedFile) {
+        res.status(400).json({ error: "A file is required" });
+        return;
+      }
+
+      const ownerId = req.authUser?.id;
+      if (!ownerId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const manualArtist = normalizeOptionalString(req.body?.artist);
+      const manualAlbum = normalizeOptionalString(req.body?.album);
+      const deferRebuild = parseBooleanField(req.body?.deferRebuild);
+      const metadataOverrides = parseUploadMetadataOverrides(req.body?.metadataOverrides);
+
+      const musicDir = await ensureSharedMusicDir();
+      const result = await processUploadedFile(
+        uploadedFile,
+        ownerId,
+        musicDir,
+        manualArtist,
+        manualAlbum,
+        metadataOverrides[0] ?? {}
+      );
+
+      if (metadataOverrides[0]) {
+        await mergeTrackMetadataOverrides({ [result.trackId]: metadataOverrides[0] });
+      }
+
+      const updatedIndex = deferRebuild ? indexStore.getSnapshot() : await indexStore.rebuild();
+      const track =
+        updatedIndex.tracks.find((t) => t.id === result.trackId) ??
+        (result.track as Track);
+
+      if (result.isNew) {
+        await appendTrackActivityLogEntries([track]);
+      }
+
+      log.info("Chunked upload complete", {
+        owner: ownerId,
+        trackId: result.trackId,
+        isNew: result.isNew
+      });
+
+      res.status(201).json({
+        processed: 1,
+        uploaded: result.isNew ? 1 : 0,
+        deduplicated: result.isNew ? 0 : 1,
+        tracks: [track],
+        overrides: { artist: manualArtist, album: manualAlbum }
+      });
+
+      void checkStorageAndWarnAdmins();
+    } catch (error) {
+      next(error);
     }
   });
 

--- a/backend/src/services/upload/chunkedUploadService.ts
+++ b/backend/src/services/upload/chunkedUploadService.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { tmpUploadsRoot } from "../../utils/paths";
+
+const log = createLogger("chunked-upload");
+
+const CHUNK_SIZE = 99 * 1024 * 1024;
+const UPLOAD_SESSION_TTL_MS = 60 * 60 * 1000;
+
+export type UploadSession = {
+  id: string;
+  fileName: string;
+  totalSize: number;
+  chunkSize: number;
+  totalChunks: number;
+  receivedChunks: Set<number>;
+  tempDir: string;
+  createdAt: number;
+};
+
+const sessions = new Map<string, UploadSession>();
+
+export function getChunkSize(): number {
+  return CHUNK_SIZE;
+}
+
+function cleanupOldSessions(): void {
+  const now = Date.now();
+  for (const [id, session] of sessions.entries()) {
+    if (now - session.createdAt > UPLOAD_SESSION_TTL_MS) {
+      void fs.rm(session.tempDir, { recursive: true, force: true }).catch(() => {});
+      sessions.delete(id);
+      log.info("Cleaned up expired upload session", { id });
+    }
+  }
+}
+
+setInterval(cleanupOldSessions, 5 * 60 * 1000);
+
+export function initChunkedUpload(fileName: string, totalSize: number): UploadSession {
+  const totalChunks = Math.ceil(totalSize / CHUNK_SIZE);
+  const sessionId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const tempDir = path.join(tmpUploadsRoot, `chunked-${sessionId}`);
+
+  const session: UploadSession = {
+    id: sessionId,
+    fileName,
+    totalSize,
+    chunkSize: CHUNK_SIZE,
+    totalChunks,
+    receivedChunks: new Set(),
+    tempDir,
+    createdAt: Date.now()
+  };
+
+  sessions.set(sessionId, session);
+  void fs.mkdir(tempDir, { recursive: true });
+
+  log.info("Initialized chunked upload session", { sessionId, fileName, totalSize, totalChunks });
+  return session;
+}
+
+export function getSession(sessionId: string): UploadSession | undefined {
+  return sessions.get(sessionId);
+}
+
+export async function saveChunk(sessionId: string, chunkIndex: number, data: Buffer): Promise<void> {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    throw new Error(`Upload session not found: ${sessionId}`);
+  }
+
+  if (chunkIndex < 0 || chunkIndex >= session.totalChunks) {
+    throw new Error(`Invalid chunk index: ${chunkIndex}`);
+  }
+
+  const chunkPath = path.join(session.tempDir, `chunk-${String(chunkIndex).padStart(6, "0")}`);
+  await fs.writeFile(chunkPath, data);
+  session.receivedChunks.add(chunkIndex);
+
+  log.debug("Chunk saved", { sessionId, chunkIndex, received: session.receivedChunks.size });
+}
+
+export async function assembleChunks(sessionId: string): Promise<string> {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    throw new Error(`Upload session not found: ${sessionId}`);
+  }
+
+  if (session.receivedChunks.size !== session.totalChunks) {
+    const missing = [];
+    for (let i = 0; i < session.totalChunks; i++) {
+      if (!session.receivedChunks.has(i)) {
+        missing.push(i);
+      }
+    }
+    throw new Error(`Missing chunks: ${missing.join(", ")}`);
+  }
+
+  const outputFileName = `${Date.now()}-${Math.random().toString(36).slice(2)}${path.extname(session.fileName)}`;
+  const outputPath = path.join(tmpUploadsRoot, outputFileName);
+
+  const writeStream = await fs.open(outputPath, "w");
+
+  try {
+    for (let i = 0; i < session.totalChunks; i++) {
+      const chunkPath = path.join(session.tempDir, `chunk-${String(i).padStart(6, "0")}`);
+      const chunkData = await fs.readFile(chunkPath);
+      await writeStream.write(chunkData);
+    }
+  } finally {
+    await writeStream.close();
+  }
+
+  await fs.rm(session.tempDir, { recursive: true, force: true });
+  sessions.delete(sessionId);
+
+  log.info("Chunks assembled successfully", { sessionId, outputFileName });
+  return outputPath;
+}
+
+export async function cancelChunkedUpload(sessionId: string): Promise<void> {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return;
+  }
+
+  await fs.rm(session.tempDir, { recursive: true, force: true }).catch(() => {});
+  sessions.delete(sessionId);
+  log.info("Chunked upload cancelled", { sessionId });
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -349,7 +349,153 @@ type UploadSingleTrackInput = {
   onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
 };
 
-function uploadSingleTrack(input: UploadSingleTrackInput): Promise<UploadTracksResult> {
+const CHUNK_SIZE = 99 * 1024 * 1024;
+
+async function getChunkSize(): Promise<number> {
+  const response = await requestJson<{ chunkSize: number }>("/api/upload/chunk-size");
+  return response.chunkSize;
+}
+
+type ChunkedUploadSession = {
+  sessionId: string;
+  chunkSize: number;
+  totalChunks: number;
+};
+
+async function initChunkedUpload(fileName: string, fileSize: number): Promise<ChunkedUploadSession> {
+  return requestJson<ChunkedUploadSession>("/api/upload/chunked/init", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ fileName, fileSize })
+  });
+}
+
+async function uploadChunk(sessionId: string, chunkIndex: number, chunk: Blob): Promise<void> {
+  const formData = new FormData();
+  formData.append("sessionId", sessionId);
+  formData.append("chunkIndex", String(chunkIndex));
+  formData.append("chunk", chunk);
+
+  await requestJson<{ received: number }>("/api/upload/chunked/chunk", {
+    method: "POST",
+    body: formData
+  });
+}
+
+async function completeChunkedUpload(sessionId: string): Promise<{ tempPath: string; fileName: string; size: number }> {
+  return requestJson<{ tempPath: string; fileName: string; size: number }>("/api/upload/chunked/complete", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sessionId })
+  });
+}
+
+async function cancelChunkedUpload(sessionId: string): Promise<void> {
+  await requestJson("/api/upload/chunked/cancel", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sessionId })
+  });
+}
+
+async function uploadChunked(
+  file: File,
+  onProgress?: (input: { loaded: number; total: number; percent: number }) => void
+): Promise<{ tempPath: string }> {
+  const { sessionId, chunkSize, totalChunks } = await initChunkedUpload(file.name, file.size);
+  let uploadedBytes = 0;
+
+  try {
+    for (let i = 0; i < totalChunks; i++) {
+      const start = i * chunkSize;
+      const end = Math.min(start + chunkSize, file.size);
+      const chunk = file.slice(start, end);
+
+      await uploadChunk(sessionId, i, chunk);
+      uploadedBytes += chunk.size;
+
+      if (onProgress) {
+        onProgress({
+          loaded: uploadedBytes,
+          total: file.size,
+          percent: Math.round((uploadedBytes / file.size) * 100)
+        });
+      }
+    }
+
+    const result = await completeChunkedUpload(sessionId);
+    return { tempPath: result.tempPath };
+  } catch (error) {
+    await cancelChunkedUpload(sessionId);
+    throw error;
+  }
+}
+
+async function uploadSingleTrack(input: UploadSingleTrackInput): Promise<UploadTracksResult> {
+  if (input.file.size > CHUNK_SIZE) {
+    return uploadSingleTrackChunked(input);
+  }
+  return uploadSingleTrackDirect(input);
+}
+
+async function uploadSingleTrackChunked(input: UploadSingleTrackInput): Promise<UploadTracksResult> {
+  const { tempPath } = await uploadChunked(input.file, input.onProgress);
+  return finalizeChunkedUpload(tempPath, input);
+}
+
+async function finalizeChunkedUpload(
+  tempPath: string,
+  input: Pick<UploadSingleTrackInput, "artist" | "album" | "deferRebuild" | "metadataOverride">
+): Promise<UploadTracksResult> {
+  const formData = new FormData();
+  formData.append("tempPath", tempPath);
+
+  if (input.artist?.trim()) {
+    formData.append("artist", input.artist.trim());
+  }
+
+  if (input.album?.trim()) {
+    formData.append("album", input.album.trim());
+  }
+
+  if (input.metadataOverride) {
+    formData.append("metadataOverrides", JSON.stringify([input.metadataOverride]));
+  }
+
+  if (input.deferRebuild) {
+    formData.append("deferRebuild", "1");
+  }
+
+  return new Promise<UploadTracksResult>((resolve, reject) => {
+    const request = new XMLHttpRequest();
+    request.open("POST", withApiBase("/api/upload/finalize"), true);
+    request.withCredentials = true;
+    request.responseType = "json";
+
+    request.onload = () => {
+      const payload = request.response as { error?: string } | UploadTracksResult | null;
+      if (request.status >= 200 && request.status < 300 && payload) {
+        resolve(payload as UploadTracksResult);
+        return;
+      }
+
+      const message =
+        (payload && typeof payload === "object" && "error" in payload && typeof payload.error === "string"
+          ? payload.error
+          : null) ?? `Request failed (${request.status})`;
+
+      reject(new ApiError(request.status, "/api/upload/finalize", message));
+    };
+
+    request.onerror = () => {
+      reject(new Error("Upload failed due to a network error"));
+    };
+
+    request.send(formData);
+  });
+}
+
+function uploadSingleTrackDirect(input: UploadSingleTrackInput): Promise<UploadTracksResult> {
   const formData = new FormData();
   formData.append("file", input.file);
 


### PR DESCRIPTION
## Summary
Enables uploading of large FLAC lossless files (>100MB) by automatically splitting them into 99MB chunks, uploading them sequentially, and reassembling on the server.

## Changes

### Backend
- **New chunked upload service** (`chunkedUploadService.ts`): Manages upload sessions, stores chunks in temp directory, reassembles files
- **New endpoints**:
  - `POST /api/upload/chunked/init` - Initialize upload session
  - `POST /api/upload/chunked/chunk` - Upload a single chunk
  - `POST /api/upload/chunked/complete` - Finalize and reassemble
  - `POST /api/upload/chunked/cancel` - Cancel upload session
  - `POST /api/upload/finalize` - Process reassembled file
  - `GET /api/upload/chunk-size` - Get chunk size configuration

### Frontend
- **Automatic chunked uploads**: Files larger than 99MB are automatically split and uploaded in chunks
- **Transparent to user**: Same progress reporting, no UI changes needed
- **Chunk size**: 99MB (safe for CloudFlare/proxy 100MB limits)

## How it works
1. For files > 99MB, frontend initiates a chunked upload session
2. File is split into 99MB chunks and uploaded sequentially
3. Server stores chunks in temp directory
4. When all chunks uploaded, server reassembles the file
5. Final `/upload/finalize` processes the complete file