### PR TITLE
Add search and improve artist/album browsing UX

### DIFF
--- a/frontend/src/components/LibraryAlbumsSection.tsx
+++ b/frontend/src/components/LibraryAlbumsSection.tsx
@@ -47,7 +47,17 @@ export function LibraryAlbumsSection({
   onAddTrackToPlaylist
 }: LibraryAlbumsSectionProps): JSX.Element {
   const [viewMode, setViewMode] = useState<AlbumViewMode>("list");
+  const [searchQuery, setSearchQuery] = useState("");
   const isListModeTracklistVisible = viewMode === "list" && selectedAlbum !== null;
+
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const filteredAlbums = normalizedQuery
+    ? albums.filter(
+        (album) =>
+          album.name.toLowerCase().includes(normalizedQuery) ||
+          (album.artist && album.artist.toLowerCase().includes(normalizedQuery))
+      )
+    : albums;
 
   function getAlbumCoverSrc(album: AlbumEntry): string {
     if (album.cover) {
@@ -68,6 +78,16 @@ export function LibraryAlbumsSection({
           <h2 className="font-display text-xl text-flaque-ink">Albums</h2>
         </div>
 
+        <div className="flex items-center gap-3">
+          {!selectedAlbum && (
+            <input
+              className="rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-3 py-1.5 text-sm text-flaque-ink placeholder:text-flaque-steel/60 focus:border-flaque-ink/40 focus:outline-none"
+              type="text"
+              placeholder="Search albums..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          )}
         <div className="inline-flex rounded-xl border border-flaque-clay/70 bg-flaque-cream/50 p-1">
           <button
             className={`rounded-lg px-3 py-1.5 text-sm transition ${
@@ -88,6 +108,7 @@ export function LibraryAlbumsSection({
             Coverflow
           </button>
         </div>
+        </div>
       </div>
 
       {libraryMetadataError ? (
@@ -96,20 +117,20 @@ export function LibraryAlbumsSection({
 
       {loadingAlbums ? (
         <p className="mt-3 text-sm text-flaque-steel">Loading albums...</p>
-      ) : albums.length === 0 ? (
-        <p className="mt-3 text-sm text-flaque-steel">No albums found for these filters.</p>
+      ) : filteredAlbums.length === 0 ? (
+        <p className="mt-3 text-sm text-flaque-steel">No albums found{normalizedQuery ? ` matching "${searchQuery.trim()}"` : " for these filters"}.</p>
       ) : (
         <>
           {viewMode === "coverflow" ? (
             <Coverflow
-              albums={albums}
+              albums={filteredAlbums}
               selectedAlbum={selectedAlbum}
               onAlbumSelect={onAlbumSelect}
               getAlbumCoverSrc={getAlbumCoverSrc}
             />
           ) : !isListModeTracklistVisible ? (
             <AlbumList
-              albums={albums}
+              albums={filteredAlbums}
               selectedAlbum={selectedAlbum}
               onAlbumSelect={onAlbumSelect}
               onPlayAlbum={onPlayAlbum}

--- a/frontend/src/components/LibraryArtistsSection.tsx
+++ b/frontend/src/components/LibraryArtistsSection.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { coverPathUrl, coverUrl } from "../api";
 import defaultCoverImage from "../assets/default-cover.png";
 import type { AlbumEntry, ArtistEntry, Playlist, Track } from "../types";
@@ -65,12 +67,29 @@ export function LibraryArtistsSection({
     return defaultCoverImage;
   }
 
+  const [searchQuery, setSearchQuery] = useState("");
   const isArtistSelected = selectedArtist !== null;
   const isTracklistVisible = selectedArtistAlbum !== null;
 
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const filteredArtists = normalizedQuery
+    ? artists.filter((artist) => artist.name.toLowerCase().includes(normalizedQuery))
+    : artists;
+
   return (
     <section className="border m-4 rounded-xl border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
-      <h2 className="font-display text-xl text-flaque-ink">Artists</h2>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <h2 className="font-display text-xl text-flaque-ink">Artists</h2>
+        {!isArtistSelected && (
+          <input
+            className="rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-3 py-1.5 text-sm text-flaque-ink placeholder:text-flaque-steel/60 focus:border-flaque-ink/40 focus:outline-none"
+            type="text"
+            placeholder="Search artists..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+        )}
+      </div>
       {isArtistSelected ? (
         <>
           <button
@@ -97,8 +116,8 @@ export function LibraryArtistsSection({
 
       {loadingArtists ? (
         <p className="mt-3 text-sm text-flaque-steel">Loading artists...</p>
-      ) : artists.length === 0 && !isArtistSelected ? (
-        <p className="mt-3 text-sm text-flaque-steel">No artists found for these filters.</p>
+      ) : filteredArtists.length === 0 && !isArtistSelected ? (
+        <p className="mt-3 text-sm text-flaque-steel">No artists found{normalizedQuery ? ` matching "${searchQuery.trim()}"` : " for these filters"}.</p>
       ) : isArtistSelected && isTracklistVisible ? (
         <div className="mt-4 overflow-hidden rounded-2xl border border-flaque-clay/60 bg-white/75">
           <div className="border-b border-flaque-clay/55 px-4 py-3">
@@ -152,43 +171,71 @@ export function LibraryArtistsSection({
           getAlbumCoverSrc={getAlbumCoverSrc}
         />
       ) : (
-        <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-          {artists.map((artist) => {
-            const artistPhoto = artist.photo
-              ? coverPathUrl(artist.photo)
-              : artist.previewTrackId
-                ? coverUrl(artist.previewTrackId)
-                : defaultCoverImage;
-
-            return (
-              <button
-                key={artist.name}
-                className="rounded-xl border border-flaque-clay/60 bg-flaque-cream/45 p-3 text-center transition hover:bg-flaque-cream"
-                title={artist.name}
-                type="button"
-                onClick={() => onArtistSelect(artist)}
-              >
-                <img
-                  className="mx-auto h-24 w-24 rounded-full border border-flaque-clay/50 object-cover"
-                  src={artistPhoto}
-                  alt={`Artwork for ${artist.name}`}
-                  onError={(event) => {
-                    event.currentTarget.src = defaultCoverImage;
-                  }}
-                />
-                <div className="mt-2 min-w-0">
-                  <p className="truncate text-sm font-medium text-flaque-ink">{artist.name}</p>
-                  <p className="text-xs text-flaque-steel">
-                    {artist.albumCount} album{artist.albumCount !== 1 ? "s" : ""}
-                    {" · "}
-                    {artist.trackCount} track{artist.trackCount !== 1 ? "s" : ""}
-                    {" · "}
-                    {formatDurationHuman(artist.totalDuration)}
-                  </p>
-                </div>
-              </button>
+        <div className="mt-3">
+          {(() => {
+            const grouped = new Map<string, ArtistEntry[]>();
+            for (const artist of filteredArtists) {
+              const first = artist.name[0]?.toUpperCase() ?? "#";
+              const letter = /[A-Z]/.test(first) ? first : "#";
+              const list = grouped.get(letter);
+              if (list) {
+                list.push(artist);
+              } else {
+                grouped.set(letter, [artist]);
+              }
+            }
+            const sortedKeys = [...grouped.keys()].sort((a, b) =>
+              a === "#" ? 1 : b === "#" ? -1 : a.localeCompare(b)
             );
-          })}
+
+            return sortedKeys.map((letter, idx) => (
+              <div key={letter}>
+                <div className="flex items-center gap-3">
+                  <span className="text-sm font-semibold text-flaque-steel">{letter}</span>
+                  <div className="flex-1 h-[2px] border-t-[2px] border-flaque-clay/40" style={{ maskImage: "linear-gradient(to right, black 50%, transparent)", WebkitMaskImage: "linear-gradient(to right, black 50%, transparent)" }} />
+                </div>
+                <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                  {grouped.get(letter)!.map((artist) => {
+                    const artistPhoto = artist.photo
+                      ? coverPathUrl(artist.photo)
+                      : artist.previewTrackId
+                        ? coverUrl(artist.previewTrackId)
+                        : defaultCoverImage;
+
+                    return (
+                      <button
+                        key={artist.name}
+                        className="aspect-square rounded-xl bg-white/85 p-3 text-center transition hover:bg-flaque-cream"
+                        title={artist.name}
+                        type="button"
+                        onClick={() => onArtistSelect(artist)}
+                      >
+                        <img
+                          className="mx-auto h-full max-h-44 w-full max-w-44 rounded-full border border-flaque-clay/50 object-cover"
+                          src={artistPhoto}
+                          alt={`Artwork for ${artist.name}`}
+                          onError={(event) => {
+                            event.currentTarget.src = defaultCoverImage;
+                          }}
+                        />
+                        <div className="mt-2 min-w-0">
+                          <p className="truncate text-sm font-medium text-flaque-ink">{artist.name}</p>
+                          <p className="text-xs text-flaque-steel">
+                            {artist.albumCount} album{artist.albumCount !== 1 ? "s" : ""}
+                            {" · "}
+                            {artist.trackCount} track{artist.trackCount !== 1 ? "s" : ""}
+                            {" · "}
+                            {formatDurationHuman(artist.totalDuration)}
+                          </p>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+                {idx < sortedKeys.length - 1 && <div className="mb-4" />}
+              </div>
+            ));
+          })()}
         </div>
       )}
     </section>


### PR DESCRIPTION
## Summary
- Add search inputs to the top-right of Artists and Albums views for quick filtering
- Group artists alphabetically with letter headers and fading separators
- Style artist cards as borderless squares with larger circular images
- Album search filters by both album name and artist name

## Test plan
- [ ] Navigate to Artists view — verify alphabetical grouping with letter headers and fading separators
- [ ] Type in the artist search input — verify artists are filtered by name
- [ ] Navigate to Albums view — verify search input appears next to List/Coverflow toggle
- [ ] Type in the album search input — verify albums filter by name and artist
- [ ] Drill into an artist or album — verify search input hides
- [ ] Navigate back — verify search input reappears with cleared state

🤖 Generated with [Claude Code](https://claude.com/claude-code)