### PR TITLE
Persist production backups across container rebuilds

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,6 +28,9 @@ services:
       - type: bind
         source: ${FLAQUE_STATE_DIR}/logs
         target: /app/data/logs
+      - type: bind
+        source: ${FLAQUE_STATE_DIR}/backups
+        target: /app/data/backups
 
   frontend:
     build:

--- a/scripts/setup-production.sh
+++ b/scripts/setup-production.sh
@@ -524,7 +524,7 @@ print_ok "Docker + Compose detected (${COMPOSE_CMD[*]})"
 
 print_step "Collecting deployment values"
 storage_input="$(prompt_with_default "Storage mount path (host -> /app/data/storage)" "${DEFAULT_STORAGE_DIR}" "trim")"
-state_input="$(prompt_with_default "State mount root (host -> /app/data/{config,index,cache})" "${DEFAULT_STATE_DIR}" "trim")"
+state_input="$(prompt_with_default "State mount root (host -> /app/data/{config,index,cache,logs,backups})" "${DEFAULT_STATE_DIR}" "trim")"
 
 STORAGE_DIR="$(to_absolute_path "${storage_input}")"
 STATE_DIR="$(to_absolute_path "${state_input}")"
@@ -612,6 +612,7 @@ ensure_writable_directory "${STATE_DIR}/cache/covers"
 ensure_writable_directory "${STATE_DIR}/cache/transcodes"
 ensure_writable_directory "${STATE_DIR}/cache/tmp-uploads"
 ensure_writable_directory "${STATE_DIR}/logs"
+ensure_writable_directory "${STATE_DIR}/backups"
 print_ok "Mount folders are ready"
 
 print_step "Writing ${ENV_FILE}"

--- a/scripts/update-production.sh
+++ b/scripts/update-production.sh
@@ -103,6 +103,13 @@ FRONTEND_PORT="$(grep -E '^FLAQUE_FRONTEND_PORT=' "${ENV_FILE}" | cut -d= -f2- |
 BACKEND_PORT="${BACKEND_PORT:-4000}"
 FRONTEND_PORT="${FRONTEND_PORT:-8080}"
 
+# ── Ensure host mount directories added since the last setup exist ────
+
+STATE_DIR="$(grep -E '^FLAQUE_STATE_DIR=' "${ENV_FILE}" | cut -d= -f2- || true)"
+if [[ -n "${STATE_DIR}" ]]; then
+  mkdir -p "${STATE_DIR}/backups"
+fi
+
 # ── Rebuild images ────────────────────────────────────────────────────
 
 print_step "Rebuilding production container images"


### PR DESCRIPTION
## Summary
- Adds a bind mount for `${FLAQUE_STATE_DIR}/backups` → `/app/data/backups` in `docker-compose.prod.yml`. Previously this directory lived inside the container's ephemeral filesystem, so every `prod:update` rebuild wiped the entire backup history — only the backup created since the last rebuild ever survived, making the retention setting effectively a no-op.
- Creates the host directory in `setup-production.sh` alongside the other `STATE_DIR` children, and updates the setup prompt text to mention `backups`.
- Ensures existing deployments heal automatically on their next `prod:update` run by `mkdir -p`ing the host directory in `update-production.sh` before bringing the stack back up.

## Test plan
- [x] On an existing production host, run `npm run prod:update` and verify `${FLAQUE_STATE_DIR}/backups` is created.
- [x] Verify the backend container comes up with the new bind mount attached (`docker inspect flaque-backend` or `docker compose config`).
- [x] Trigger a manual backup and confirm it lands in `${FLAQUE_STATE_DIR}/backups` on the host.
- [x] Rebuild the backend container (`prod:update`) and confirm the previously-created backup still appears in Settings → Backups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)