### PR TITLE
Parse upload metadata in browser, remove /upload/inspect endpoint

### DIFF
--- a/backend/src/api/uploadRoutes.ts
+++ b/backend/src/api/uploadRoutes.ts
@@ -8,7 +8,7 @@ import { requireAuth } from "../auth/middleware";
 import { appendTrackActivityLogEntries, readTrackActivityLog } from "../services/activity/trackActivityStore";
 import { mergeTrackMetadataOverrides } from "../services/indexer/metadataOverrideStore";
 import { IndexStore } from "../services/indexer/indexStore";
-import { extractAudioMetadata } from "../services/scanner/audioProbe";
+
 import {
   processUploadedFile,
   sanitizeExtension,
@@ -108,16 +108,6 @@ async function cleanupTemporaryFiles(filePaths: string[]): Promise<void> {
       await fs.unlink(filePath);
     })
   );
-}
-
-function toCoverDataUrl(cover?: { data: Buffer; format?: string }): string | undefined {
-  if (!cover || !cover.data) {
-    return undefined;
-  }
-
-  const mimeType =
-    typeof cover.format === "string" && cover.format.trim() ? cover.format.trim() : "image/jpeg";
-  return `data:${mimeType};base64,${cover.data.toString("base64")}`;
 }
 
 function createAudioUpload(maxUploadBytes: number): multer.Multer {
@@ -522,42 +512,6 @@ export function createUploadRouter(indexStore: IndexStore): Router {
         await cleanupTemporaryFiles([directTempPath]);
       }
       next(error);
-    }
-  });
-
-  router.post("/upload/inspect", requireAuth, upload.single("file"), async (req, res, next) => {
-    const temporaryPath = req.file?.path;
-
-    try {
-      const uploadedFile = req.file;
-      if (!uploadedFile) {
-        res.status(400).json({ error: "A file is required" });
-        return;
-      }
-
-      if (!isSupportedAudioFile(uploadedFile.originalname)) {
-        res.status(400).json({ error: `Unsupported audio format: ${uploadedFile.originalname}` });
-        return;
-      }
-
-      const metadata = await extractAudioMetadata(uploadedFile.path);
-      res.json({
-        fileName: uploadedFile.originalname,
-        size: uploadedFile.size,
-        mimeType: getAudioMimeType(uploadedFile.originalname),
-        duration: metadata.duration,
-        codec: metadata.codec,
-        bitrate: metadata.bitrate,
-        sampleRate: metadata.sampleRate,
-        tags: metadata.tags,
-        coverDataUrl: toCoverDataUrl(metadata.cover)
-      });
-    } catch (error) {
-      next(error);
-    } finally {
-      if (temporaryPath) {
-        await cleanupTemporaryFiles([temporaryPath]);
-      }
     }
   });
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -440,33 +440,6 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
-  /api/upload/inspect:
-    post:
-      tags: [Upload]
-      summary: Inspect one upload candidate without importing it
-      requestBody:
-        required: true
-        content:
-          multipart/form-data:
-            schema:
-              type: object
-              properties:
-                file:
-                  type: string
-                  format: binary
-              required: [file]
-      responses:
-        "200":
-          description: Parsed metadata preview
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/UploadInspectResponse"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-
   /api/upload:
     post:
       tags: [Upload]
@@ -1480,29 +1453,6 @@ components:
           items:
             $ref: "#/components/schemas/Track"
       required: [album, tracks]
-
-    UploadInspectResponse:
-      type: object
-      properties:
-        fileName:
-          type: string
-        size:
-          type: integer
-        mimeType:
-          type: string
-        duration:
-          type: number
-        codec:
-          type: string
-        bitrate:
-          type: number
-        sampleRate:
-          type: number
-        tags:
-          $ref: "#/components/schemas/TrackTags"
-        coverDataUrl:
-          type: string
-      required: [fileName, size, mimeType, duration, codec, tags]
 
     UploadOverrides:
       type: object

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "music-metadata": "^10.9.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -629,16 +629,6 @@ export async function uploadTracks(input: UploadTracksInput): Promise<UploadTrac
   return aggregate;
 }
 
