### PR TITLE
Fix password validation error feedback

### DIFF
--- a/frontend/src/components/AccountView.tsx
+++ b/frontend/src/components/AccountView.tsx
@@ -73,7 +73,7 @@ export function AccountView({
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [passwordMessage, setPasswordMessage] = useState<string | null>(null);
+  const [passwordMessage, setPasswordMessage] = useState<{ text: string; isError: boolean } | null>(null);
   const [updatingPassword, setUpdatingPassword] = useState(false);
   const [sessions, setSessions] = useState<UserSession[]>([]);
   const [loadingSessions, setLoadingSessions] = useState(false);
@@ -167,12 +167,12 @@ export function AccountView({
     setPasswordMessage(null);
 
     if (!currentPassword.trim() || !newPassword.trim()) {
-      setPasswordMessage("Current and new password are required.");
+      setPasswordMessage({ text: "Current and new password are required.", isError: true });
       return;
     }
 
     if (newPassword !== confirmPassword) {
-      setPasswordMessage("Password confirmation does not match.");
+      setPasswordMessage({ text: "Password confirmation does not match.", isError: true });
       return;
     }
 
@@ -187,9 +187,12 @@ export function AccountView({
       setCurrentPassword("");
       setNewPassword("");
       setConfirmPassword("");
-      setPasswordMessage("Password updated.");
+      setPasswordMessage({ text: "Password updated.", isError: false });
     } catch (error) {
-      setPasswordMessage(error instanceof Error ? error.message : "Unable to update password");
+      setPasswordMessage({
+        text: error instanceof Error ? error.message : "Unable to update password",
+        isError: true
+      });
     } finally {
       setUpdatingPassword(false);
     }
@@ -444,7 +447,17 @@ export function AccountView({
           </div>
         </form>
 
-        {passwordMessage ? <p className="mt-3 text-sm text-flaque-steel">{passwordMessage}</p> : null}
+        {passwordMessage ? (
+          <p
+            className={`mt-3 rounded-xl px-3 py-2 text-sm ${
+              passwordMessage.isError
+                ? "border border-red-300 bg-red-50 text-red-700"
+                : "border border-green-300 bg-green-50 text-green-700"
+            }`}
+          >
+            {passwordMessage.text}
+          </p>
+        ) : null}
       </section>
 
       <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">

--- a/frontend/src/components/AdminUsersView.tsx
+++ b/frontend/src/components/AdminUsersView.tsx
@@ -52,7 +52,7 @@ export function AdminUsersView({
   const [searchText, setSearchText] = useState("");
   const [roleFilter, setRoleFilter] = useState<UserRoleFilter>("all");
   const [submitting, setSubmitting] = useState(false);
-  const [formMessage, setFormMessage] = useState<string | null>(null);
+  const [formMessage, setFormMessage] = useState<{ text: string; isError: boolean } | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [activeUserActionId, setActiveUserActionId] = useState<string | null>(null);
@@ -90,13 +90,16 @@ export function AdminUsersView({
         role
       });
 
-      setFormMessage("User created successfully.");
+      setFormMessage({ text: "User created successfully.", isError: false });
       setUsername("");
       setPassword("");
       setEmail("");
       setRole("user");
     } catch (submitError) {
-      setFormMessage(submitError instanceof Error ? submitError.message : "Failed to create user");
+      setFormMessage({
+        text: submitError instanceof Error ? submitError.message : "Failed to create user",
+        isError: true
+      });
     } finally {
       setSubmitting(false);
     }
@@ -227,8 +230,8 @@ export function AdminUsersView({
 
         case "resetPassword": {
           const nextPassword = modalState.password.trim();
-          if (nextPassword.length < 8) {
-            setModalError("Password must be at least 8 characters.");
+          if (!nextPassword) {
+            setModalError("Password cannot be empty.");
             return;
           }
 
@@ -384,8 +387,16 @@ export function AdminUsersView({
         </p>
 
         {formMessage ? (
-          <p className="mt-3 text-sm text-flaque-steel" role="status" aria-live="polite">
-            {formMessage}
+          <p
+            className={`mt-3 rounded-xl px-3 py-2 text-sm ${
+              formMessage.isError
+                ? "border border-red-300 bg-red-50 text-red-700"
+                : "border border-green-300 bg-green-50 text-green-700"
+            }`}
+            role="status"
+            aria-live="polite"
+          >
+            {formMessage.text}
           </p>
         ) : null}
         {actionMessage ? (


### PR DESCRIPTION
## Summary
- Error messages from password validation (create user, reset password, change password) were styled identically to success messages (neutral gray), making failures invisible
- Errors now display in a red banner, successes in a green banner, in both AdminUsersView and AccountView
- Removed weak client-side `length < 8` check on admin password reset — backend validates fully (length, letter+digit, common password blocklist) and its errors are now properly surfaced

## Test plan
- [ ] Admin: create a user with password `12345678` (no letter) → red error banner with backend message
- [ ] Admin: create a user with valid password → green success banner
- [ ] Admin: reset a user's password to `password1` (common password) → red error in modal
- [ ] User: change password with mismatched confirmation → red error banner
- [ ] User: change password with weak new password → red error from backend
- [ ] User: change password successfully → green success banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)