### PR TITLE
Add bulk file operations and year editing to admin file management

### DIFF
--- a/backend/src/api/libraryRoutes.ts
+++ b/backend/src/api/libraryRoutes.ts
@@ -259,43 +259,6 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
     }
   };
 
-  router.patch("/tracks/:id/metadata", requireAuth, requireAdmin, handlePatchTrackMetadata);
-  router.patch("/tracks/:id", requireAuth, requireAdmin, handlePatchTrackMetadata);
-
-  // DELETE /tracks/:id
-  router.delete("/tracks/:id", requireAuth, requireAdmin, async (req, res, next) => {
-    try {
-      const trackId = req.params.id;
-      if (!trackId) {
-        res.status(400).json({ error: "Track id is required" });
-        return;
-      }
-
-      const track = indexStore.getTrackById(trackId);
-      if (!track) {
-        res.status(404).json({ error: "Track not found" });
-        return;
-      }
-
-      const absolutePath = resolveTrackAbsolutePath(track.path);
-      try {
-        await fs.unlink(absolutePath);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-          throw error;
-        }
-      }
-
-      await deleteTrackCover(trackId);
-      await mergeTrackMetadataOverrides({ [trackId]: {} });
-
-      const rebuiltIndex = await indexStore.rebuild();
-      res.json({ deletedTrackId: trackId, totalTracks: rebuiltIndex.totalTracks });
-    } catch (error) {
-      next(error);
-    }
-  });
-
   router.post("/tracks/bulk/delete", requireAuth, requireAdmin, async (req, res, next) => {
     try {
       const trackIds = req.body?.trackIds;
@@ -408,6 +371,43 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
 
       await indexStore.rebuild();
       res.json({ updated, notFound });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.patch("/tracks/:id/metadata", requireAuth, requireAdmin, handlePatchTrackMetadata);
+  router.patch("/tracks/:id", requireAuth, requireAdmin, handlePatchTrackMetadata);
+
+  // DELETE /tracks/:id
+  router.delete("/tracks/:id", requireAuth, requireAdmin, async (req, res, next) => {
+    try {
+      const trackId = req.params.id;
+      if (!trackId) {
+        res.status(400).json({ error: "Track id is required" });
+        return;
+      }
+
+      const track = indexStore.getTrackById(trackId);
+      if (!track) {
+        res.status(404).json({ error: "Track not found" });
+        return;
+      }
+
+      const absolutePath = resolveTrackAbsolutePath(track.path);
+      try {
+        await fs.unlink(absolutePath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+      }
+
+      await deleteTrackCover(trackId);
+      await mergeTrackMetadataOverrides({ [trackId]: {} });
+
+      const rebuiltIndex = await indexStore.rebuild();
+      res.json({ deletedTrackId: trackId, totalTracks: rebuiltIndex.totalTracks });
     } catch (error) {
       next(error);
     }

--- a/backend/src/api/libraryRoutes.ts
+++ b/backend/src/api/libraryRoutes.ts
@@ -37,6 +37,7 @@ import type { Track } from "../types/library";
 import {
   hasOwnProperty,
   parseMetadataField,
+  parseMetadataYearField,
   readDirection,
   readFilter,
   readTracksQuery,
@@ -203,9 +204,10 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       const hasTitle = hasOwnProperty(req.body, "title");
       const hasArtist = hasOwnProperty(req.body, "artist");
       const hasAlbum = hasOwnProperty(req.body, "album");
+      const hasYear = hasOwnProperty(req.body, "year");
 
-      if (!hasTitle && !hasArtist && !hasAlbum) {
-        res.status(400).json({ error: "At least one metadata field is required: title, artist, album" });
+      if (!hasTitle && !hasArtist && !hasAlbum && !hasYear) {
+        res.status(400).json({ error: "At least one metadata field is required: title, artist, album, year" });
         return;
       }
 
@@ -218,10 +220,12 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       const parsedTitle = hasTitle ? parseMetadataField(req.body?.title) : undefined;
       const parsedArtist = hasArtist ? parseMetadataField(req.body?.artist) : undefined;
       const parsedAlbum = hasAlbum ? parseMetadataField(req.body?.album) : undefined;
+      const parsedYear = hasYear ? parseMetadataYearField(req.body?.year) : undefined;
 
       if (parsedTitle === null) { res.status(400).json({ error: "title must be a string or null" }); return; }
       if (parsedArtist === null) { res.status(400).json({ error: "artist must be a string or null" }); return; }
       if (parsedAlbum === null) { res.status(400).json({ error: "album must be a string or null" }); return; }
+      if (parsedYear === null) { res.status(400).json({ error: "year must be an integer between 1000 and 2999, or null" }); return; }
 
       const currentOverrides = await readTrackMetadataOverrides();
       const currentOverride = currentOverrides[trackId] ?? {};
@@ -230,7 +234,8 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
         [trackId]: {
           title: hasTitle ? parsedTitle : currentOverride.title,
           artist: hasArtist ? parsedArtist : currentOverride.artist,
-          album: hasAlbum ? parsedAlbum : currentOverride.album
+          album: hasAlbum ? parsedAlbum : currentOverride.album,
+          year: hasYear ? parsedYear : currentOverride.year
         }
       });
 
@@ -243,7 +248,7 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       }
 
       const fallbackTrack = applyMetadataPatchToTrack(currentTrack, {
-        hasTitle, title: parsedTitle, hasArtist, artist: parsedArtist, hasAlbum, album: parsedAlbum
+        hasTitle, title: parsedTitle, hasArtist, artist: parsedArtist, hasAlbum, album: parsedAlbum, hasYear, year: parsedYear
       });
       res.json({
         track: mapTrackResponse(mapTrackOwners([fallbackTrack], ownerNamesById)[0]!),
@@ -286,6 +291,123 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
 
       const rebuiltIndex = await indexStore.rebuild();
       res.json({ deletedTrackId: trackId, totalTracks: rebuiltIndex.totalTracks });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/tracks/bulk/delete", requireAuth, requireAdmin, async (req, res, next) => {
+    try {
+      const trackIds = req.body?.trackIds;
+      if (!Array.isArray(trackIds) || trackIds.length === 0) {
+        res.status(400).json({ error: "trackIds array is required" });
+        return;
+      }
+
+      const validIds = trackIds.filter((id): id is string => typeof id === "string" && id.length > 0);
+      if (validIds.length === 0) {
+        res.status(400).json({ error: "No valid track ids provided" });
+        return;
+      }
+
+      const deleted: string[] = [];
+      const notFound: string[] = [];
+      const overridePatch: Record<string, Record<string, never>> = {};
+
+      for (const trackId of validIds) {
+        const track = indexStore.getTrackById(trackId);
+        if (!track) {
+          notFound.push(trackId);
+          continue;
+        }
+
+        const absolutePath = resolveTrackAbsolutePath(track.path);
+        try {
+          await fs.unlink(absolutePath);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            throw error;
+          }
+        }
+
+        await deleteTrackCover(trackId);
+        overridePatch[trackId] = {};
+        deleted.push(trackId);
+      }
+
+      if (Object.keys(overridePatch).length > 0) {
+        await mergeTrackMetadataOverrides(overridePatch);
+      }
+
+      const rebuiltIndex = await indexStore.rebuild();
+      res.json({ deleted, notFound, totalTracks: rebuiltIndex.totalTracks });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.patch("/tracks/bulk/metadata", requireAuth, requireAdmin, async (req, res, next) => {
+    try {
+      const trackIds = req.body?.trackIds;
+      if (!Array.isArray(trackIds) || trackIds.length === 0) {
+        res.status(400).json({ error: "trackIds array is required" });
+        return;
+      }
+
+      const validIds = trackIds.filter((id): id is string => typeof id === "string" && id.length > 0);
+      if (validIds.length === 0) {
+        res.status(400).json({ error: "No valid track ids provided" });
+        return;
+      }
+
+      const hasTitle = hasOwnProperty(req.body, "title");
+      const hasArtist = hasOwnProperty(req.body, "artist");
+      const hasAlbum = hasOwnProperty(req.body, "album");
+      const hasYear = hasOwnProperty(req.body, "year");
+
+      if (!hasTitle && !hasArtist && !hasAlbum && !hasYear) {
+        res.status(400).json({ error: "At least one metadata field is required: title, artist, album, year" });
+        return;
+      }
+
+      const parsedTitle = hasTitle ? parseMetadataField(req.body?.title) : undefined;
+      const parsedArtist = hasArtist ? parseMetadataField(req.body?.artist) : undefined;
+      const parsedAlbum = hasAlbum ? parseMetadataField(req.body?.album) : undefined;
+      const parsedYear = hasYear ? parseMetadataYearField(req.body?.year) : undefined;
+
+      if (parsedTitle === null) { res.status(400).json({ error: "title must be a string or null" }); return; }
+      if (parsedArtist === null) { res.status(400).json({ error: "artist must be a string or null" }); return; }
+      if (parsedAlbum === null) { res.status(400).json({ error: "album must be a string or null" }); return; }
+      if (parsedYear === null) { res.status(400).json({ error: "year must be an integer between 1000 and 2999, or null" }); return; }
+
+      const currentOverrides = await readTrackMetadataOverrides();
+      const overridePatch: Record<string, { title?: string; artist?: string; album?: string; year?: number }> = {};
+      const updated: string[] = [];
+      const notFound: string[] = [];
+
+      for (const trackId of validIds) {
+        const track = indexStore.getTrackById(trackId);
+        if (!track) {
+          notFound.push(trackId);
+          continue;
+        }
+
+        const current = currentOverrides[trackId] ?? {};
+        overridePatch[trackId] = {
+          title: hasTitle ? parsedTitle : current.title,
+          artist: hasArtist ? parsedArtist : current.artist,
+          album: hasAlbum ? parsedAlbum : current.album,
+          year: hasYear ? parsedYear : current.year
+        };
+        updated.push(trackId);
+      }
+
+      if (Object.keys(overridePatch).length > 0) {
+        await mergeTrackMetadataOverrides(overridePatch);
+      }
+
+      await indexStore.rebuild();
+      res.json({ updated, notFound });
     } catch (error) {
       next(error);
     }

--- a/backend/src/api/queryParsers.ts
+++ b/backend/src/api/queryParsers.ts
@@ -186,3 +186,16 @@ export function parseMetadataField(value: unknown): string | undefined | null {
   const trimmed = value.trim();
   return trimmed ? trimmed : undefined;
 }
+
+export function parseMetadataYearField(value: unknown): number | undefined | null {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n < 1000 || n > 2999) {
+    return null;
+  }
+
+  return n;
+}

--- a/backend/src/api/trackPipeline.ts
+++ b/backend/src/api/trackPipeline.ts
@@ -101,6 +101,8 @@ export function applyMetadataPatchToTrack(
     artist?: string;
     hasAlbum: boolean;
     album?: string;
+    hasYear: boolean;
+    year?: number;
   }
 ): Track {
   return {
@@ -109,7 +111,8 @@ export function applyMetadataPatchToTrack(
       ...track.tags,
       ...(patch.hasTitle ? { title: patch.title } : {}),
       ...(patch.hasArtist ? { artist: patch.artist } : {}),
-      ...(patch.hasAlbum ? { album: patch.album } : {})
+      ...(patch.hasAlbum ? { album: patch.album } : {}),
+      ...(patch.hasYear ? { year: patch.year } : {})
     }
   };
 }

--- a/backend/src/services/indexer/metadataOverrideStore.ts
+++ b/backend/src/services/indexer/metadataOverrideStore.ts
@@ -5,6 +5,7 @@ export type TrackMetadataOverride = {
   title?: string;
   artist?: string;
   album?: string;
+  year?: number;
 };
 
 type TrackMetadataOverridesMap = Record<string, TrackMetadataOverride>;
@@ -18,23 +19,33 @@ function normalizeField(value: unknown): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+function normalizeYear(value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n < 1000 || n > 2999) return undefined;
+  return n;
+}
+
 function normalizeOverride(override: unknown): TrackMetadataOverride | undefined {
   if (!override || typeof override !== "object") {
     return undefined;
   }
 
-  const artist = normalizeField((override as { artist?: unknown }).artist);
-  const album = normalizeField((override as { album?: unknown }).album);
-  const title = normalizeField((override as { title?: unknown }).title);
+  const record = override as Record<string, unknown>;
+  const artist = normalizeField(record.artist);
+  const album = normalizeField(record.album);
+  const title = normalizeField(record.title);
+  const year = normalizeYear(record.year);
 
-  if (!title && !artist && !album) {
+  if (!title && !artist && !album && year === undefined) {
     return undefined;
   }
 
   return {
     title,
     artist,
-    album
+    album,
+    year
   };
 }
 
@@ -93,7 +104,8 @@ export async function mergeTrackMetadataOverrides(
     if (
       existing?.title === cleanOverride.title &&
       existing?.artist === cleanOverride.artist &&
-      existing?.album === cleanOverride.album
+      existing?.album === cleanOverride.album &&
+      existing?.year === cleanOverride.year
     ) {
       continue;
     }

--- a/backend/src/services/scanner/scannerService.ts
+++ b/backend/src/services/scanner/scannerService.ts
@@ -54,7 +54,7 @@ type ClassifiedTracks = {
 // ── Filesystem traversal ────────────────────────────────────────────────
 
 async function sortRootMusicFiles(
-  metadataOverrides: Record<string, { artist?: string; album?: string }>
+  metadataOverrides: Record<string, { artist?: string; album?: string; year?: number }>
 ): Promise<void> {
   let entries: Dirent[] = [];
 
@@ -154,7 +154,7 @@ async function collectAudioFiles(rootDir: string): Promise<string[]> {
 
 async function collectFilesystemState(
   ownership: Record<string, string>,
-  metadataOverrides: Record<string, { artist?: string; album?: string }>
+  metadataOverrides: Record<string, { artist?: string; album?: string; year?: number }>
 ): Promise<FileSystemTrackState[]> {
   const states: FileSystemTrackState[] = [];
 
@@ -221,7 +221,7 @@ function classifyTrackChanges(
 
 function applyTrackMetadataOverride(
   track: Track,
-  metadataOverride?: { title?: string; artist?: string; album?: string }
+  metadataOverride?: { title?: string; artist?: string; album?: string; year?: number }
 ): Track {
   if (!metadataOverride) {
     return track;
@@ -233,14 +233,15 @@ function applyTrackMetadataOverride(
       ...track.tags,
       title: metadataOverride.title ?? track.tags.title,
       artist: metadataOverride.artist ?? track.tags.artist,
-      album: metadataOverride.album ?? track.tags.album
+      album: metadataOverride.album ?? track.tags.album,
+      year: metadataOverride.year ?? track.tags.year
     }
   };
 }
 
 async function probeChangedTracks(
   changedTracks: FileSystemTrackState[],
-  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string }>,
+  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string; year?: number }>,
   albumsByDirectory: Map<string, AlbumAggregate>,
   processedArtists: Set<string>,
   processedAlbums: Set<string>
@@ -297,7 +298,7 @@ function compareTrackOrder(a: Track, b: Track): number {
 async function mergeFinalTracks(
   unchangedTracks: ClassifiedTracks["unchanged"],
   changedTracks: Track[],
-  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string }>,
+  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string; year?: number }>,
   albumsByDirectory: Map<string, AlbumAggregate>,
   processedArtists: Set<string>,
   processedAlbums: Set<string>
@@ -329,7 +330,7 @@ async function mergeFinalTracks(
 async function performScan(
   mode: ScanMode,
   previousIndex: LibraryIndex | undefined,
-  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string }>
+  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string; year?: number }>
 ): Promise<LibraryIndex> {
   const ownership = await readTrackOwnership();
   const filesystemState = await collectFilesystemState(ownership, metadataOverrides);

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -196,6 +196,7 @@ export function AuthenticatedApp({
   const {
     handleUpload, handleInspectUploadFile, handleRebuildIndex,
     handleDeleteTrack, handleUpdateTrackMetadata,
+    handleBulkDeleteTracks, handleBulkUpdateTrackMetadata,
     handleCreatePlaylist, handleAddTrackToPlaylist,
     handlePatchPlaylist, handleDeletePlaylist
   } = useLibraryCommands({
@@ -359,7 +360,9 @@ export function AuthenticatedApp({
         onRebuildIndex: handleRebuildIndex,
         onRefreshTracks: refreshAllTracks,
         onDeleteTrack: handleDeleteTrack,
-        onUpdateTrackMetadata: handleUpdateTrackMetadata
+        onUpdateTrackMetadata: handleUpdateTrackMetadata,
+        onBulkDeleteTracks: handleBulkDeleteTracks,
+        onBulkUpdateTrackMetadata: handleBulkUpdateTrackMetadata
       }}
       usersViewProps={{
         currentUser: user,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -805,6 +805,35 @@ export async function deleteTrackFile(trackId: string): Promise<{
   );
 }
 
+export async function bulkDeleteTracks(trackIds: string[]): Promise<{
+  deleted: string[];
+  notFound: string[];
+  totalTracks: number;
+}> {
+  return requestJson<{ deleted: string[]; notFound: string[]; totalTracks: number }>(
+    "/api/tracks/bulk/delete",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ trackIds })
+    }
+  );
+}
+
+export async function bulkUpdateTrackMetadata(
+  trackIds: string[],
+  patch: TrackMetadataPatch
+): Promise<{ updated: string[]; notFound: string[] }> {
+  return requestJson<{ updated: string[]; notFound: string[] }>(
+    "/api/tracks/bulk/metadata",
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ trackIds, ...patch })
+    }
+  );
+}
+
 export async function createRadioStation(): Promise<RadioCreateResponse> {
   return requestJson<RadioCreateResponse>("/api/radio/create", {
     method: "POST"

--- a/frontend/src/components/ConfigView.tsx
+++ b/frontend/src/components/ConfigView.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useCallback, useMemo, useState } from "react";
 
 import type { Track, TrackMetadataPatch, User } from "../types";
 import {
@@ -21,6 +21,8 @@ export type ConfigViewProps = {
   onRefreshTracks: () => Promise<void>;
   onDeleteTrack: (trackId: string) => Promise<void>;
   onUpdateTrackMetadata: (trackId: string, patch: TrackMetadataPatch) => Promise<void>;
+  onBulkDeleteTracks: (trackIds: string[]) => Promise<void>;
+  onBulkUpdateTrackMetadata: (trackIds: string[], patch: TrackMetadataPatch) => Promise<void>;
   activeSection: ConfigSection;
   onSectionChange: (section: ConfigSection) => void;
 };
@@ -29,6 +31,24 @@ export type ConfigSection = "index" | "files" | "users" | "server" | "backup";
 
 function normalizeSearch(value: string): string {
   return value.trim().toLowerCase();
+}
+
+type BulkEditState = {
+  trackIds: string[];
+  title: string;
+  artist: string;
+  album: string;
+  year: string;
+  commonTitle: string | undefined;
+  commonArtist: string | undefined;
+  commonAlbum: string | undefined;
+  commonYear: string | undefined;
+};
+
+function computeCommonField(tracks: Track[], getter: (t: Track) => string | undefined): string | undefined {
+  if (tracks.length === 0) return undefined;
+  const first = getter(tracks[0]);
+  return tracks.every((t) => getter(t) === first) ? first : undefined;
 }
 
 export function ConfigView({
@@ -41,6 +61,8 @@ export function ConfigView({
   onRefreshTracks,
   onDeleteTrack,
   onUpdateTrackMetadata,
+  onBulkDeleteTracks,
+  onBulkUpdateTrackMetadata,
   activeSection
 }: ConfigViewProps): JSX.Element {
   const [searchText, setSearchText] = useState("");
@@ -51,6 +73,12 @@ export function ConfigView({
   const [deletingTrack, setDeletingTrack] = useState(false);
   const [editState, setEditState] = useState<EditTrackState | null>(null);
   const [savingEdit, setSavingEdit] = useState(false);
+
+  const [selectedTrackIds, setSelectedTrackIds] = useState<Set<string>>(new Set());
+  const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState(false);
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+  const [bulkEditState, setBulkEditState] = useState<BulkEditState | null>(null);
+  const [bulkSavingEdit, setBulkSavingEdit] = useState(false);
 
   const resolveOwnerLabel = (owner: string): string => ownerNameById?.[owner] ?? owner;
 
@@ -115,7 +143,8 @@ export function ConfigView({
       track,
       title: track.tags.title ?? "",
       artist: track.tags.artist ?? "",
-      album: track.tags.album ?? ""
+      album: track.tags.album ?? "",
+      year: track.tags.year != null ? String(track.tags.year) : ""
     });
   }
 
@@ -135,16 +164,132 @@ export function ConfigView({
     setSavingEdit(true);
 
     try {
+      const yearValue = editState.year.trim();
+      const parsedYear = yearValue ? Number(yearValue) : null;
+
       await onUpdateTrackMetadata(editState.track.id, {
         title: editState.title.trim() || null,
         artist: editState.artist.trim() || null,
-        album: editState.album.trim() || null
+        album: editState.album.trim() || null,
+        year: Number.isInteger(parsedYear) ? parsedYear : parsedYear === null ? null : undefined
       });
       setEditState(null);
     } catch (error) {
       void error;
     } finally {
       setSavingEdit(false);
+    }
+  }
+
+  const toggleTrackSelection = useCallback((trackId: string) => {
+    setSelectedTrackIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(trackId)) {
+        next.delete(trackId);
+      } else {
+        next.add(trackId);
+      }
+      return next;
+    });
+  }, []);
+
+  const togglePageSelection = useCallback(() => {
+    setSelectedTrackIds((prev) => {
+      const pageIds = paginatedTracks.map((t) => t.id);
+      const allPageSelected = pageIds.length > 0 && pageIds.every((id) => prev.has(id));
+      const next = new Set(prev);
+      if (allPageSelected) {
+        for (const id of pageIds) next.delete(id);
+      } else {
+        for (const id of pageIds) next.add(id);
+      }
+      return next;
+    });
+  }, [paginatedTracks]);
+
+  const clearSelection = useCallback(() => setSelectedTrackIds(new Set()), []);
+
+  const selectedTracks = useMemo(
+    () => tracks.filter((t) => selectedTrackIds.has(t.id)),
+    [tracks, selectedTrackIds]
+  );
+
+  const pageAllSelected = paginatedTracks.length > 0 && paginatedTracks.every((t) => selectedTrackIds.has(t.id));
+  const pageSomeSelected = paginatedTracks.some((t) => selectedTrackIds.has(t.id));
+
+  function openBulkEditModal(): void {
+    const selected = selectedTracks;
+    if (selected.length === 0) return;
+
+    const commonTitle = computeCommonField(selected, (t) => t.tags.title);
+    const commonArtist = computeCommonField(selected, (t) => t.tags.artist);
+    const commonAlbum = computeCommonField(selected, (t) => t.tags.album);
+    const commonYear = computeCommonField(selected, (t) => t.tags.year != null ? String(t.tags.year) : undefined);
+
+    setBulkEditState({
+      trackIds: selected.map((t) => t.id),
+      title: commonTitle ?? "",
+      artist: commonArtist ?? "",
+      album: commonAlbum ?? "",
+      year: commonYear ?? "",
+      commonTitle,
+      commonArtist,
+      commonAlbum,
+      commonYear
+    });
+  }
+
+  async function handleBulkEditSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    if (!bulkEditState) return;
+
+    const patch: TrackMetadataPatch = {};
+    if (bulkEditState.title !== (bulkEditState.commonTitle ?? "")) {
+      patch.title = bulkEditState.title.trim() || null;
+    }
+    if (bulkEditState.artist !== (bulkEditState.commonArtist ?? "")) {
+      patch.artist = bulkEditState.artist.trim() || null;
+    }
+    if (bulkEditState.album !== (bulkEditState.commonAlbum ?? "")) {
+      patch.album = bulkEditState.album.trim() || null;
+    }
+    if (bulkEditState.year !== (bulkEditState.commonYear ?? "")) {
+      const yearValue = bulkEditState.year.trim();
+      const parsedYear = yearValue ? Number(yearValue) : null;
+      patch.year = Number.isInteger(parsedYear) ? parsedYear : parsedYear === null ? null : undefined;
+    }
+
+    const hasChanges = "title" in patch || "artist" in patch || "album" in patch || "year" in patch;
+    if (!hasChanges) {
+      setBulkEditState(null);
+      return;
+    }
+
+    setBulkSavingEdit(true);
+    try {
+      await onBulkUpdateTrackMetadata(bulkEditState.trackIds, patch);
+      setBulkEditState(null);
+      clearSelection();
+    } catch (error) {
+      void error;
+    } finally {
+      setBulkSavingEdit(false);
+    }
+  }
+
+  async function handleBulkDelete(): Promise<void> {
+    const ids = Array.from(selectedTrackIds);
+    if (ids.length === 0) return;
+
+    setBulkDeleting(true);
+    try {
+      await onBulkDeleteTracks(ids);
+      setBulkDeleteConfirm(false);
+      clearSelection();
+    } catch (error) {
+      void error;
+    } finally {
+      setBulkDeleting(false);
     }
   }
 
@@ -211,41 +356,81 @@ export function ConfigView({
           />
         </div>
 
+        {selectedTrackIds.size > 0 ? (
+          <div className="mt-3 flex flex-wrap items-center gap-2 rounded-xl border border-flaque-clay/60 bg-flaque-cream/60 px-4 py-2.5">
+            <span className="text-sm font-medium text-flaque-ink">
+              {selectedTrackIds.size} selected
+            </span>
+            <button
+              className="rounded-lg border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+              type="button"
+              onClick={openBulkEditModal}
+            >
+              Edit metadata
+            </button>
+            <button
+              className="rounded-lg border border-red-300 bg-white px-3 py-1.5 text-xs text-red-700 transition hover:bg-red-50"
+              type="button"
+              onClick={() => setBulkDeleteConfirm(true)}
+            >
+              Delete files
+            </button>
+            <button
+              className="ml-auto rounded-lg px-3 py-1.5 text-xs text-flaque-steel transition hover:text-flaque-ink"
+              type="button"
+              onClick={clearSelection}
+            >
+              Clear selection
+            </button>
+          </div>
+        ) : null}
+
         <div className="mt-4 space-y-3 lg:hidden">
           {paginatedTracks.map((track) => {
             const runningAction = activeTrackActionId === track.id;
             const title = getTrackDisplayTitle(track);
+            const isSelected = selectedTrackIds.has(track.id);
 
             return (
-              <article key={track.id} className="rounded-2xl border border-flaque-clay/60 bg-flaque-cream/45 p-3">
-                <p className="truncate text-sm font-medium text-flaque-ink" title={title}>
-                  {title}
-                </p>
-                <p className="mt-1 truncate text-xs text-flaque-steel">
-                  {getTrackDisplayArtist(track) ?? "Unknown"}
-                  {getTrackDisplayAlbumWithYear(track) ? ` - ${getTrackDisplayAlbumWithYear(track)}` : ""}
-                </p>
-                <p className="mt-1 truncate font-mono text-[11px] text-flaque-steel/80" title={track.path}>
-                  {track.path}
-                </p>
+              <article key={track.id} className={`rounded-2xl border p-3 ${isSelected ? "border-flaque-ink/40 bg-flaque-cream/70" : "border-flaque-clay/60 bg-flaque-cream/45"}`}>
+                <div className="flex items-start gap-3">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5 h-4 w-4 shrink-0 rounded border-flaque-clay text-flaque-ink"
+                    checked={isSelected}
+                    onChange={() => toggleTrackSelection(track.id)}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-flaque-ink" title={title}>
+                      {title}
+                    </p>
+                    <p className="mt-1 truncate text-xs text-flaque-steel">
+                      {getTrackDisplayArtist(track) ?? "Unknown"}
+                      {getTrackDisplayAlbumWithYear(track) ? ` - ${getTrackDisplayAlbumWithYear(track)}` : ""}
+                    </p>
+                    <p className="mt-1 truncate font-mono text-[11px] text-flaque-steel/80" title={track.path}>
+                      {track.path}
+                    </p>
 
-                <div className="mt-3 flex items-center gap-2">
-                  <button
-                    className="rounded-lg border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
-                    type="button"
-                    disabled={runningAction}
-                    onClick={() => openEditModal(track)}
-                  >
-                    Edit
-                  </button>
-                  <button
-                    className="rounded-lg border border-red-300 bg-white px-3 py-1.5 text-xs text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
-                    type="button"
-                    disabled={runningAction}
-                    onClick={() => openDeleteTrackModal(track)}
-                  >
-                    Delete file
-                  </button>
+                    <div className="mt-3 flex items-center gap-2">
+                      <button
+                        className="rounded-lg border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+                        type="button"
+                        disabled={runningAction}
+                        onClick={() => openEditModal(track)}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        className="rounded-lg border border-red-300 bg-white px-3 py-1.5 text-xs text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                        type="button"
+                        disabled={runningAction}
+                        onClick={() => openDeleteTrackModal(track)}
+                      >
+                        Delete file
+                      </button>
+                    </div>
+                  </div>
                 </div>
               </article>
             );
@@ -258,6 +443,15 @@ export function ConfigView({
           <table className="w-full min-w-[980px] border-collapse text-left text-sm">
             <thead className="sticky top-0 bg-flaque-cream/95 text-flaque-ink">
               <tr>
+                <th className="w-10 px-3 py-3">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-flaque-clay text-flaque-ink"
+                    checked={pageAllSelected}
+                    ref={(el) => { if (el) el.indeterminate = pageSomeSelected && !pageAllSelected; }}
+                    onChange={togglePageSelection}
+                  />
+                </th>
                 <th className="px-4 py-3 font-medium">Title</th>
                 <th className="px-4 py-3 font-medium">Artist</th>
                 <th className="px-4 py-3 font-medium">Album</th>
@@ -270,9 +464,18 @@ export function ConfigView({
               {paginatedTracks.map((track) => {
                 const runningAction = activeTrackActionId === track.id;
                 const title = getTrackDisplayTitle(track);
+                const isSelected = selectedTrackIds.has(track.id);
 
                 return (
-                  <tr key={track.id} className="border-t border-flaque-clay/40">
+                  <tr key={track.id} className={`border-t border-flaque-clay/40 ${isSelected ? "bg-flaque-cream/60" : ""}`}>
+                    <td className="px-3 py-3">
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border-flaque-clay text-flaque-ink"
+                        checked={isSelected}
+                        onChange={() => toggleTrackSelection(track.id)}
+                      />
+                    </td>
                     <td className="px-4 py-3 text-flaque-ink">
                       <span className="block max-w-[20rem] truncate" title={title}>
                         {title}
@@ -310,7 +513,7 @@ export function ConfigView({
 
               {filteredTracks.length === 0 ? (
                 <tr>
-                  <td className="px-4 py-4 text-flaque-steel" colSpan={6}>
+                  <td className="px-4 py-4 text-flaque-steel" colSpan={7}>
                     No tracks match this search.
                   </td>
                 </tr>
@@ -369,6 +572,117 @@ export function ConfigView({
           onClose={closeDeleteTrackModal}
           deleting={deletingTrack}
         />
+      ) : null}
+
+      {bulkDeleteConfirm ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4">
+          <div className="w-full max-w-md rounded-3xl border border-flaque-clay/60 bg-white p-5 shadow-panel">
+            <h3 className="font-display text-xl text-flaque-ink">Delete {selectedTrackIds.size} files</h3>
+            <p className="mt-2 text-sm text-red-700">
+              This action cannot be undone. <strong>{selectedTrackIds.size} file{selectedTrackIds.size !== 1 ? "s" : ""}</strong> will
+              be permanently removed from storage.
+            </p>
+            <div className="mt-5 flex items-center justify-end gap-2">
+              <button
+                className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+                type="button"
+                onClick={() => setBulkDeleteConfirm(false)}
+                disabled={bulkDeleting}
+              >
+                Cancel
+              </button>
+              <button
+                className="rounded-xl bg-red-700 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-800 disabled:cursor-not-allowed disabled:opacity-60"
+                type="button"
+                disabled={bulkDeleting}
+                onClick={() => { void handleBulkDelete(); }}
+              >
+                {bulkDeleting ? "Deleting..." : `Delete ${selectedTrackIds.size} files`}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {bulkEditState ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4">
+          <form
+            className="w-full max-w-md rounded-3xl border border-flaque-clay/60 bg-white p-5 shadow-panel"
+            onSubmit={(e) => { void handleBulkEditSubmit(e); }}
+          >
+            <h3 className="font-display text-xl text-flaque-ink">Edit {bulkEditState.trackIds.length} tracks</h3>
+            <p className="mt-2 text-sm text-flaque-steel">
+              Only fields you change will be updated. Unchanged fields keep their current values.
+            </p>
+
+            <label className="mt-4 block text-sm text-flaque-ink">
+              Title
+              <input
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                type="text"
+                value={bulkEditState.title}
+                placeholder={bulkEditState.commonTitle === undefined ? "Mixed values" : ""}
+                onChange={(e) => setBulkEditState((s) => s ? { ...s, title: e.target.value } : s)}
+              />
+            </label>
+
+            <label className="mt-3 block text-sm text-flaque-ink">
+              Artist
+              <input
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                type="text"
+                value={bulkEditState.artist}
+                placeholder={bulkEditState.commonArtist === undefined ? "Mixed values" : ""}
+                onChange={(e) => setBulkEditState((s) => s ? { ...s, artist: e.target.value } : s)}
+              />
+            </label>
+
+            <label className="mt-3 block text-sm text-flaque-ink">
+              Album
+              <input
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                type="text"
+                value={bulkEditState.album}
+                placeholder={bulkEditState.commonAlbum === undefined ? "Mixed values" : ""}
+                onChange={(e) => setBulkEditState((s) => s ? { ...s, album: e.target.value } : s)}
+              />
+            </label>
+
+            <label className="mt-3 block text-sm text-flaque-ink">
+              Year
+              <input
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                type="text"
+                inputMode="numeric"
+                value={bulkEditState.year}
+                placeholder={bulkEditState.commonYear === undefined ? "Mixed values" : "e.g. 1979"}
+                onChange={(e) => setBulkEditState((s) => s ? { ...s, year: e.target.value } : s)}
+              />
+            </label>
+
+            <p className="mt-3 text-xs text-flaque-steel">
+              Leave a field empty to clear override and fallback to embedded file metadata.
+            </p>
+
+            <div className="mt-5 flex items-center justify-end gap-2">
+              <button
+                className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+                type="button"
+                onClick={() => setBulkEditState(null)}
+                disabled={bulkSavingEdit}
+              >
+                Cancel
+              </button>
+              <button
+                className="rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-flaque-cream transition hover:bg-black disabled:cursor-not-allowed disabled:opacity-60"
+                type="submit"
+                disabled={bulkSavingEdit}
+              >
+                {bulkSavingEdit ? "Saving..." : `Save ${bulkEditState.trackIds.length} tracks`}
+              </button>
+            </div>
+          </form>
+        </div>
       ) : null}
     </div>
   );

--- a/frontend/src/components/ConfigView.tsx
+++ b/frontend/src/components/ConfigView.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useCallback, useMemo, useState } from "react";
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { Track, TrackMetadataPatch, User } from "../types";
 import {
@@ -79,6 +79,18 @@ export function ConfigView({
   const [bulkDeleting, setBulkDeleting] = useState(false);
   const [bulkEditState, setBulkEditState] = useState<BulkEditState | null>(null);
   const [bulkSavingEdit, setBulkSavingEdit] = useState(false);
+  const [bulkSuccessMessage, setBulkSuccessMessage] = useState<string | null>(null);
+  const bulkSuccessTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => { clearTimeout(bulkSuccessTimerRef.current); };
+  }, []);
+
+  function showBulkSuccess(message: string): void {
+    clearTimeout(bulkSuccessTimerRef.current);
+    setBulkSuccessMessage(message);
+    bulkSuccessTimerRef.current = setTimeout(() => setBulkSuccessMessage(null), 4000);
+  }
 
   const resolveOwnerLabel = (owner: string): string => ownerNameById?.[owner] ?? owner;
 
@@ -267,9 +279,11 @@ export function ConfigView({
 
     setBulkSavingEdit(true);
     try {
+      const count = bulkEditState.trackIds.length;
       await onBulkUpdateTrackMetadata(bulkEditState.trackIds, patch);
       setBulkEditState(null);
       clearSelection();
+      showBulkSuccess(`Metadata updated for ${count} track${count !== 1 ? "s" : ""}.`);
     } catch (error) {
       void error;
     } finally {
@@ -283,9 +297,11 @@ export function ConfigView({
 
     setBulkDeleting(true);
     try {
+      const count = ids.length;
       await onBulkDeleteTracks(ids);
       setBulkDeleteConfirm(false);
       clearSelection();
+      showBulkSuccess(`${count} track${count !== 1 ? "s" : ""} deleted from the library.`);
     } catch (error) {
       void error;
     } finally {
@@ -382,6 +398,16 @@ export function ConfigView({
             >
               Clear selection
             </button>
+          </div>
+        ) : null}
+
+        {bulkSuccessMessage ? (
+          <div
+            className="mt-3 rounded-xl border border-emerald-300 bg-emerald-50 px-4 py-2.5 text-sm text-emerald-800"
+            role="status"
+            aria-live="polite"
+          >
+            {bulkSuccessMessage}
           </div>
         ) : null}
 

--- a/frontend/src/components/TrackEditModal.tsx
+++ b/frontend/src/components/TrackEditModal.tsx
@@ -8,6 +8,7 @@ export type EditTrackState = {
   title: string;
   artist: string;
   album: string;
+  year: string;
 };
 
 type TrackEditModalProps = {
@@ -84,6 +85,27 @@ export function TrackEditModal({
                   ? {
                       ...current,
                       album: event.target.value
+                    }
+                  : current
+              )
+            }
+          />
+        </label>
+
+        <label className="mt-3 block text-sm text-flaque-ink">
+          Year
+          <input
+            className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+            type="text"
+            inputMode="numeric"
+            value={editState.year}
+            placeholder="e.g. 1979"
+            onChange={(event) =>
+              onStateChange((current) =>
+                current
+                  ? {
+                      ...current,
+                      year: event.target.value
                     }
                   : current
               )

--- a/frontend/src/hooks/useLibraryCommands.ts
+++ b/frontend/src/hooks/useLibraryCommands.ts
@@ -1,6 +1,8 @@
 import type { Dispatch, SetStateAction } from "react";
 
 import {
+  bulkDeleteTracks,
+  bulkUpdateTrackMetadata,
   createPlaylist,
   deletePlaylist,
   deleteTrackFile,
@@ -48,6 +50,8 @@ type UseLibraryCommandsResult = {
   handleAddTrackToPlaylist: (input: { trackId: string; playlistId: string }) => Promise<void>;
   handlePatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
   handleDeletePlaylist: (playlistId: string) => Promise<void>;
+  handleBulkDeleteTracks: (trackIds: string[]) => Promise<void>;
+  handleBulkUpdateTrackMetadata: (trackIds: string[], patch: TrackMetadataPatch) => Promise<void>;
 };
 
 /**
@@ -205,12 +209,43 @@ export function useLibraryCommands({
     refreshPaginatedLibrary();
   }
 
+  async function handleBulkDeleteTracks(trackIds: string[]): Promise<void> {
+    const result = await bulkDeleteTracks(trackIds);
+    for (const id of result.deleted) {
+      removeTrackFromPlayback(id);
+    }
+
+    setAppNotice({
+      tone: "success",
+      message: `${result.deleted.length} track${result.deleted.length !== 1 ? "s" : ""} deleted from the library.`
+    });
+
+    await Promise.all([refreshCurrentLibrary(), refreshAllTracks()]);
+    refreshRecentlyUploaded();
+    refreshPaginatedLibrary();
+  }
+
+  async function handleBulkUpdateTrackMetadata(trackIds: string[], patch: TrackMetadataPatch): Promise<void> {
+    const result = await bulkUpdateTrackMetadata(trackIds, patch);
+
+    setAppNotice({
+      tone: "success",
+      message: `Metadata updated for ${result.updated.length} track${result.updated.length !== 1 ? "s" : ""}.`
+    });
+
+    await Promise.all([refreshCurrentLibrary(), refreshAllTracks()]);
+    refreshRecentlyUploaded();
+    refreshPaginatedLibrary();
+  }
+
   return {
     handleUpload,
     handleInspectUploadFile,
     handleRebuildIndex,
     handleDeleteTrack,
     handleUpdateTrackMetadata,
+    handleBulkDeleteTracks,
+    handleBulkUpdateTrackMetadata,
     handleCreatePlaylist,
     handleAddTrackToPlaylist,
     handlePatchPlaylist,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -111,6 +111,7 @@ export type TrackMetadataPatch = {
   title?: string | null;
   artist?: string | null;
   album?: string | null;
+  year?: number | null;
 };
 
 export type RadioTrack = {


### PR DESCRIPTION
## Summary
- **Bulk selection** in Config > Files: per-row checkboxes, select-all-on-page header checkbox (with indeterminate state), bulk action bar with "Edit metadata", "Delete files", and "Clear selection".
- **Bulk delete** (`POST /tracks/bulk/delete`): deletes all selected files, covers, and metadata overrides in one request with a single index rebuild.
- **Bulk edit** (`PATCH /tracks/bulk/metadata`): applies the same metadata patch to all selected tracks in one request. The modal pre-fills fields with common values across selected tracks, and shows "Mixed values" as placeholder for fields that differ.
- **Year field** added to both single-track and bulk edit modals. Year overrides are persisted and applied during index rebuild, same as title/artist/album. Validated as integer 1000–2999.

## Test plan
- [x] TypeScript compiles cleanly (both workspaces)
- [x] All 260 tests pass (227 backend + 33 frontend)
- [x] Frontend builds successfully
- [x] Manual: select tracks via checkboxes, verify bulk action bar appears
- [x] Manual: bulk delete — confirm modal shows count, files are removed
- [x] Manual: bulk edit — verify common values pre-filled, mixed values placeholder, submit updates all tracks
- [x] Manual: single-track edit — verify year field appears and persists
- [x] Manual: year override reflects in album views after index rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)