### PR TITLE
Show CPU model in Server view and bump version to 0.2.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flaque-backend",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/server.ts",

--- a/backend/src/api/logRoutes.ts
+++ b/backend/src/api/logRoutes.ts
@@ -218,10 +218,15 @@ export function createLogRouter(): Router {
     const freeMem = os.freemem();
     const usedMem = totalMem - freeMem;
 
+    const cpus = os.cpus();
+    const rawCpuModel = cpus[0]?.model;
+    const cpuModel = rawCpuModel ? rawCpuModel.replace(/\s+/g, " ").trim() : undefined;
+
     res.json({
       cpu: {
         usagePercent: cpuUsagePercent,
-        cores: os.cpus().length
+        cores: cpus.length,
+        model: cpuModel
       },
       memory: {
         total: totalMem,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flaque-frontend",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -875,7 +875,7 @@ export type StorageUsage = {
 };
 
 export type SystemStats = {
-  cpu: { usagePercent: number; cores: number };
+  cpu: { usagePercent: number; cores: number; model?: string };
   memory: { total: number; used: number; free: number; usagePercent: number };
 };
 

--- a/frontend/src/components/AdminServerView.tsx
+++ b/frontend/src/components/AdminServerView.tsx
@@ -172,7 +172,9 @@ function SystemStatsSection({ systemStats, history, loading }: SystemStatsSectio
           <div className="flex items-baseline justify-between text-sm">
             <span className="font-medium text-flaque-ink">CPU</span>
             <span className="text-flaque-steel">
-              {cpuPercent.toFixed(1)}% &middot; {systemStats.cpu.cores} cores
+              {cpuPercent.toFixed(1)}%
+              {systemStats.cpu.model ? <> &middot; {systemStats.cpu.model}</> : null}
+              {" "}&middot; {systemStats.cpu.cores} cores
             </span>
           </div>
           <div className="mt-1.5 h-2.5 overflow-hidden rounded-full bg-flaque-clay/30">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flaque",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary
- Adds `cpu.model` to the `/logs/system-stats` response and displays it between the CPU usage percentage and the core count in Settings → Server → System. Whitespace in the raw `os.cpus()[0].model` string is collapsed; falls back gracefully when unavailable.
- Bumps all three `package.json` files from `0.1.3` to `0.2.0` so the version-check endpoint stops reporting a phantom "update available" against the running instance — the `v0.2.0` tag had already been cut on GitHub but the manifests were never bumped.

## Test plan
- [x] `npx tsc --noEmit` clean (backend + frontend)
- [x] Visually verify the CPU model line renders correctly in Settings → Server → System
- [x] Verify the "update available" banner is gone on a running 0.2.0 instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)