### PR TITLE
Fix duplicate notification on bulk file operations

### DIFF
--- a/frontend/src/hooks/useLibraryCommands.ts
+++ b/frontend/src/hooks/useLibraryCommands.ts
@@ -219,23 +219,13 @@ export function useLibraryCommands({
       removeTrackFromPlayback(id);
     }
 
-    setAppNotice({
-      tone: "success",
-      message: `${result.deleted.length} track${result.deleted.length !== 1 ? "s" : ""} deleted from the library.`
-    });
-
     await Promise.all([refreshCurrentLibrary(), refreshAllTracks()]);
     refreshRecentlyUploaded();
     refreshPaginatedLibrary();
   }
 
   async function handleBulkUpdateTrackMetadata(trackIds: string[], patch: TrackMetadataPatch): Promise<void> {
-    const result = await bulkUpdateTrackMetadata(trackIds, patch);
-
-    setAppNotice({
-      tone: "success",
-      message: `Metadata updated for ${result.updated.length} track${result.updated.length !== 1 ? "s" : ""}.`
-    });
+    await bulkUpdateTrackMetadata(trackIds, patch);
 
     await Promise.all([refreshCurrentLibrary(), refreshAllTracks()]);
     refreshRecentlyUploaded();


### PR DESCRIPTION
## Summary
- Bulk delete and bulk metadata edit in admin files view were showing two success messages simultaneously: a global AppNotice banner and an inline ConfigView banner
- Removed the `setAppNotice` calls from `handleBulkDeleteTracks` and `handleBulkUpdateTrackMetadata` in `useLibraryCommands`, keeping only the inline banner in ConfigView (the higher one in the view)

## Test plan
- [ ] Admin files view: select tracks, bulk delete → only one green inline banner appears
- [ ] Admin files view: select tracks, bulk edit metadata → only one green inline banner appears
- [ ] Verify no notification shows on failure beyond the existing error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)