### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flaque-backend",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "scripts": {
     "dev": "tsx watch src/server.ts",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flaque-frontend",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flaque",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flaque",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "workspaces": [
         "backend",
         "frontend"
@@ -18,7 +18,7 @@
     },
     "backend": {
       "name": "flaque-backend",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.9.0",
@@ -49,7 +49,7 @@
     },
     "frontend": {
       "name": "flaque-frontend",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "music-metadata": "^10.9.1",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flaque",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary
- Bump version to 0.2.2 across all package.json files and lock file

## Test plan
- [ ] Verify version displays as 0.2.2 in admin Server view

🤖 Generated with [Claude Code](https://claude.com/claude-code)