-export async function inspectUploadFile(file: File): Promise<UploadTrackPreview> {
-  const formData = new FormData();
-  formData.append("file", file);
-
-  return requestJson<UploadTrackPreview>("/api/upload/inspect", {
-    method: "POST",
-    body: formData
-  });
-}
-
 export async function rebuildIndex(): Promise<{ generatedAt: string; totalTracks: number }> {
   return requestJson<{ generatedAt: string; totalTracks: number }>("/api/index/rebuild", {
     method: "POST"

--- a/frontend/src/hooks/useLibraryCommands.ts
+++ b/frontend/src/hooks/useLibraryCommands.ts
@@ -4,7 +4,6 @@ import {
   createPlaylist,
   deletePlaylist,
   deleteTrackFile,
-  inspectUploadFile,
   patchPlaylist,
   rebuildIndex,
   updateTrackMetadata,
@@ -12,6 +11,7 @@ import {
   type UploadTrackPreview,
   type UploadTracksResult
 } from "../api";
+import { inspectAudioFile } from "../utils/inspectAudioFile";
 import type { AppNotice } from "../components/AppStatusBanners";
 import type { Playlist, PlaylistVisibility, TrackMetadataPatch } from "../types";
 
@@ -90,7 +90,7 @@ export function useLibraryCommands({
   }
 
   async function handleInspectUploadFile(file: File): Promise<UploadTrackPreview> {
-    return inspectUploadFile(file);
+    return inspectAudioFile(file);
   }
 
   async function handleRebuildIndex(): Promise<void> {

--- a/frontend/src/utils/inspectAudioFile.ts
+++ b/frontend/src/utils/inspectAudioFile.ts
@@ -1,0 +1,184 @@
+import { parseBlob, type IAudioMetadata, type IPicture } from "music-metadata";
+
+import type { TrackTags, TrackTagExtraValue } from "../types";
+import type { UploadTrackPreview } from "../api";
+
+const AUDIO_MIME_BY_EXT: Record<string, string> = {
+  ".flac": "audio/flac",
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".opus": "audio/opus",
+  ".m4a": "audio/mp4"
+};
+
+const SUPPORTED_EXTENSIONS = new Set(Object.keys(AUDIO_MIME_BY_EXT));
+
+function extOf(name: string): string {
+  const dot = name.lastIndexOf(".");
+  return dot >= 0 ? name.slice(dot).toLowerCase() : "";
+}
+
+function toNumber(value?: number | string | null): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function toInteger(value?: number | string | null): number | undefined {
+  const n = toNumber(value);
+  return n === undefined ? undefined : Math.trunc(n);
+}
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function normalizeStringArray(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    const items = value
+      .map((v) => normalizeString(v))
+      .filter((v): v is string => Boolean(v));
+    return items.length > 0 ? Array.from(new Set(items)) : undefined;
+  }
+  const single = normalizeString(value);
+  return single ? [single] : undefined;
+}
+
+function normalizeExtraPrimitive(value: unknown): string | number | boolean | undefined {
+  if (typeof value === "string") return normalizeString(value);
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value === "boolean") return value;
+  return undefined;
+}
+
+function normalizeExtraValue(value: unknown): TrackTagExtraValue | undefined {
+  const primitive = normalizeExtraPrimitive(value);
+  if (primitive !== undefined) return primitive;
+  if (!Array.isArray(value)) return undefined;
+  const items = value
+    .map((v) => normalizeExtraPrimitive(v))
+    .filter((v): v is string | number | boolean => v !== undefined);
+  return items.length > 0 ? items : undefined;
+}
+
+function extractYearFromDate(date?: string): number | undefined {
+  if (!date) return undefined;
+  const match = date.match(/(?:^|\D)(\d{4})(?:\D|$)/);
+  if (!match?.[1]) return undefined;
+  const year = Number(match[1]);
+  return Number.isInteger(year) && year >= 1000 && year <= 2999 ? year : undefined;
+}
+
+const KNOWN_COMMON_KEYS = new Set([
+  "title", "artist", "artists", "album", "albumartist", "year", "date",
+  "originaldate", "genre", "track", "disk", "composer", "lyricist",
+  "comment", "bpm", "isrc", "label", "copyright", "language", "encodedby",
+  "picture", "lyrics"
+]);
+
+function normalizeTrackTags(meta?: IAudioMetadata): TrackTags {
+  if (!meta?.common) return {};
+
+  const c = meta.common;
+  const artists = normalizeStringArray(c.artists);
+  const albumArtist = normalizeString(c.albumartist);
+  const artist = normalizeString(c.artist) ?? artists?.[0] ?? albumArtist;
+  const date = normalizeString(c.date);
+  const originalDate = normalizeString(c.originaldate);
+  const year = toInteger(c.year) ?? extractYearFromDate(date) ?? extractYearFromDate(originalDate);
+
+  const tags: TrackTags = {
+    title: normalizeString(c.title),
+    artist,
+    artists,
+    album: normalizeString(c.album),
+    albumArtist,
+    year,
+    date,
+    originalDate,
+    genre: normalizeStringArray(c.genre),
+    trackNumber: toInteger(c.track.no),
+    trackTotal: toInteger(c.track.of),
+    discNumber: toInteger(c.disk.no),
+    discTotal: toInteger(c.disk.of),
+    composer: normalizeStringArray(c.composer),
+    lyricist: normalizeStringArray(c.lyricist),
+    comment: normalizeStringArray(c.comment),
+    bpm: toInteger(c.bpm),
+    isrc: normalizeStringArray(c.isrc),
+    label: normalizeStringArray(c.label),
+    copyright: normalizeString(c.copyright),
+    language: normalizeString(c.language),
+    encodedBy: normalizeString(c.encodedby)
+  };
+
+  const extra: Record<string, TrackTagExtraValue> = {};
+
+  type SyncTextEntry = { timestamp?: number; text?: string };
+  type LyricsEntry = { text?: string; syncText?: SyncTextEntry[] };
+
+  if (Array.isArray(c.lyrics)) {
+    let extracted = false;
+    for (const entry of c.lyrics as LyricsEntry[]) {
+      if (extracted) break;
+      if (Array.isArray(entry.syncText) && entry.syncText.length > 0) {
+        const lines = entry.syncText
+          .filter((s) => typeof s.text === "string" && s.text.trim() && typeof s.timestamp === "number")
+          .map((s) => ({ t: Math.round((s.timestamp! / 1000) * 100) / 100, text: s.text!.trim() }));
+        if (lines.length > 0) {
+          extra.lyrics = "SYNCED:" + JSON.stringify(lines);
+          extracted = true;
+        }
+      }
+      if (!extracted && typeof entry.text === "string" && entry.text.trim()) {
+        extra.lyrics = entry.text.trim();
+        extracted = true;
+      }
+    }
+  }
+
+  for (const [key, value] of Object.entries(c as unknown as Record<string, unknown>)) {
+    if (KNOWN_COMMON_KEYS.has(key)) continue;
+    const normalized = normalizeExtraValue(value);
+    if (normalized !== undefined) extra[key] = normalized;
+  }
+
+  if (Object.keys(extra).length > 0) tags.extra = extra;
+  return tags;
+}
+
+function pictureToDataUrl(picture?: IPicture): string | undefined {
+  if (!picture?.data || picture.data.length === 0) return undefined;
+  const mime = picture.format || "image/jpeg";
+  const bytes = picture.data instanceof Uint8Array ? picture.data : new Uint8Array(picture.data);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return `data:${mime};base64,${btoa(binary)}`;
+}
+
+export async function inspectAudioFile(file: File): Promise<UploadTrackPreview> {
+  const ext = extOf(file.name);
+  if (!SUPPORTED_EXTENSIONS.has(ext)) {
+    throw new Error(`Unsupported audio format: ${file.name}`);
+  }
+
+  const meta = await parseBlob(file, { duration: true });
+  const cover = meta.common.picture?.[0];
+
+  return {
+    fileName: file.name,
+    size: file.size,
+    mimeType: AUDIO_MIME_BY_EXT[ext] ?? "application/octet-stream",
+    duration: Math.max(0, toNumber(meta.format.duration) ?? 0),
+    codec: meta.format.codec ?? "unknown",
+    bitrate: toNumber(meta.format.bitrate),
+    sampleRate: toNumber(meta.format.sampleRate),
+    tags: normalizeTrackTags(meta),
+    coverDataUrl: pictureToDataUrl(cover)
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flaque",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flaque",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "workspaces": [
         "backend",
         "frontend"
@@ -18,7 +18,7 @@
     },
     "backend": {
       "name": "flaque-backend",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.9.0",
@@ -49,8 +49,9 @@
     },
     "frontend": {
       "name": "flaque-frontend",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
+        "music-metadata": "^10.9.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },


### PR DESCRIPTION
## Summary
- Metadata preview during upload is now parsed **client-side** using `music-metadata`'s `parseBlob()`, replacing the `POST /upload/inspect` endpoint that required uploading the full file to the server.
- Eliminates the **413 error on large files** (files over 100 MB hit the reverse-proxy body limit before metadata could even be read).
- Metadata preview is now **instant** regardless of file size — no network round-trip, no temp file on the server.
- Removed the backend `/upload/inspect` route, the `toCoverDataUrl` helper, and the `UploadInspectResponse` OpenAPI schema.

## Test plan
- [x] TypeScript compiles cleanly (both workspaces)
- [x] All 260 tests pass (227 backend + 33 frontend)
- [x] Frontend builds successfully — `music-metadata` tree-shaken into lazy format-specific chunks
- [x] Old `/upload/inspect` endpoint returns 404
- [x] Manual test: select files in Upload view, verify metadata + cover art display instantly without network requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)