### PR TITLE
Add functional logging and year editing at upload

### DIFF
--- a/backend/src/api/backupRoutes.ts
+++ b/backend/src/api/backupRoutes.ts
@@ -81,6 +81,7 @@ export function createBackupRouter(): Router {
     try {
       const config = await readBackupConfig();
       const manifest = await createBackup("manual", { includeIndex: config.includeIndex });
+      log.info("Manual backup created", { userId: _req.authUser?.id ?? "unknown" });
       res.status(201).json(manifest);
     } catch (error) {
       next(error);
@@ -138,6 +139,7 @@ export function createBackupRouter(): Router {
         return;
       }
 
+      log.info("Backup deleted", { backupId: safeId, userId: req.authUser?.id ?? "unknown" });
       res.status(204).end();
     } catch (error) {
       next(error);
@@ -154,6 +156,7 @@ export function createBackupRouter(): Router {
       }
 
       await restoreDatabase(safeId);
+      log.info("Database restored from backup", { backupId: safeId, userId: req.authUser?.id ?? "unknown" });
       res.json({ message: "Database restored successfully. Active sessions have been preserved from the backup." });
     } catch (error) {
       next(error);
@@ -165,6 +168,7 @@ export function createBackupRouter(): Router {
     try {
       const config = await readBackupConfig();
       const deleted = await purgeExpiredBackups(config.retentionDays);
+      log.info("Expired backups purged", { deletedCount: deleted, retentionDays: config.retentionDays, userId: _req.authUser?.id ?? "unknown" });
       res.json({ deleted, retentionDays: config.retentionDays });
     } catch (error) {
       next(error);

--- a/backend/src/api/coverRoutes.ts
+++ b/backend/src/api/coverRoutes.ts
@@ -6,8 +6,11 @@ import { requireAuth } from "../auth/middleware";
 import type { IndexStore } from "../services/indexer/indexStore";
 import { findCoverFileByTrackId } from "../services/storage/coverService";
 import { fileExists, readJsonFile } from "../utils/fs";
+import { createLogger } from "../utils/logger";
 import { ALBUM_METADATA_FILE } from "../utils/music";
 import { resolveDataRelativePath } from "../utils/paths";
+
+const log = createLogger("covers");
 const ALLOWED_IMAGE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp", ".gif", ".avif"]);
 
 type AlbumMetadata = {
@@ -56,6 +59,7 @@ export function createCoverRouter(indexStore: IndexStore): Router {
       const absolutePath = resolveDataRelativePath(relativePath);
       const hasFile = await fileExists(absolutePath);
       if (!hasFile) {
+        log.warn("Cover not found for path", { path: relativePath });
         res.status(404).json({ error: "Cover not found" });
         return;
       }
@@ -77,6 +81,7 @@ export function createCoverRouter(indexStore: IndexStore): Router {
 
       const coverPath = (await resolveAlbumCoverByTrackId(indexStore, trackId)) ?? (await findCoverFileByTrackId(trackId));
       if (!coverPath) {
+        log.warn("Cover not found for track", { trackId });
         res.status(404).json({ error: "Cover not found" });
         return;
       }

--- a/backend/src/api/indexRoutes.ts
+++ b/backend/src/api/indexRoutes.ts
@@ -2,6 +2,9 @@ import { Router } from "express";
 
 import { requireAdmin, requireAuth } from "../auth/middleware";
 import { IndexStore } from "../services/indexer/indexStore";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("index");
 
 export function createIndexRouter(indexStore: IndexStore): Router {
   const router = Router();
@@ -10,10 +13,18 @@ export function createIndexRouter(indexStore: IndexStore): Router {
     try {
       const startedAt = Date.now();
       const index = await indexStore.rebuild();
+      const durationMs = Date.now() - startedAt;
+
+      log.info("Index rebuild triggered", {
+        userId: _req.authUser?.id ?? "unknown",
+        totalTracks: index.totalTracks,
+        durationMs
+      });
+
       res.json({
         generatedAt: index.generatedAt,
         totalTracks: index.totalTracks,
-        durationMs: Date.now() - startedAt
+        durationMs
       });
     } catch (error) {
       next(error);

--- a/backend/src/api/libraryRoutes.ts
+++ b/backend/src/api/libraryRoutes.ts
@@ -51,6 +51,9 @@ import {
   resolveFilteredTracks,
   selectIndexedTracks
 } from "./trackPipeline";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("library");
 
 // ── Album detail helpers ────────────────────────────────────────────────
 
@@ -239,6 +242,13 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
         }
       });
 
+      log.info("Track metadata updated", {
+        trackId,
+        title: currentTrack.tags.title ?? currentTrack.path,
+        userId: req.authUser?.id ?? "unknown",
+        fields: [hasTitle && "title", hasArtist && "artist", hasAlbum && "album", hasYear && "year"].filter(Boolean).join(", ")
+      });
+
       await indexStore.rebuild();
       const ownerNamesById = getOwnerNamesById();
       const updatedTrack = indexStore.getTrackById(trackId);
@@ -301,6 +311,12 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       if (Object.keys(overridePatch).length > 0) {
         await mergeTrackMetadataOverrides(overridePatch);
       }
+
+      log.info("Tracks deleted in bulk", {
+        userId: req.authUser?.id ?? "unknown",
+        deletedCount: deleted.length,
+        notFoundCount: notFound.length
+      });
 
       const rebuiltIndex = await indexStore.rebuild();
       res.json({ deleted, notFound, totalTracks: rebuiltIndex.totalTracks });
@@ -369,6 +385,13 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
         await mergeTrackMetadataOverrides(overridePatch);
       }
 
+      log.info("Track metadata updated in bulk", {
+        userId: req.authUser?.id ?? "unknown",
+        updatedCount: updated.length,
+        notFoundCount: notFound.length,
+        fields: [hasTitle && "title", hasArtist && "artist", hasAlbum && "album", hasYear && "year"].filter(Boolean).join(", ")
+      });
+
       await indexStore.rebuild();
       res.json({ updated, notFound });
     } catch (error) {
@@ -405,6 +428,12 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
 
       await deleteTrackCover(trackId);
       await mergeTrackMetadataOverrides({ [trackId]: {} });
+
+      log.info("Track deleted", {
+        trackId,
+        title: track.tags.title ?? track.path,
+        userId: req.authUser?.id ?? "unknown"
+      });
 
       const rebuiltIndex = await indexStore.rebuild();
       res.json({ deletedTrackId: trackId, totalTracks: rebuiltIndex.totalTracks });

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -2,6 +2,9 @@ import { Router } from "express";
 
 import { requireAuth } from "../auth/middleware";
 import { IndexStore } from "../services/indexer/indexStore";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("playlists");
 import {
   canManagePlaylist,
   createFilesystemPlaylist,
@@ -158,6 +161,14 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
+      log.info("Playlist created", {
+        playlistId,
+        name,
+        userId: authUser.id,
+        trackCount: trackIds?.length ?? 0,
+        visibility: visibility ?? "private"
+      });
+
       res.status(201).json({ playlist: mapPlaylistResponse(playlist) });
     } catch (error) {
       if (
@@ -231,6 +242,13 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         res.status(500).json({ error: "Playlist updated but not found after reindex" });
         return;
       }
+
+      log.info("Playlist updated", {
+        playlistId,
+        name,
+        userId: authUser.id,
+        trackCount: trackIds.length
+      });
 
       res.json({ playlist: mapPlaylistResponse(updated) });
     } catch (error) {
@@ -306,6 +324,12 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
+      log.info("Playlist patched", {
+        playlistId,
+        name: name ?? existing.name,
+        userId: authUser.id
+      });
+
       res.json({ playlist: mapPlaylistResponse(updated) });
     } catch (error) {
       if (
@@ -345,6 +369,12 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
 
       await deleteFilesystemPlaylist(playlistId);
       await indexStore.refreshPlaylists();
+
+      log.info("Playlist deleted", {
+        playlistId,
+        name: existing.name,
+        userId: authUser.id
+      });
 
       res.status(204).send();
     } catch (error) {

--- a/backend/src/api/radioRoutes.ts
+++ b/backend/src/api/radioRoutes.ts
@@ -4,6 +4,9 @@ import { Router } from "express";
 import { requireAuth } from "../auth/middleware";
 import type { IndexStore } from "../services/indexer/indexStore";
 import { RadioService } from "../services/radio/radioService";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("radio");
 
 export function createRadioRouter(indexStore: IndexStore): Router {
   const router = Router();
@@ -12,6 +15,7 @@ export function createRadioRouter(indexStore: IndexStore): Router {
   router.post("/radio/create", requireAuth, async (_req: Request, res: Response, next: NextFunction) => {
     try {
       const payload = await radioService.createStation();
+      log.info("Radio station created", { userId: _req.authUser?.id ?? "unknown" });
       res.json(payload);
     } catch (error) {
       next(error);
@@ -53,6 +57,7 @@ export function createRadioRouter(indexStore: IndexStore): Router {
         }
 
         const payload = await radioService.rebuildStation(stationId);
+        log.info("Radio station rebuilt", { stationId, userId: req.authUser?.id ?? "unknown" });
         res.json(payload);
       } catch (error) {
         next(error);

--- a/backend/src/api/serverRoutes.ts
+++ b/backend/src/api/serverRoutes.ts
@@ -2,6 +2,9 @@ import { Router } from "express";
 
 import { requireAdmin, requireAuth } from "../auth/middleware";
 import { getVersionCheckResult, forceVersionCheck } from "../services/versionCheck";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("server");
 
 export function createServerRouter(): Router {
   const router = Router();
@@ -13,6 +16,7 @@ export function createServerRouter(): Router {
   router.post("/server/version/check", requireAuth, requireAdmin, async (_req, res, next) => {
     try {
       const result = await forceVersionCheck();
+      log.info("Version check triggered", { userId: _req.authUser?.id ?? "unknown" });
       res.json(result);
     } catch (error) {
       next(error);
@@ -27,6 +31,8 @@ export function createServerRouter(): Router {
         return;
       }
 
+      log.info("Server update initiated", { userId: _req.authUser?.id ?? "unknown" });
+
       const updaterUrl = process.env.UPDATER_URL ?? "http://updater:9090";
 
       const response = await fetch(`${updaterUrl}/update`, {
@@ -39,6 +45,7 @@ export function createServerRouter(): Router {
       const body = await response.json() as Record<string, unknown>;
 
       if (!response.ok) {
+        log.warn("Server update request failed", { status: response.status, userId: _req.authUser?.id ?? "unknown" });
         res.status(response.status).json(body);
         return;
       }

--- a/backend/src/api/streamingRoutes.ts
+++ b/backend/src/api/streamingRoutes.ts
@@ -11,6 +11,9 @@ import {
   streamTranscodedAudio,
   type TranscodeFormat
 } from "../services/streaming/transcodeService";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("streaming");
 
 function isFlacTrack(track: { codec: string; mimeType: string; path: string }): boolean {
   return (
@@ -54,6 +57,13 @@ export function createStreamingRouter(indexStore: IndexStore): Router {
 
       const absolutePath = resolveTrackAbsolutePath(track.path);
       await fs.access(absolutePath);
+
+      log.debug("Stream started", {
+        trackId,
+        title: track.tags.title ?? track.path,
+        userId: req.authUser?.id ?? "unknown",
+        transcode: transcode ?? "source"
+      });
 
       if (transcode) {
         if (!isFlacTrack(track)) {

--- a/backend/src/api/uploadRoutes.ts
+++ b/backend/src/api/uploadRoutes.ts
@@ -74,10 +74,20 @@ export function parseUploadMetadataOverrides(value: unknown): UploadMetadataOver
         return {};
       }
 
+      const rawYear = (entry as { year?: unknown }).year;
+      let year: number | undefined;
+      if (rawYear !== undefined && rawYear !== null) {
+        const n = typeof rawYear === "number" ? rawYear : Number(rawYear);
+        if (Number.isInteger(n) && n >= 1000 && n <= 2999) {
+          year = n;
+        }
+      }
+
       return {
         title: normalizeOptionalString((entry as { title?: unknown }).title),
         artist: normalizeOptionalString((entry as { artist?: unknown }).artist),
-        album: normalizeOptionalString((entry as { album?: unknown }).album)
+        album: normalizeOptionalString((entry as { album?: unknown }).album),
+        year
       };
     });
   } catch {
@@ -198,7 +208,7 @@ async function ingestUploadedFiles(
     );
   }
 
-  const metadataOverridePatch: Record<string, { title?: string; artist?: string; album?: string }> = {};
+  const metadataOverridePatch: Record<string, { title?: string; artist?: string; album?: string; year?: number }> = {};
   for (const result of results) {
     if (result.overrides) {
       metadataOverridePatch[result.trackId] = result.overrides;
@@ -232,11 +242,16 @@ async function ingestUploadedFiles(
   const deduplicated = results.filter((r) => !r.isNew).length;
   const uploaded = results.length - deduplicated;
 
+  const trackTitles = tracks
+    .map((track) => track.tags.title ?? track.path)
+    .slice(0, 10);
+
   log.info("Upload complete", {
     owner: options.ownerId,
     processed: results.length,
     uploaded,
-    deduplicated
+    deduplicated,
+    titles: trackTitles
   });
 
   return {

--- a/backend/src/api/uploadRoutes.ts
+++ b/backend/src/api/uploadRoutes.ts
@@ -164,6 +164,7 @@ type IngestOptions = {
   ownerId: string;
   manualArtist?: string;
   manualAlbum?: string;
+  manualYear?: number;
   deferRebuild: boolean;
   metadataOverrides: UploadMetadataOverride[];
 };
@@ -203,7 +204,8 @@ async function ingestUploadedFiles(
         musicDir,
         options.manualArtist,
         options.manualAlbum,
-        options.metadataOverrides[index] ?? {}
+        options.metadataOverrides[index] ?? {},
+        options.manualYear
       )
     );
   }
@@ -336,15 +338,29 @@ function requireSessionId(req: { body?: Record<string, unknown> }, res: Response
 type ParsedUploadRequestBody = {
   manualArtist?: string;
   manualAlbum?: string;
+  manualYear?: number;
   deferRebuild: boolean;
   metadataOverrides: UploadMetadataOverride[];
 };
+
+function parseManualYear(value: unknown): number | undefined {
+  const raw = normalizeOptionalString(value);
+  if (!raw) {
+    return undefined;
+  }
+  const n = Number(raw);
+  if (Number.isInteger(n) && n >= 1000 && n <= 2999) {
+    return n;
+  }
+  return undefined;
+}
 
 function parseUploadRequestBody(body: unknown): ParsedUploadRequestBody {
   const source = (body ?? {}) as Record<string, unknown>;
   return {
     manualArtist: normalizeOptionalString(source.artist),
     manualAlbum: normalizeOptionalString(source.album),
+    manualYear: parseManualYear(source.year),
     deferRebuild: parseBooleanField(source.deferRebuild),
     metadataOverrides: parseUploadMetadataOverrides(source.metadataOverrides)
   };

--- a/backend/src/api/userRoutes.ts
+++ b/backend/src/api/userRoutes.ts
@@ -182,6 +182,12 @@ export function createUserRouter(): Router {
       await removeExistingProfilePhotos(authUser.id);
       await fs.rename(tmpPath, targetPath);
 
+      emitSecurityAuditLog("info", "user-profile-photo-updated", {
+        userId: authUser.id,
+        originalName: file.originalname ?? "unknown",
+        sizeBytes: file.size
+      });
+
       res.json({ ok: true });
     } catch (error) {
       next(error);
@@ -468,8 +474,11 @@ export function createUserRouter(): Router {
         adminUserId: req.authUser!.id,
         targetUserId: userId,
         usernameChanged: shouldChangeUsername,
+        ...(shouldChangeUsername ? { oldUsername: existingUser.username, newUsername: nextUsername! } : {}),
         roleChanged: shouldChangeRole,
+        ...(shouldChangeRole ? { oldRole: existingUser.role, newRole: nextRole! } : {}),
         emailChanged: shouldChangeEmail,
+        ...(shouldChangeEmail ? { newEmail: nextEmail! } : {}),
         ip: getClientIp(req) ?? "unknown"
       });
 

--- a/backend/src/services/upload/uploadService.ts
+++ b/backend/src/services/upload/uploadService.ts
@@ -74,12 +74,13 @@ function resolveEffectiveNames(
 function resolveEffectiveOverrides(
   override: UploadMetadataOverride,
   manualArtist: string | undefined,
-  manualAlbum: string | undefined
+  manualAlbum: string | undefined,
+  manualYear: number | undefined
 ): { title?: string; artist?: string; album?: string; year?: number } | undefined {
   const effectiveTitle = override.title;
   const effectiveArtist = override.artist ?? manualArtist;
   const effectiveAlbum = override.album ?? manualAlbum;
-  const effectiveYear = override.year;
+  const effectiveYear = override.year ?? manualYear;
 
   if (!effectiveTitle && !effectiveArtist && !effectiveAlbum && effectiveYear === undefined) {
     return undefined;
@@ -162,7 +163,8 @@ export async function processUploadedFile(
   musicDir: string,
   manualArtist: string | undefined,
   manualAlbum: string | undefined,
-  metadataOverride: UploadMetadataOverride
+  metadataOverride: UploadMetadataOverride,
+  manualYear?: number
 ): Promise<ProcessedUpload> {
   if (!isSupportedAudioFile(uploadedFile.originalname)) {
     throw new Error(`Unsupported audio format: ${uploadedFile.originalname}`);
@@ -180,7 +182,7 @@ export async function processUploadedFile(
   const { trackId, relativePath, isNew } = await placeFile(uploadedFile, ownerId, albumDir);
   const cover = await ensureTrackCover(trackId, metadata.cover);
 
-  const overrides = resolveEffectiveOverrides(metadataOverride, manualArtist, manualAlbum);
+  const overrides = resolveEffectiveOverrides(metadataOverride, manualArtist, manualAlbum, manualYear);
   const tags = {
     ...metadata.tags,
     ...(overrides?.title ? { title: overrides.title } : {}),

--- a/backend/src/services/upload/uploadService.ts
+++ b/backend/src/services/upload/uploadService.ts
@@ -33,13 +33,14 @@ export type UploadMetadataOverride = {
   title?: string;
   artist?: string;
   album?: string;
+  year?: number;
 };
 
 export type ProcessedUpload = {
   trackId: string;
   track: Track;
   isNew: boolean;
-  overrides?: { title?: string; artist?: string; album?: string };
+  overrides?: { title?: string; artist?: string; album?: string; year?: number };
 };
 
 export function sanitizeExtension(fileName: string): string {
@@ -74,16 +75,17 @@ function resolveEffectiveOverrides(
   override: UploadMetadataOverride,
   manualArtist: string | undefined,
   manualAlbum: string | undefined
-): { title?: string; artist?: string; album?: string } | undefined {
+): { title?: string; artist?: string; album?: string; year?: number } | undefined {
   const effectiveTitle = override.title;
   const effectiveArtist = override.artist ?? manualArtist;
   const effectiveAlbum = override.album ?? manualAlbum;
+  const effectiveYear = override.year;
 
-  if (!effectiveTitle && !effectiveArtist && !effectiveAlbum) {
+  if (!effectiveTitle && !effectiveArtist && !effectiveAlbum && effectiveYear === undefined) {
     return undefined;
   }
 
-  return { title: effectiveTitle, artist: effectiveArtist, album: effectiveAlbum };
+  return { title: effectiveTitle, artist: effectiveArtist, album: effectiveAlbum, year: effectiveYear };
 }
 
 async function ensureArtistDirectory(artistDir: string, artistName: string): Promise<void> {
@@ -183,7 +185,8 @@ export async function processUploadedFile(
     ...metadata.tags,
     ...(overrides?.title ? { title: overrides.title } : {}),
     ...(overrides?.artist ? { artist: overrides.artist } : {}),
-    ...(overrides?.album ? { album: overrides.album } : {})
+    ...(overrides?.album ? { album: overrides.album } : {}),
+    ...(overrides?.year !== undefined ? { year: overrides.year } : {})
   };
 
   const track: Track = {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -305,6 +305,7 @@ export type UploadTracksInput = {
   files: File[];
   artist?: string;
   album?: string;
+  year?: number;
   metadataOverrides?: Array<{
     title?: string;
     artist?: string;
@@ -341,6 +342,7 @@ type UploadSingleTrackInput = {
   file: File;
   artist?: string;
   album?: string;
+  year?: number;
   deferRebuild?: boolean;
   metadataOverride?: {
     title?: string;
@@ -447,7 +449,7 @@ async function uploadSingleTrackChunked(input: UploadSingleTrackInput): Promise<
 async function finalizeChunkedUpload(
   tempPath: string,
   fileName: string,
-  input: Pick<UploadSingleTrackInput, "artist" | "album" | "deferRebuild" | "metadataOverride">
+  input: Pick<UploadSingleTrackInput, "artist" | "album" | "year" | "deferRebuild" | "metadataOverride">
 ): Promise<UploadTracksResult> {
   const formData = new FormData();
   formData.append("tempPath", tempPath);
@@ -459,6 +461,10 @@ async function finalizeChunkedUpload(
 
   if (input.album?.trim()) {
     formData.append("album", input.album.trim());
+  }
+
+  if (input.year !== undefined) {
+    formData.append("year", String(input.year));
   }
 
   if (input.metadataOverride) {
@@ -508,6 +514,10 @@ function uploadSingleTrackDirect(input: UploadSingleTrackInput): Promise<UploadT
 
   if (input.album?.trim()) {
     formData.append("album", input.album.trim());
+  }
+
+  if (input.year !== undefined) {
+    formData.append("year", String(input.year));
   }
 
   if (input.metadataOverride) {
@@ -590,6 +600,7 @@ export async function uploadTracks(input: UploadTracksInput): Promise<UploadTrac
       file,
       artist: input.artist,
       album: input.album,
+      year: input.year,
       deferRebuild: !isLastFile,
       metadataOverride,
       onProgress: input.onProgress

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -309,6 +309,7 @@ export type UploadTracksInput = {
     title?: string;
     artist?: string;
     album?: string;
+    year?: number;
   } | null>;
   onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
 };
@@ -345,6 +346,7 @@ type UploadSingleTrackInput = {
     title?: string;
     artist?: string;
     album?: string;
+    year?: number;
   } | null;
   onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
 };

--- a/frontend/src/components/UploadView.tsx
+++ b/frontend/src/components/UploadView.tsx
@@ -9,6 +9,7 @@ type UploadViewProps = {
     files: File[];
     artist?: string;
     album?: string;
+    year?: number;
     metadataOverrides?: Array<{
       title?: string;
       artist?: string;
@@ -82,6 +83,7 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
   >({});
   const [uploadArtist, setUploadArtist] = useState("");
   const [uploadAlbum, setUploadAlbum] = useState("");
+  const [uploadYear, setUploadYear] = useState("");
   const [uploading, setUploading] = useState(false);
   const [uploadProgressPercent, setUploadProgressPercent] = useState<number>(0);
   const [draggingFiles, setDraggingFiles] = useState(false);
@@ -215,10 +217,17 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
     });
 
     try {
+      const globalYearStr = uploadYear.trim();
+      const globalYearNum = globalYearStr ? Number(globalYearStr) : undefined;
+      const globalYear = globalYearNum && Number.isInteger(globalYearNum) && globalYearNum >= 1000 && globalYearNum <= 2999
+        ? globalYearNum
+        : undefined;
+
       const result = await onUpload({
         files: pendingFiles,
         artist: uploadArtist.trim() || undefined,
         album: uploadAlbum.trim() || undefined,
+        year: globalYear,
         metadataOverrides,
         onProgress: (progress) => {
           setUploadProgressPercent(progress.percent);
@@ -310,7 +319,7 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
 
           <p className="text-xs text-flaque-steel/90">Supported formats: FLAC, MP3, WAV, OGG, Opus, M4A.</p>
 
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
             <label className="text-sm text-flaque-ink">
               Artist override (optional)
               <input
@@ -319,7 +328,7 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
                 value={uploadArtist}
                 onChange={(event) => setUploadArtist(event.target.value)}
                 disabled={uploading}
-                placeholder="Apply artist to all uploaded files"
+                placeholder="Apply artist to all files"
               />
             </label>
 
@@ -331,7 +340,20 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
                 value={uploadAlbum}
                 onChange={(event) => setUploadAlbum(event.target.value)}
                 disabled={uploading}
-                placeholder="Apply album to all uploaded files"
+                placeholder="Apply album to all files"
+              />
+            </label>
+
+            <label className="text-sm text-flaque-ink">
+              Year override (optional)
+              <input
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                type="text"
+                inputMode="numeric"
+                value={uploadYear}
+                onChange={(event) => setUploadYear(event.target.value)}
+                disabled={uploading}
+                placeholder="e.g. 1979"
               />
             </label>
 

--- a/frontend/src/components/UploadView.tsx
+++ b/frontend/src/components/UploadView.tsx
@@ -13,6 +13,7 @@ type UploadViewProps = {
       title?: string;
       artist?: string;
       album?: string;
+      year?: number;
     } | null>;
     onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
   }) => Promise<UploadTracksResult>;
@@ -77,7 +78,7 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
   const [previewByFileKey, setPreviewByFileKey] = useState<Record<string, PreviewState>>({});
   const [editableMetadataByFileKey, setEditableMetadataByFileKey] = useState<
-    Record<string, { title: string; artist: string; album: string }>
+    Record<string, { title: string; artist: string; album: string; year: string }>
   >({});
   const [uploadArtist, setUploadArtist] = useState("");
   const [uploadAlbum, setUploadAlbum] = useState("");
@@ -198,14 +199,18 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
       const title = editedMetadata.title.trim();
       const artist = editedMetadata.artist.trim();
       const album = editedMetadata.album.trim();
-      if (!title && !artist && !album) {
+      const yearStr = editedMetadata.year.trim();
+      const yearNum = yearStr ? Number(yearStr) : undefined;
+      const year = yearNum && Number.isInteger(yearNum) && yearNum >= 1000 && yearNum <= 2999 ? yearNum : undefined;
+      if (!title && !artist && !album && year === undefined) {
         return null;
       }
 
       return {
         title: title || undefined,
         artist: artist || undefined,
-        album: album || undefined
+        album: album || undefined,
+        year
       };
     });
 
@@ -397,6 +402,7 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
               const editableTitle = editableMetadata?.title ?? title;
               const editableArtist = editableMetadata?.artist ?? artist;
               const editableAlbum = editableMetadata?.album ?? albumBase;
+              const editableYear = editableMetadata?.year ?? (year ?? "");
               const trackPosition =
                 typeof preview?.tags.trackNumber === "number"
                   ? `${preview.tags.trackNumber}${
@@ -438,7 +444,8 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
                                   [fileKey]: {
                                     title: nextTitle,
                                     artist: current[fileKey]?.artist ?? editableArtist,
-                                    album: current[fileKey]?.album ?? editableAlbum
+                                    album: current[fileKey]?.album ?? editableAlbum,
+                                    year: current[fileKey]?.year ?? editableYear
                                   }
                                 }));
                               }}
@@ -457,7 +464,8 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
                                   [fileKey]: {
                                     title: current[fileKey]?.title ?? editableTitle,
                                     artist: nextArtist,
-                                    album: current[fileKey]?.album ?? editableAlbum
+                                    album: current[fileKey]?.album ?? editableAlbum,
+                                    year: current[fileKey]?.year ?? editableYear
                                   }
                                 }));
                               }}
@@ -476,23 +484,36 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
                                   [fileKey]: {
                                     title: current[fileKey]?.title ?? editableTitle,
                                     artist: current[fileKey]?.artist ?? editableArtist,
-                                    album: nextAlbum
+                                    album: nextAlbum,
+                                    year: current[fileKey]?.year ?? editableYear
                                   }
                                 }));
                               }}
                             />
                           </label>
 
-                          {year ? (
-                            <label className="text-flaque-steel">
-                              Year
-                              <input
-                                className="mt-1 w-full rounded-lg border border-flaque-clay bg-white px-2 py-1 text-flaque-ink"
-                                value={year}
-                                readOnly
-                              />
-                            </label>
-                          ) : null}
+                          <label className="text-flaque-steel">
+                            Year
+                            <input
+                              className="mt-1 w-full rounded-lg border border-flaque-clay bg-white px-2 py-1 text-flaque-ink"
+                              value={editableYear}
+                              disabled={uploading}
+                              inputMode="numeric"
+                              placeholder="e.g. 1979"
+                              onChange={(event) => {
+                                const nextYear = event.target.value;
+                                setEditableMetadataByFileKey((current) => ({
+                                  ...current,
+                                  [fileKey]: {
+                                    title: current[fileKey]?.title ?? editableTitle,
+                                    artist: current[fileKey]?.artist ?? editableArtist,
+                                    album: current[fileKey]?.album ?? editableAlbum,
+                                    year: nextYear
+                                  }
+                                }));
+                              }}
+                            />
+                          </label>
 
                           <p className="text-xs text-flaque-steel">
                             {preview?.codec?.toUpperCase() ?? "Unknown codec"}

--- a/frontend/src/hooks/useLibraryCommands.ts
+++ b/frontend/src/hooks/useLibraryCommands.ts
@@ -35,10 +35,12 @@ type UseLibraryCommandsResult = {
     files: File[];
     artist?: string;
     album?: string;
+    year?: number;
     metadataOverrides?: Array<{
       title?: string;
       artist?: string;
       album?: string;
+      year?: number;
     } | null>;
     onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
   }) => Promise<UploadTracksResult>;
@@ -73,10 +75,12 @@ export function useLibraryCommands({
     files: File[];
     artist?: string;
     album?: string;
+    year?: number;
     metadataOverrides?: Array<{
       title?: string;
       artist?: string;
       album?: string;
+      year?: number;
     } | null>;
     onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
   }): Promise<UploadTracksResult> {


### PR DESCRIPTION
## Summary
- **Structured logging** added to all route handlers that perform mutations:
  - Library: track metadata edit (single + bulk), track delete (single + bulk)
  - Playlists: create, update (PUT + PATCH), delete
  - Radio: station create, station rebuild
  - Index: manual rebuild (with duration + track count)
  - Backup: manual create, delete, restore, purge
  - Upload: now includes track titles in completion log (up to 10)
  - All log entries include `userId` for admin traceability
- **Year editable at upload**: the year field in the upload metadata preview is now an editable input (was read-only). Year overrides propagate through the full pipeline from frontend form to metadata override store.

## Test plan
- [ ] Upload a track, edit the year in the preview → verify year is stored in metadata overrides
- [ ] Upload a track with embedded year tag, don't edit → verify extracted year is preserved
- [ ] Check server logs after: upload, track delete, metadata edit, playlist create/delete, backup create/restore, index rebuild
- [ ] Verify log entries contain userId, relevant track/playlist info, and meaningful context

🤖 Generated with [Claude Code](https://claude.com/claude-code)