### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flaque-backend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/server.ts",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flaque-frontend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flaque",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary
- Bumps root, backend, and frontend package.json from 0.2.0 to 0.2.1 ahead of the v0.2.1 release.

## Test plan
- [x] Version strings match across the three package.json files

🤖 Generated with [Claude Code](https://claude.com/claude-code)