### PR TITLE
Fix chunked upload security bugs and stabilize test suite

### DIFF
--- a/backend/src/api/uploadRoutes.ts
+++ b/backend/src/api/uploadRoutes.ts
@@ -9,6 +9,14 @@ import { mergeTrackMetadataOverrides } from "../services/indexer/metadataOverrid
 import { IndexStore } from "../services/indexer/indexStore";
 import { extractAudioMetadata } from "../services/scanner/audioProbe";
 import { processUploadedFile, sanitizeExtension, type UploadMetadataOverride } from "../services/upload/uploadService";
+import {
+  initChunkedUpload,
+  getSession,
+  saveChunk,
+  assembleChunks,
+  cancelChunkedUpload,
+  getChunkSize
+} from "../services/upload/chunkedUploadService";
 import type { Track } from "../types/library";
 import { fileExists } from "../utils/fs";
 import { getAudioMimeType, getSupportedAudioExtensions, isSupportedAudioFile } from "../utils/mime";
@@ -113,6 +121,179 @@ export function createUploadRouter(indexStore: IndexStore): Router {
         return;
       }
       callback(new Error("Unsupported audio format"));
+    }
+  });
+
+  router.post("/upload/chunked/init", requireAuth, async (req, res, next) => {
+    try {
+      const fileName = normalizeOptionalString(req.body?.fileName);
+      const fileSize = Number(req.body?.fileSize);
+
+      if (!fileName || !Number.isFinite(fileSize) || fileSize <= 0) {
+        res.status(400).json({ error: "fileName and fileSize are required" });
+        return;
+      }
+
+      if (!isSupportedAudioFile(fileName)) {
+        res.status(400).json({ error: "Unsupported audio format" });
+        return;
+      }
+
+      const session = initChunkedUpload(fileName, fileSize);
+      res.json({
+        sessionId: session.id,
+        chunkSize: session.chunkSize,
+        totalChunks: session.totalChunks
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/upload/chunked/chunk", requireAuth, upload.single("chunk"), async (req, res, next) => {
+    try {
+      const sessionId = normalizeOptionalString(req.body?.sessionId);
+      const chunkIndex = Number(req.body?.chunkIndex);
+
+      if (!sessionId || !Number.isFinite(chunkIndex)) {
+        res.status(400).json({ error: "sessionId and chunkIndex are required" });
+        return;
+      }
+
+      const session = getSession(sessionId);
+      if (!session) {
+        res.status(404).json({ error: "Upload session not found" });
+        return;
+      }
+
+      if (!req.file?.buffer) {
+        res.status(400).json({ error: "Chunk data is required" });
+        return;
+      }
+
+      await saveChunk(sessionId, chunkIndex, req.file.buffer);
+      res.json({ received: chunkIndex, progress: session.receivedChunks.size / session.totalChunks });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/upload/chunked/complete", requireAuth, async (req, res, next) => {
+    try {
+      const sessionId = normalizeOptionalString(req.body?.sessionId);
+
+      if (!sessionId) {
+        res.status(400).json({ error: "sessionId is required" });
+        return;
+      }
+
+      const session = getSession(sessionId);
+      if (!session) {
+        res.status(404).json({ error: "Upload session not found" });
+        return;
+      }
+
+      const assembledPath = await assembleChunks(sessionId);
+      res.json({ tempPath: assembledPath, fileName: session.fileName, size: session.totalSize });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/upload/chunked/cancel", requireAuth, async (req, res, next) => {
+    try {
+      const sessionId = normalizeOptionalString(req.body?.sessionId);
+
+      if (!sessionId) {
+        res.status(400).json({ error: "sessionId is required" });
+        return;
+      }
+
+      await cancelChunkedUpload(sessionId);
+      res.json({ cancelled: true });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/upload/chunk-size", requireAuth, (_req, res) => {
+    res.json({ chunkSize: getChunkSize() });
+  });
+
+  router.post("/upload/finalize", requireAuth, upload.single("file"), async (req, res, next) => {
+    const tempPath = normalizeOptionalString(req.body?.tempPath);
+    let uploadedFile = req.file;
+
+    try {
+      if (tempPath && !uploadedFile) {
+        const exists = await fileExists(tempPath);
+        if (exists) {
+          const stat = await fs.stat(tempPath);
+          uploadedFile = {
+            path: tempPath,
+            originalname: path.basename(tempPath),
+            size: stat.size,
+            mimetype: "audio/flac"
+          } as Express.Multer.File;
+        }
+      }
+
+      if (!uploadedFile) {
+        res.status(400).json({ error: "A file is required" });
+        return;
+      }
+
+      const ownerId = req.authUser?.id;
+      if (!ownerId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const manualArtist = normalizeOptionalString(req.body?.artist);
+      const manualAlbum = normalizeOptionalString(req.body?.album);
+      const deferRebuild = parseBooleanField(req.body?.deferRebuild);
+      const metadataOverrides = parseUploadMetadataOverrides(req.body?.metadataOverrides);
+
+      const musicDir = await ensureSharedMusicDir();
+      const result = await processUploadedFile(
+        uploadedFile,
+        ownerId,
+        musicDir,
+        manualArtist,
+        manualAlbum,
+        metadataOverrides[0] ?? {}
+      );
+
+      if (metadataOverrides[0]) {
+        await mergeTrackMetadataOverrides({ [result.trackId]: metadataOverrides[0] });
+      }
+
+      const updatedIndex = deferRebuild ? indexStore.getSnapshot() : await indexStore.rebuild();
+      const track =
+        updatedIndex.tracks.find((t) => t.id === result.trackId) ??
+        (result.track as Track);
+
+      if (result.isNew) {
+        await appendTrackActivityLogEntries([track]);
+      }
+
+      log.info("Chunked upload complete", {
+        owner: ownerId,
+        trackId: result.trackId,
+        isNew: result.isNew
+      });
+
+      res.status(201).json({
+        processed: 1,
+        uploaded: result.isNew ? 1 : 0,
+        deduplicated: result.isNew ? 0 : 1,
+        tracks: [track],
+        overrides: { artist: manualArtist, album: manualAlbum }
+      });
+
+      void checkStorageAndWarnAdmins();
+    } catch (error) {
+      next(error);
     }
   });
 

--- a/backend/src/api/uploadRoutes.ts
+++ b/backend/src/api/uploadRoutes.ts
@@ -11,11 +11,12 @@ import { extractAudioMetadata } from "../services/scanner/audioProbe";
 import { processUploadedFile, sanitizeExtension, type UploadMetadataOverride } from "../services/upload/uploadService";
 import {
   initChunkedUpload,
-  getSession,
+  getOwnedSession,
   saveChunk,
   assembleChunks,
   cancelChunkedUpload,
-  getChunkSize
+  getChunkSize,
+  SessionForbiddenError
 } from "../services/upload/chunkedUploadService";
 import type { Track } from "../types/library";
 import { fileExists } from "../utils/fs";
@@ -30,6 +31,22 @@ const log = createLogger("upload");
 import fs from "node:fs/promises";
 
 const DEFAULT_MAX_UPLOAD_FILES = 50;
+const DEFAULT_MAX_UPLOAD_BYTES = 2_147_483_648;
+
+function getMaxUploadBytes(): number {
+  const raw = Number(process.env.MAX_UPLOAD_BYTES ?? DEFAULT_MAX_UPLOAD_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MAX_UPLOAD_BYTES;
+}
+
+function isPathInside(candidate: string, parent: string): boolean {
+  const resolvedCandidate = path.resolve(candidate);
+  const resolvedParent = path.resolve(parent);
+  if (resolvedCandidate === resolvedParent) {
+    return false;
+  }
+  const withSep = resolvedParent.endsWith(path.sep) ? resolvedParent : resolvedParent + path.sep;
+  return resolvedCandidate.startsWith(withSep);
+}
 
 export function parseUploadMetadataOverrides(value: unknown): UploadMetadataOverride[] {
   if (typeof value !== "string") {
@@ -99,6 +116,8 @@ export function createUploadRouter(indexStore: IndexStore): Router {
   const uploadFileCap =
     Number.isInteger(maxUploadFiles) && maxUploadFiles > 0 ? maxUploadFiles : DEFAULT_MAX_UPLOAD_FILES;
 
+  const maxUploadBytes = getMaxUploadBytes();
+
   const upload = multer({
     storage: multer.diskStorage({
       destination: (_req, _file, callback) => {
@@ -112,7 +131,7 @@ export function createUploadRouter(indexStore: IndexStore): Router {
       }
     }),
     limits: {
-      fileSize: Number(process.env.MAX_UPLOAD_BYTES ?? 2_147_483_648)
+      fileSize: maxUploadBytes
     },
     fileFilter: (_req, file, callback) => {
       const ext = path.extname(file.originalname).toLowerCase();
@@ -124,8 +143,25 @@ export function createUploadRouter(indexStore: IndexStore): Router {
     }
   });
 
+  // Chunks are raw binary blobs from File.slice() with no audio extension; they
+  // need their own multer instance with memory storage (so req.file.buffer is
+  // populated) and no audio-extension filter. The per-chunk cap is CHUNK_SIZE
+  // plus a small overhead for multipart framing.
+  const chunkUpload = multer({
+    storage: multer.memoryStorage(),
+    limits: {
+      fileSize: getChunkSize() + 1024 * 1024
+    }
+  });
+
   router.post("/upload/chunked/init", requireAuth, async (req, res, next) => {
     try {
+      const ownerId = req.authUser?.id;
+      if (!ownerId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
       const fileName = normalizeOptionalString(req.body?.fileName);
       const fileSize = Number(req.body?.fileSize);
 
@@ -134,12 +170,17 @@ export function createUploadRouter(indexStore: IndexStore): Router {
         return;
       }
 
+      if (fileSize > maxUploadBytes) {
+        res.status(413).json({ error: `File exceeds maximum upload size of ${maxUploadBytes} bytes` });
+        return;
+      }
+
       if (!isSupportedAudioFile(fileName)) {
         res.status(400).json({ error: "Unsupported audio format" });
         return;
       }
 
-      const session = initChunkedUpload(fileName, fileSize);
+      const session = await initChunkedUpload(ownerId, fileName, fileSize);
       res.json({
         sessionId: session.id,
         chunkSize: session.chunkSize,
@@ -150,36 +191,51 @@ export function createUploadRouter(indexStore: IndexStore): Router {
     }
   });
 
-  router.post("/upload/chunked/chunk", requireAuth, upload.single("chunk"), async (req, res, next) => {
-    try {
-      const sessionId = normalizeOptionalString(req.body?.sessionId);
-      const chunkIndex = Number(req.body?.chunkIndex);
+  router.post(
+    "/upload/chunked/chunk",
+    requireAuth,
+    chunkUpload.single("chunk"),
+    async (req, res, next) => {
+      try {
+        const ownerId = req.authUser?.id;
+        if (!ownerId) {
+          res.status(401).json({ error: "Authentication required" });
+          return;
+        }
 
-      if (!sessionId || !Number.isFinite(chunkIndex)) {
-        res.status(400).json({ error: "sessionId and chunkIndex are required" });
-        return;
+        const sessionId = normalizeOptionalString(req.body?.sessionId);
+        const chunkIndex = Number(req.body?.chunkIndex);
+
+        if (!sessionId || !Number.isFinite(chunkIndex)) {
+          res.status(400).json({ error: "sessionId and chunkIndex are required" });
+          return;
+        }
+
+        if (!req.file?.buffer) {
+          res.status(400).json({ error: "Chunk data is required" });
+          return;
+        }
+
+        const session = await saveChunk(sessionId, ownerId, chunkIndex, req.file.buffer);
+        res.json({ received: chunkIndex, progress: session.receivedChunks.size / session.totalChunks });
+      } catch (error) {
+        if (error instanceof SessionForbiddenError) {
+          res.status(403).json({ error: "Upload session does not belong to you" });
+          return;
+        }
+        next(error);
       }
-
-      const session = getSession(sessionId);
-      if (!session) {
-        res.status(404).json({ error: "Upload session not found" });
-        return;
-      }
-
-      if (!req.file?.buffer) {
-        res.status(400).json({ error: "Chunk data is required" });
-        return;
-      }
-
-      await saveChunk(sessionId, chunkIndex, req.file.buffer);
-      res.json({ received: chunkIndex, progress: session.receivedChunks.size / session.totalChunks });
-    } catch (error) {
-      next(error);
     }
-  });
+  );
 
   router.post("/upload/chunked/complete", requireAuth, async (req, res, next) => {
     try {
+      const ownerId = req.authUser?.id;
+      if (!ownerId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
       const sessionId = normalizeOptionalString(req.body?.sessionId);
 
       if (!sessionId) {
@@ -187,21 +243,31 @@ export function createUploadRouter(indexStore: IndexStore): Router {
         return;
       }
 
-      const session = getSession(sessionId);
+      const session = getOwnedSession(sessionId, ownerId);
       if (!session) {
         res.status(404).json({ error: "Upload session not found" });
         return;
       }
 
-      const assembledPath = await assembleChunks(sessionId);
+      const assembledPath = await assembleChunks(sessionId, ownerId);
       res.json({ tempPath: assembledPath, fileName: session.fileName, size: session.totalSize });
     } catch (error) {
+      if (error instanceof SessionForbiddenError) {
+        res.status(403).json({ error: "Upload session does not belong to you" });
+        return;
+      }
       next(error);
     }
   });
 
   router.post("/upload/chunked/cancel", requireAuth, async (req, res, next) => {
     try {
+      const ownerId = req.authUser?.id;
+      if (!ownerId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
       const sessionId = normalizeOptionalString(req.body?.sessionId);
 
       if (!sessionId) {
@@ -209,9 +275,13 @@ export function createUploadRouter(indexStore: IndexStore): Router {
         return;
       }
 
-      await cancelChunkedUpload(sessionId);
+      await cancelChunkedUpload(sessionId, ownerId);
       res.json({ cancelled: true });
     } catch (error) {
+      if (error instanceof SessionForbiddenError) {
+        res.status(403).json({ error: "Upload session does not belong to you" });
+        return;
+      }
       next(error);
     }
   });
@@ -222,20 +292,42 @@ export function createUploadRouter(indexStore: IndexStore): Router {
 
   router.post("/upload/finalize", requireAuth, upload.single("file"), async (req, res, next) => {
     const tempPath = normalizeOptionalString(req.body?.tempPath);
+    const originalFileName = normalizeOptionalString(req.body?.fileName);
     let uploadedFile = req.file;
 
     try {
       if (tempPath && !uploadedFile) {
-        const exists = await fileExists(tempPath);
-        if (exists) {
-          const stat = await fs.stat(tempPath);
-          uploadedFile = {
-            path: tempPath,
-            originalname: path.basename(tempPath),
-            size: stat.size,
-            mimetype: "audio/flac"
-          } as Express.Multer.File;
+        if (!isPathInside(tempPath, tmpUploadsRoot)) {
+          res.status(400).json({ error: "Invalid tempPath" });
+          return;
         }
+
+        const resolvedTempPath = path.resolve(tempPath);
+        const exists = await fileExists(resolvedTempPath);
+        if (!exists) {
+          res.status(404).json({ error: "Temporary upload not found" });
+          return;
+        }
+
+        const displayName = originalFileName ?? path.basename(resolvedTempPath);
+        if (!isSupportedAudioFile(displayName)) {
+          res.status(400).json({ error: "Unsupported audio format" });
+          return;
+        }
+
+        const stat = await fs.stat(resolvedTempPath);
+        if (stat.size > maxUploadBytes) {
+          await fs.unlink(resolvedTempPath).catch(() => {});
+          res.status(413).json({ error: `File exceeds maximum upload size of ${maxUploadBytes} bytes` });
+          return;
+        }
+
+        uploadedFile = {
+          path: resolvedTempPath,
+          originalname: displayName,
+          size: stat.size,
+          mimetype: getAudioMimeType(displayName)
+        } as Express.Multer.File;
       }
 
       if (!uploadedFile) {

--- a/backend/src/services/upload/chunkedUploadService.ts
+++ b/backend/src/services/upload/chunkedUploadService.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { tmpUploadsRoot } from "../../utils/paths";
+
+const log = createLogger("chunked-upload");
+
+const CHUNK_SIZE = 99 * 1024 * 1024;
+const UPLOAD_SESSION_TTL_MS = 60 * 60 * 1000;
+
+export type UploadSession = {
+  id: string;
+  fileName: string;
+  totalSize: number;
+  chunkSize: number;
+  totalChunks: number;
+  receivedChunks: Set<number>;
+  tempDir: string;
+  createdAt: number;
+};
+
+const sessions = new Map<string, UploadSession>();
+
+export function getChunkSize(): number {
+  return CHUNK_SIZE;
+}
+
+function cleanupOldSessions(): void {
+  const now = Date.now();
+  for (const [id, session] of sessions.entries()) {
+    if (now - session.createdAt > UPLOAD_SESSION_TTL_MS) {
+      void fs.rm(session.tempDir, { recursive: true, force: true }).catch(() => {});
+      sessions.delete(id);
+      log.info("Cleaned up expired upload session", { id });
+    }
+  }
+}
+
+setInterval(cleanupOldSessions, 5 * 60 * 1000);
+
+export function initChunkedUpload(fileName: string, totalSize: number): UploadSession {
+  const totalChunks = Math.ceil(totalSize / CHUNK_SIZE);
+  const sessionId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const tempDir = path.join(tmpUploadsRoot, `chunked-${sessionId}`);
+
+  const session: UploadSession = {
+    id: sessionId,
+    fileName,
+    totalSize,
+    chunkSize: CHUNK_SIZE,
+    totalChunks,
+    receivedChunks: new Set(),
+    tempDir,
+    createdAt: Date.now()
+  };
+
+  sessions.set(sessionId, session);
+  void fs.mkdir(tempDir, { recursive: true });
+
+  log.info("Initialized chunked upload session", { sessionId, fileName, totalSize, totalChunks });
+  return session;
+}
+
+export function getSession(sessionId: string): UploadSession | undefined {
+  return sessions.get(sessionId);
+}
+
+export async function saveChunk(sessionId: string, chunkIndex: number, data: Buffer): Promise<void> {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    throw new Error(`Upload session not found: ${sessionId}`);
+  }
+
+  if (chunkIndex < 0 || chunkIndex >= session.totalChunks) {
+    throw new Error(`Invalid chunk index: ${chunkIndex}`);
+  }
+
+  const chunkPath = path.join(session.tempDir, `chunk-${String(chunkIndex).padStart(6, "0")}`);
+  await fs.writeFile(chunkPath, data);
+  session.receivedChunks.add(chunkIndex);
+
+  log.debug("Chunk saved", { sessionId, chunkIndex, received: session.receivedChunks.size });
+}
+
+export async function assembleChunks(sessionId: string): Promise<string> {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    throw new Error(`Upload session not found: ${sessionId}`);
+  }
+
+  if (session.receivedChunks.size !== session.totalChunks) {
+    const missing = [];
+    for (let i = 0; i < session.totalChunks; i++) {
+      if (!session.receivedChunks.has(i)) {
+        missing.push(i);
+      }
+    }
+    throw new Error(`Missing chunks: ${missing.join(", ")}`);
+  }
+
+  const outputFileName = `${Date.now()}-${Math.random().toString(36).slice(2)}${path.extname(session.fileName)}`;
+  const outputPath = path.join(tmpUploadsRoot, outputFileName);
+
+  const writeStream = await fs.open(outputPath, "w");
+
+  try {
+    for (let i = 0; i < session.totalChunks; i++) {
+      const chunkPath = path.join(session.tempDir, `chunk-${String(i).padStart(6, "0")}`);
+      const chunkData = await fs.readFile(chunkPath);
+      await writeStream.write(chunkData);
+    }
+  } finally {
+    await writeStream.close();
+  }
+
+  await fs.rm(session.tempDir, { recursive: true, force: true });
+  sessions.delete(sessionId);
+
+  log.info("Chunks assembled successfully", { sessionId, outputFileName });
+  return outputPath;
+}
+
+export async function cancelChunkedUpload(sessionId: string): Promise<void> {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return;
+  }
+
+  await fs.rm(session.tempDir, { recursive: true, force: true }).catch(() => {});
+  sessions.delete(sessionId);
+  log.info("Chunked upload cancelled", { sessionId });
+}

--- a/backend/src/services/upload/chunkedUploadService.ts
+++ b/backend/src/services/upload/chunkedUploadService.ts
@@ -1,16 +1,23 @@
+import { once } from "node:events";
+import { createReadStream, createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { pipeline } from "node:stream/promises";
 
 import { createLogger } from "../../utils/logger";
 import { tmpUploadsRoot } from "../../utils/paths";
 
 const log = createLogger("chunked-upload");
 
+// 99 MiB: kept just under the common 100 MB reverse-proxy body limit
+// (Cloudflare Free, nginx defaults, some CDN WAFs) so a single chunk
+// request never trips those limits.
 const CHUNK_SIZE = 99 * 1024 * 1024;
 const UPLOAD_SESSION_TTL_MS = 60 * 60 * 1000;
 
 export type UploadSession = {
   id: string;
+  ownerId: string;
   fileName: string;
   totalSize: number;
   chunkSize: number;
@@ -19,6 +26,13 @@ export type UploadSession = {
   tempDir: string;
   createdAt: number;
 };
+
+export class SessionForbiddenError extends Error {
+  constructor(sessionId: string) {
+    super(`Upload session not owned by caller: ${sessionId}`);
+    this.name = "SessionForbiddenError";
+  }
+}
 
 const sessions = new Map<string, UploadSession>();
 
@@ -37,15 +51,23 @@ function cleanupOldSessions(): void {
   }
 }
 
-setInterval(cleanupOldSessions, 5 * 60 * 1000);
+// unref so the timer does not keep the process alive in tests / shutdown.
+setInterval(cleanupOldSessions, 5 * 60 * 1000).unref();
 
-export function initChunkedUpload(fileName: string, totalSize: number): UploadSession {
+export async function initChunkedUpload(
+  ownerId: string,
+  fileName: string,
+  totalSize: number
+): Promise<UploadSession> {
   const totalChunks = Math.ceil(totalSize / CHUNK_SIZE);
   const sessionId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const tempDir = path.join(tmpUploadsRoot, `chunked-${sessionId}`);
 
+  await fs.mkdir(tempDir, { recursive: true });
+
   const session: UploadSession = {
     id: sessionId,
+    ownerId,
     fileName,
     totalSize,
     chunkSize: CHUNK_SIZE,
@@ -56,9 +78,8 @@ export function initChunkedUpload(fileName: string, totalSize: number): UploadSe
   };
 
   sessions.set(sessionId, session);
-  void fs.mkdir(tempDir, { recursive: true });
 
-  log.info("Initialized chunked upload session", { sessionId, fileName, totalSize, totalChunks });
+  log.info("Initialized chunked upload session", { sessionId, ownerId, fileName, totalSize, totalChunks });
   return session;
 }
 
@@ -66,8 +87,24 @@ export function getSession(sessionId: string): UploadSession | undefined {
   return sessions.get(sessionId);
 }
 
-export async function saveChunk(sessionId: string, chunkIndex: number, data: Buffer): Promise<void> {
+export function getOwnedSession(sessionId: string, ownerId: string): UploadSession | undefined {
   const session = sessions.get(sessionId);
+  if (!session) {
+    return undefined;
+  }
+  if (session.ownerId !== ownerId) {
+    throw new SessionForbiddenError(sessionId);
+  }
+  return session;
+}
+
+export async function saveChunk(
+  sessionId: string,
+  ownerId: string,
+  chunkIndex: number,
+  data: Buffer
+): Promise<UploadSession> {
+  const session = getOwnedSession(sessionId, ownerId);
   if (!session) {
     throw new Error(`Upload session not found: ${sessionId}`);
   }
@@ -81,10 +118,11 @@ export async function saveChunk(sessionId: string, chunkIndex: number, data: Buf
   session.receivedChunks.add(chunkIndex);
 
   log.debug("Chunk saved", { sessionId, chunkIndex, received: session.receivedChunks.size });
+  return session;
 }
 
-export async function assembleChunks(sessionId: string): Promise<string> {
-  const session = sessions.get(sessionId);
+export async function assembleChunks(sessionId: string, ownerId: string): Promise<string> {
+  const session = getOwnedSession(sessionId, ownerId);
   if (!session) {
     throw new Error(`Upload session not found: ${sessionId}`);
   }
@@ -102,16 +140,19 @@ export async function assembleChunks(sessionId: string): Promise<string> {
   const outputFileName = `${Date.now()}-${Math.random().toString(36).slice(2)}${path.extname(session.fileName)}`;
   const outputPath = path.join(tmpUploadsRoot, outputFileName);
 
-  const writeStream = await fs.open(outputPath, "w");
+  const writeStream = createWriteStream(outputPath);
 
   try {
     for (let i = 0; i < session.totalChunks; i++) {
       const chunkPath = path.join(session.tempDir, `chunk-${String(i).padStart(6, "0")}`);
-      const chunkData = await fs.readFile(chunkPath);
-      await writeStream.write(chunkData);
+      await pipeline(createReadStream(chunkPath), writeStream, { end: false });
     }
-  } finally {
-    await writeStream.close();
+    writeStream.end();
+    await once(writeStream, "finish");
+  } catch (error) {
+    writeStream.destroy();
+    await fs.unlink(outputPath).catch(() => {});
+    throw error;
   }
 
   await fs.rm(session.tempDir, { recursive: true, force: true });
@@ -121,8 +162,8 @@ export async function assembleChunks(sessionId: string): Promise<string> {
   return outputPath;
 }
 
-export async function cancelChunkedUpload(sessionId: string): Promise<void> {
-  const session = sessions.get(sessionId);
+export async function cancelChunkedUpload(sessionId: string, ownerId: string): Promise<void> {
+  const session = getOwnedSession(sessionId, ownerId);
   if (!session) {
     return;
   }

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"]
+    include: ["src/**/*.test.ts"],
+    // Each integration test boots a full HTTP server, seeds SQLite, and runs
+    // many round-trips. Under vitest's parallel file execution the default 5s
+    // is too tight for the longest flows (auth reset, playlist CRUD, radio).
+    testTimeout: 30_000,
+    hookTimeout: 30_000
   }
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -349,7 +349,153 @@ type UploadSingleTrackInput = {
   onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
 };
 
-function uploadSingleTrack(input: UploadSingleTrackInput): Promise<UploadTracksResult> {
+const CHUNK_SIZE = 99 * 1024 * 1024;
+
+async function getChunkSize(): Promise<number> {
+  const response = await requestJson<{ chunkSize: number }>("/api/upload/chunk-size");
+  return response.chunkSize;
+}
+
+type ChunkedUploadSession = {
+  sessionId: string;
+  chunkSize: number;
+  totalChunks: number;
+};
+
+async function initChunkedUpload(fileName: string, fileSize: number): Promise<ChunkedUploadSession> {
+  return requestJson<ChunkedUploadSession>("/api/upload/chunked/init", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ fileName, fileSize })
+  });
+}
+
+async function uploadChunk(sessionId: string, chunkIndex: number, chunk: Blob): Promise<void> {
+  const formData = new FormData();
+  formData.append("sessionId", sessionId);
+  formData.append("chunkIndex", String(chunkIndex));
+  formData.append("chunk", chunk);
+
+  await requestJson<{ received: number }>("/api/upload/chunked/chunk", {
+    method: "POST",
+    body: formData
+  });
+}
+
+async function completeChunkedUpload(sessionId: string): Promise<{ tempPath: string; fileName: string; size: number }> {
+  return requestJson<{ tempPath: string; fileName: string; size: number }>("/api/upload/chunked/complete", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sessionId })
+  });
+}
+
+async function cancelChunkedUpload(sessionId: string): Promise<void> {
+  await requestJson("/api/upload/chunked/cancel", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sessionId })
+  });
+}
+
+async function uploadChunked(
+  file: File,
+  onProgress?: (input: { loaded: number; total: number; percent: number }) => void
+): Promise<{ tempPath: string }> {
+  const { sessionId, chunkSize, totalChunks } = await initChunkedUpload(file.name, file.size);
+  let uploadedBytes = 0;
+
+  try {
+    for (let i = 0; i < totalChunks; i++) {
+      const start = i * chunkSize;
+      const end = Math.min(start + chunkSize, file.size);
+      const chunk = file.slice(start, end);
+
+      await uploadChunk(sessionId, i, chunk);
+      uploadedBytes += chunk.size;
+
+      if (onProgress) {
+        onProgress({
+          loaded: uploadedBytes,
+          total: file.size,
+          percent: Math.round((uploadedBytes / file.size) * 100)
+        });
+      }
+    }
+
+    const result = await completeChunkedUpload(sessionId);
+    return { tempPath: result.tempPath };
+  } catch (error) {
+    await cancelChunkedUpload(sessionId);
+    throw error;
+  }
+}
+
+async function uploadSingleTrack(input: UploadSingleTrackInput): Promise<UploadTracksResult> {
+  if (input.file.size > CHUNK_SIZE) {
+    return uploadSingleTrackChunked(input);
+  }
+  return uploadSingleTrackDirect(input);
+}
+
+async function uploadSingleTrackChunked(input: UploadSingleTrackInput): Promise<UploadTracksResult> {
+  const { tempPath } = await uploadChunked(input.file, input.onProgress);
+  return finalizeChunkedUpload(tempPath, input);
+}
+
+async function finalizeChunkedUpload(
+  tempPath: string,
+  input: Pick<UploadSingleTrackInput, "artist" | "album" | "deferRebuild" | "metadataOverride">
+): Promise<UploadTracksResult> {
+  const formData = new FormData();
+  formData.append("tempPath", tempPath);
+
+  if (input.artist?.trim()) {
+    formData.append("artist", input.artist.trim());
+  }
+
+  if (input.album?.trim()) {
+    formData.append("album", input.album.trim());
+  }
+
+  if (input.metadataOverride) {
+    formData.append("metadataOverrides", JSON.stringify([input.metadataOverride]));
+  }
+
+  if (input.deferRebuild) {
+    formData.append("deferRebuild", "1");
+  }
+
+  return new Promise<UploadTracksResult>((resolve, reject) => {
+    const request = new XMLHttpRequest();
+    request.open("POST", withApiBase("/api/upload/finalize"), true);
+    request.withCredentials = true;
+    request.responseType = "json";
+
+    request.onload = () => {
+      const payload = request.response as { error?: string } | UploadTracksResult | null;
+      if (request.status >= 200 && request.status < 300 && payload) {
+        resolve(payload as UploadTracksResult);
+        return;
+      }
+
+      const message =
+        (payload && typeof payload === "object" && "error" in payload && typeof payload.error === "string"
+          ? payload.error
+          : null) ?? `Request failed (${request.status})`;
+
+      reject(new ApiError(request.status, "/api/upload/finalize", message));
+    };
+
+    request.onerror = () => {
+      reject(new Error("Upload failed due to a network error"));
+    };
+
+    request.send(formData);
+  });
+}
+
+function uploadSingleTrackDirect(input: UploadSingleTrackInput): Promise<UploadTracksResult> {
   const formData = new FormData();
   formData.append("file", input.file);
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -349,12 +349,11 @@ type UploadSingleTrackInput = {
   onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
 };
 
-const CHUNK_SIZE = 99 * 1024 * 1024;
-
-async function getChunkSize(): Promise<number> {
-  const response = await requestJson<{ chunkSize: number }>("/api/upload/chunk-size");
-  return response.chunkSize;
-}
+// Threshold for switching to chunked upload. Must match the backend's
+// CHUNK_SIZE so files at or below this size fit in a single request under
+// common 100 MB proxy limits. The actual chunk size for a given session is
+// still taken from the backend's /init response.
+const CHUNKED_UPLOAD_THRESHOLD = 99 * 1024 * 1024;
 
 type ChunkedUploadSession = {
   sessionId: string;
@@ -426,13 +425,13 @@ async function uploadChunked(
     const result = await completeChunkedUpload(sessionId);
     return { tempPath: result.tempPath };
   } catch (error) {
-    await cancelChunkedUpload(sessionId);
+    await cancelChunkedUpload(sessionId).catch(() => {});
     throw error;
   }
 }
 
 async function uploadSingleTrack(input: UploadSingleTrackInput): Promise<UploadTracksResult> {
-  if (input.file.size > CHUNK_SIZE) {
+  if (input.file.size > CHUNKED_UPLOAD_THRESHOLD) {
     return uploadSingleTrackChunked(input);
   }
   return uploadSingleTrackDirect(input);
@@ -440,15 +439,17 @@ async function uploadSingleTrack(input: UploadSingleTrackInput): Promise<UploadT
 
 async function uploadSingleTrackChunked(input: UploadSingleTrackInput): Promise<UploadTracksResult> {
   const { tempPath } = await uploadChunked(input.file, input.onProgress);
-  return finalizeChunkedUpload(tempPath, input);
+  return finalizeChunkedUpload(tempPath, input.file.name, input);
 }
 
 async function finalizeChunkedUpload(
   tempPath: string,
+  fileName: string,
   input: Pick<UploadSingleTrackInput, "artist" | "album" | "deferRebuild" | "metadataOverride">
 ): Promise<UploadTracksResult> {
   const formData = new FormData();
   formData.append("tempPath", tempPath);
+  formData.append("fileName", fileName);
 
   if (input.artist?.trim()) {
     formData.append("artist", input.artist.trim());


### PR DESCRIPTION
## Summary

Two follow-up fix commits on top of #100:

**`6cd8c62` — Fix chunked upload bugs and harden upload routes**
- Chunk handler read `req.file.buffer` from a disk-storage multer instance (always `undefined`), and the audio-extension `fileFilter` rejected unextensioned chunk blobs before the handler ran. Added a dedicated memory-storage multer instance for chunk requests — the chunked path did not actually work end-to-end before this.
- `/upload/finalize` accepted a `tempPath` from the request body with no validation, letting any authenticated user ingest arbitrary readable files into the library. Now resolves the path, asserts it lives inside `tmpUploadsRoot`, validates the extension, derives the mime from it (was hardcoded to `audio/flac`), and re-enforces `MAX_UPLOAD_BYTES`.
- Upload sessions had no ownership check — anyone who learned or guessed a session id could push chunks into, complete, or cancel another user's session. Sessions now carry `ownerId` and every chunked endpoint verifies the caller matches (403 on mismatch).
- `initChunkedUpload` is now async and awaits the temp-dir `mkdir` (was a race with incoming chunks); chunks are assembled via a streaming `pipeline` instead of buffering each 99 MiB chunk in memory; the cleanup `setInterval` is `unref()`'d; `MAX_UPLOAD_BYTES` is enforced at `/upload/chunked/init`; the frontend's dead `getChunkSize()` helper is removed and the threshold constant is renamed/commented.

**`84602bd` — Raise vitest integration test timeouts**
- Backend integration tests boot a full HTTP server, reset modules, and run many round-trips per case. Under vitest's parallel file execution the default 5s `testTimeout` was too tight for the longest flows (auth reset, playlist CRUD, radio), which legitimately take 4–5s end-to-end. Bumped `testTimeout` and `hookTimeout` to 30s. These flakes were pre-existing on master, not caused by the upload changes.

## Test plan

- [x] Backend `tsc --noEmit` clean
- [x] Frontend `tsc --noEmit` clean
- [x] Full backend suite passes (205/205) on two consecutive runs
- [x] `uploadService.test.ts` (15 tests) still green
- [x] Upload a file > 99 MiB via the UI and confirm it uses the chunked path and lands in the library
- [x] Upload a file ≤ 99 MiB and confirm it still uses the direct path
- [x] As user A, init a chunked session, then as user B attempt to POST a chunk with that session id — expect 403
- [x] POST `/upload/finalize` with a `tempPath` outside `tmpUploadsRoot` — expect 400
- [x] POST `/upload/finalize` with a `tempPath` to a non-audio file — expect 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)