### PR TITLE
Finalize site title to 'flaque'

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png" />
 
-    <title>Flaque Hifi Player</title>
+    <title>flaque</title>
 
     <!-- ✅ Early theme application (no FOUC) -->
     <script>

--- a/frontend/src/hooks/useDocumentTitle.ts
+++ b/frontend/src/hooks/useDocumentTitle.ts
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import type { Track } from "../types";
 import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
 
-const DEFAULT_DOCUMENT_TITLE = "Flaque Hifi Player";
+const DEFAULT_DOCUMENT_TITLE = "flaque";
 
 export function useDocumentTitle(track: Track | null): void {
   useEffect(() => {


### PR DESCRIPTION
This PR completes the title refresh: static index.html and dynamic document title defaults updated to 'flaque'.