### PR TITLE
Implement genre infrastructure (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage/
 
 runtime/
 
+data/backups/
 data/config/users.db
 data/config/users.db-*
 data/storage/users/*

--- a/backend/src/api/genreRoutes.ts
+++ b/backend/src/api/genreRoutes.ts
@@ -1,0 +1,97 @@
+import { Router } from "express";
+
+import { requireAdmin, requireAuth } from "../auth/middleware";
+import type { IndexStore } from "../services/indexer/indexStore";
+import {
+  getEnrichmentStatus,
+  runBackgroundEnrichment,
+  stopEnrichment
+} from "../services/genre/genreEnrichmentService";
+import {
+  getSynonyms,
+  setSynonym,
+  removeSynonym,
+  resetSynonymsToDefaults
+} from "../services/genre/genreSynonymService";
+import { getGenreCacheStats, clearGenreCache } from "../services/genre/musicBrainzService";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("genre-routes");
+
+export function createGenreRouter(indexStore: IndexStore): Router {
+  const router = Router();
+
+  router.get("/genre/enrichment/status", requireAuth, requireAdmin, (_req, res) => {
+    res.json(getEnrichmentStatus());
+  });
+
+  router.post("/genre/enrichment/start", requireAuth, requireAdmin, (_req, res) => {
+    const status = getEnrichmentStatus();
+    if (status.running) {
+      res.json({ started: false, message: "Enrichment already running", status });
+      return;
+    }
+
+    void runBackgroundEnrichment(indexStore);
+
+    log.info("Genre enrichment started", { userId: _req.authUser?.id ?? "unknown" });
+    res.json({ started: true, message: "Genre enrichment started" });
+  });
+
+  router.post("/genre/enrichment/stop", requireAuth, requireAdmin, (_req, res) => {
+    stopEnrichment();
+    log.info("Genre enrichment stopped", { userId: _req.authUser?.id ?? "unknown" });
+    res.json({ stopped: true });
+  });
+
+  router.get("/genre/synonyms", requireAuth, requireAdmin, (_req, res) => {
+    res.json(getSynonyms());
+  });
+
+  router.put("/genre/synonyms", requireAuth, requireAdmin, (req, res) => {
+    const { from, to } = req.body as { from?: string; to?: string };
+    if (typeof from !== "string" || !from.trim() || typeof to !== "string" || !to.trim()) {
+      res.status(400).json({ error: "Both 'from' and 'to' must be non-empty strings" });
+      return;
+    }
+
+    setSynonym(from, to);
+    log.info("Genre synonym updated", { from, to, userId: req.authUser?.id ?? "unknown" });
+    res.json({ from: from.trim().toLowerCase(), to: to.trim() });
+  });
+
+  router.delete("/genre/synonyms/:key", requireAuth, requireAdmin, (req, res) => {
+    const key = req.params.key;
+    if (!key) {
+      res.status(400).json({ error: "Synonym key required" });
+      return;
+    }
+
+    const removed = removeSynonym(key);
+    if (!removed) {
+      res.status(404).json({ error: "Synonym not found" });
+      return;
+    }
+
+    log.info("Genre synonym removed", { key, userId: req.authUser?.id ?? "unknown" });
+    res.json({ removed: true });
+  });
+
+  router.post("/genre/synonyms/reset", requireAuth, requireAdmin, (_req, res) => {
+    resetSynonymsToDefaults();
+    log.info("Genre synonyms reset to defaults", { userId: _req.authUser?.id ?? "unknown" });
+    res.json({ reset: true });
+  });
+
+  router.get("/genre/cache/stats", requireAuth, requireAdmin, (_req, res) => {
+    res.json(getGenreCacheStats());
+  });
+
+  router.post("/genre/cache/clear", requireAuth, requireAdmin, (_req, res) => {
+    clearGenreCache();
+    log.info("MusicBrainz genre cache cleared", { userId: _req.authUser?.id ?? "unknown" });
+    res.json({ cleared: true });
+  });
+
+  return router;
+}

--- a/backend/src/api/libraryRoutes.ts
+++ b/backend/src/api/libraryRoutes.ts
@@ -37,6 +37,7 @@ import type { Track } from "../types/library";
 import {
   hasOwnProperty,
   parseMetadataField,
+  parseMetadataGenreField,
   parseMetadataYearField,
   readDirection,
   readFilter,
@@ -208,9 +209,10 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       const hasArtist = hasOwnProperty(req.body, "artist");
       const hasAlbum = hasOwnProperty(req.body, "album");
       const hasYear = hasOwnProperty(req.body, "year");
+      const hasGenre = hasOwnProperty(req.body, "genre");
 
-      if (!hasTitle && !hasArtist && !hasAlbum && !hasYear) {
-        res.status(400).json({ error: "At least one metadata field is required: title, artist, album, year" });
+      if (!hasTitle && !hasArtist && !hasAlbum && !hasYear && !hasGenre) {
+        res.status(400).json({ error: "At least one metadata field is required: title, artist, album, year, genre" });
         return;
       }
 
@@ -224,11 +226,13 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       const parsedArtist = hasArtist ? parseMetadataField(req.body?.artist) : undefined;
       const parsedAlbum = hasAlbum ? parseMetadataField(req.body?.album) : undefined;
       const parsedYear = hasYear ? parseMetadataYearField(req.body?.year) : undefined;
+      const parsedGenre = hasGenre ? parseMetadataGenreField(req.body?.genre) : undefined;
 
       if (parsedTitle === null) { res.status(400).json({ error: "title must be a string or null" }); return; }
       if (parsedArtist === null) { res.status(400).json({ error: "artist must be a string or null" }); return; }
       if (parsedAlbum === null) { res.status(400).json({ error: "album must be a string or null" }); return; }
       if (parsedYear === null) { res.status(400).json({ error: "year must be an integer between 1000 and 2999, or null" }); return; }
+      if (parsedGenre === null) { res.status(400).json({ error: "genre must be an array of strings or null" }); return; }
 
       const currentOverrides = await readTrackMetadataOverrides();
       const currentOverride = currentOverrides[trackId] ?? {};
@@ -238,7 +242,8 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
           title: hasTitle ? parsedTitle : currentOverride.title,
           artist: hasArtist ? parsedArtist : currentOverride.artist,
           album: hasAlbum ? parsedAlbum : currentOverride.album,
-          year: hasYear ? parsedYear : currentOverride.year
+          year: hasYear ? parsedYear : currentOverride.year,
+          genre: hasGenre ? parsedGenre : currentOverride.genre
         }
       });
 
@@ -246,7 +251,7 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
         trackId,
         title: currentTrack.tags.title ?? currentTrack.path,
         userId: req.authUser?.id ?? "unknown",
-        fields: [hasTitle && "title", hasArtist && "artist", hasAlbum && "album", hasYear && "year"].filter(Boolean).join(", ")
+        fields: [hasTitle && "title", hasArtist && "artist", hasAlbum && "album", hasYear && "year", hasGenre && "genre"].filter(Boolean).join(", ")
       });
 
       await indexStore.rebuild();
@@ -258,7 +263,7 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       }
 
       const fallbackTrack = applyMetadataPatchToTrack(currentTrack, {
-        hasTitle, title: parsedTitle, hasArtist, artist: parsedArtist, hasAlbum, album: parsedAlbum, hasYear, year: parsedYear
+        hasTitle, title: parsedTitle, hasArtist, artist: parsedArtist, hasAlbum, album: parsedAlbum, hasYear, year: parsedYear, hasGenre, genre: parsedGenre
       });
       res.json({
         track: mapTrackResponse(mapTrackOwners([fallbackTrack], ownerNamesById)[0]!),
@@ -343,9 +348,10 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       const hasArtist = hasOwnProperty(req.body, "artist");
       const hasAlbum = hasOwnProperty(req.body, "album");
       const hasYear = hasOwnProperty(req.body, "year");
+      const hasGenre = hasOwnProperty(req.body, "genre");
 
-      if (!hasTitle && !hasArtist && !hasAlbum && !hasYear) {
-        res.status(400).json({ error: "At least one metadata field is required: title, artist, album, year" });
+      if (!hasTitle && !hasArtist && !hasAlbum && !hasYear && !hasGenre) {
+        res.status(400).json({ error: "At least one metadata field is required: title, artist, album, year, genre" });
         return;
       }
 
@@ -353,14 +359,16 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       const parsedArtist = hasArtist ? parseMetadataField(req.body?.artist) : undefined;
       const parsedAlbum = hasAlbum ? parseMetadataField(req.body?.album) : undefined;
       const parsedYear = hasYear ? parseMetadataYearField(req.body?.year) : undefined;
+      const parsedGenre = hasGenre ? parseMetadataGenreField(req.body?.genre) : undefined;
 
       if (parsedTitle === null) { res.status(400).json({ error: "title must be a string or null" }); return; }
       if (parsedArtist === null) { res.status(400).json({ error: "artist must be a string or null" }); return; }
       if (parsedAlbum === null) { res.status(400).json({ error: "album must be a string or null" }); return; }
       if (parsedYear === null) { res.status(400).json({ error: "year must be an integer between 1000 and 2999, or null" }); return; }
+      if (parsedGenre === null) { res.status(400).json({ error: "genre must be an array of strings or null" }); return; }
 
       const currentOverrides = await readTrackMetadataOverrides();
-      const overridePatch: Record<string, { title?: string; artist?: string; album?: string; year?: number }> = {};
+      const overridePatch: Record<string, { title?: string; artist?: string; album?: string; year?: number; genre?: string[] }> = {};
       const updated: string[] = [];
       const notFound: string[] = [];
 
@@ -376,7 +384,8 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
           title: hasTitle ? parsedTitle : current.title,
           artist: hasArtist ? parsedArtist : current.artist,
           album: hasAlbum ? parsedAlbum : current.album,
-          year: hasYear ? parsedYear : current.year
+          year: hasYear ? parsedYear : current.year,
+          genre: hasGenre ? parsedGenre : current.genre
         };
         updated.push(trackId);
       }
@@ -389,7 +398,7 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
         userId: req.authUser?.id ?? "unknown",
         updatedCount: updated.length,
         notFoundCount: notFound.length,
-        fields: [hasTitle && "title", hasArtist && "artist", hasAlbum && "album", hasYear && "year"].filter(Boolean).join(", ")
+        fields: [hasTitle && "title", hasArtist && "artist", hasAlbum && "album", hasYear && "year", hasGenre && "genre"].filter(Boolean).join(", ")
       });
 
       await indexStore.rebuild();

--- a/backend/src/api/queryParsers.ts
+++ b/backend/src/api/queryParsers.ts
@@ -199,3 +199,24 @@ export function parseMetadataYearField(value: unknown): number | undefined | nul
 
   return n;
 }
+
+export function parseMetadataGenreField(value: unknown): string[] | undefined | null {
+  if (value === null) {
+    return undefined;
+  }
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const genres: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") return null;
+    const trimmed = item.trim();
+    if (trimmed) genres.push(trimmed);
+  }
+
+  return genres.length > 0 ? genres : undefined;
+}

--- a/backend/src/api/router.ts
+++ b/backend/src/api/router.ts
@@ -4,6 +4,7 @@ import { IndexStore } from "../services/indexer/indexStore";
 import { createAuthRouter } from "./authRoutes";
 import { createBackupRouter } from "./backupRoutes";
 import { createCoverRouter } from "./coverRoutes";
+import { createGenreRouter } from "./genreRoutes";
 import { createIndexRouter } from "./indexRoutes";
 import { createLibraryRouter } from "./libraryRoutes";
 import { createLogRouter } from "./logRoutes";
@@ -25,6 +26,7 @@ export function createApiRouter(indexStore: IndexStore): Router {
   router.use(createStreamingRouter(indexStore));
   router.use(createCoverRouter(indexStore));
   router.use(createIndexRouter(indexStore));
+  router.use(createGenreRouter(indexStore));
   router.use(createUserRouter());
   router.use(createLogRouter());
   router.use(createServerRouter());

--- a/backend/src/api/trackPipeline.ts
+++ b/backend/src/api/trackPipeline.ts
@@ -103,6 +103,8 @@ export function applyMetadataPatchToTrack(
     album?: string;
     hasYear: boolean;
     year?: number;
+    hasGenre?: boolean;
+    genre?: string[];
   }
 ): Track {
   return {
@@ -112,7 +114,8 @@ export function applyMetadataPatchToTrack(
       ...(patch.hasTitle ? { title: patch.title } : {}),
       ...(patch.hasArtist ? { artist: patch.artist } : {}),
       ...(patch.hasAlbum ? { album: patch.album } : {}),
-      ...(patch.hasYear ? { year: patch.year } : {})
+      ...(patch.hasYear ? { year: patch.year } : {}),
+      ...(patch.hasGenre ? { genre: patch.genre } : {})
     }
   };
 }

--- a/backend/src/api/uploadRoutes.ts
+++ b/backend/src/api/uploadRoutes.ts
@@ -6,6 +6,7 @@ import { Router, type NextFunction, type Response } from "express";
 
 import { requireAuth } from "../auth/middleware";
 import { appendTrackActivityLogEntries, readTrackActivityLog } from "../services/activity/trackActivityStore";
+import { enrichTrackGenre } from "../services/genre/genreEnrichmentService";
 import { mergeTrackMetadataOverrides } from "../services/indexer/metadataOverrideStore";
 import { IndexStore } from "../services/indexer/indexStore";
 
@@ -83,11 +84,22 @@ export function parseUploadMetadataOverrides(value: unknown): UploadMetadataOver
         }
       }
 
+      let genre: string[] | undefined;
+      const rawGenre = (entry as { genre?: unknown }).genre;
+      if (Array.isArray(rawGenre)) {
+        const parsed = rawGenre
+          .filter((g): g is string => typeof g === "string")
+          .map((g) => g.trim())
+          .filter(Boolean);
+        if (parsed.length > 0) genre = parsed;
+      }
+
       return {
         title: normalizeOptionalString((entry as { title?: unknown }).title),
         artist: normalizeOptionalString((entry as { artist?: unknown }).artist),
         album: normalizeOptionalString((entry as { album?: unknown }).album),
-        year
+        year,
+        genre
       };
     });
   } catch {
@@ -239,6 +251,16 @@ async function ingestUploadedFiles(
 
   if (newUploadTracks.length > 0) {
     await appendTrackActivityLogEntries(newUploadTracks);
+  }
+
+  for (const track of newUploadTracks) {
+    if (!track.tags.genre || track.tags.genre.length === 0) {
+      const artist = track.tags.artist;
+      const title = track.tags.title;
+      if (artist && title) {
+        void enrichTrackGenre(track.id, artist, title).catch(() => {});
+      }
+    }
   }
 
   const deduplicated = results.filter((r) => !r.isNew).length;

--- a/backend/src/services/genre/genreEnrichmentService.ts
+++ b/backend/src/services/genre/genreEnrichmentService.ts
@@ -1,0 +1,120 @@
+import type { IndexStore } from "../indexer/indexStore";
+import { mergeTrackMetadataOverrides } from "../indexer/metadataOverrideStore";
+import { lookupGenre } from "./musicBrainzService";
+import { normalizeGenreLabels } from "./genreSynonymService";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("genre-enrichment");
+
+export type EnrichmentStatus = {
+  running: boolean;
+  total: number;
+  processed: number;
+  enriched: number;
+  failed: number;
+  startedAt: string | null;
+};
+
+let status: EnrichmentStatus = {
+  running: false,
+  total: 0,
+  processed: 0,
+  enriched: 0,
+  failed: 0,
+  startedAt: null
+};
+
+let abortController: AbortController | null = null;
+
+export function getEnrichmentStatus(): EnrichmentStatus {
+  return { ...status };
+}
+
+export function stopEnrichment(): void {
+  if (abortController) {
+    abortController.abort();
+    abortController = null;
+  }
+}
+
+export async function enrichTrackGenre(
+  trackId: string,
+  artist: string,
+  title: string
+): Promise<string[] | null> {
+  const rawGenres = await lookupGenre(artist, title);
+  if (rawGenres.length === 0) return null;
+
+  const genres = normalizeGenreLabels(rawGenres);
+  if (genres.length === 0) return null;
+
+  await mergeTrackMetadataOverrides({ [trackId]: { genre: genres } });
+  return genres;
+}
+
+export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<void> {
+  if (status.running) {
+    log.info("Genre enrichment already running, skipping");
+    return;
+  }
+
+  const tracks = indexStore.getTracks();
+  const tracksWithoutGenre = tracks.filter(
+    (t) => !t.tags.genre || t.tags.genre.length === 0
+  );
+
+  if (tracksWithoutGenre.length === 0) {
+    log.info("All tracks have genre metadata, nothing to enrich");
+    return;
+  }
+
+  abortController = new AbortController();
+  const signal = abortController.signal;
+
+  status = {
+    running: true,
+    total: tracksWithoutGenre.length,
+    processed: 0,
+    enriched: 0,
+    failed: 0,
+    startedAt: new Date().toISOString()
+  };
+
+  log.info(`Starting genre enrichment for ${tracksWithoutGenre.length} tracks`);
+
+  for (const track of tracksWithoutGenre) {
+    if (signal.aborted) {
+      log.info("Genre enrichment aborted");
+      break;
+    }
+
+    const artist = track.tags.artist;
+    const title = track.tags.title;
+
+    if (!artist || !title) {
+      status.processed++;
+      continue;
+    }
+
+    try {
+      const genres = await enrichTrackGenre(track.id, artist, title);
+      status.processed++;
+      if (genres) {
+        status.enriched++;
+        log.debug(`Enriched genre for "${title}" by "${artist}": ${genres.join(", ")}`);
+      }
+    } catch (error) {
+      status.processed++;
+      status.failed++;
+      log.warn(`Failed to enrich genre for "${title}" by "${artist}"`, {
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  status.running = false;
+  abortController = null;
+  log.info(
+    `Genre enrichment complete: ${status.enriched} enriched, ${status.failed} failed, ${status.processed} processed out of ${status.total}`
+  );
+}

--- a/backend/src/services/genre/genreSynonymService.ts
+++ b/backend/src/services/genre/genreSynonymService.ts
@@ -1,0 +1,276 @@
+import fs from "node:fs";
+
+import { createLogger } from "../../utils/logger";
+import { configRoot } from "../../utils/paths";
+import path from "node:path";
+
+const log = createLogger("genre-synonyms");
+
+const SYNONYMS_FILE = path.join(configRoot, "genre-synonyms.json");
+
+type SynonymMap = Record<string, string>;
+
+const DEFAULT_SYNONYMS: SynonymMap = {
+  "prog rock": "Progressive Rock",
+  "prog": "Progressive Rock",
+  "synth pop": "Synthpop",
+  "synth-pop": "Synthpop",
+  "synthwave": "Synthwave",
+  "retrowave": "Synthwave",
+  "hiphop": "Hip-Hop",
+  "hip hop": "Hip-Hop",
+  "rap": "Hip-Hop",
+  "r&b": "R&B",
+  "rnb": "R&B",
+  "rhythm and blues": "R&B",
+  "electronica": "Electronic",
+  "electro": "Electronic",
+  "edm": "Electronic",
+  "techno": "Techno",
+  "house music": "House",
+  "deep house": "Deep House",
+  "drum and bass": "Drum & Bass",
+  "dnb": "Drum & Bass",
+  "d&b": "Drum & Bass",
+  "drum n bass": "Drum & Bass",
+  "alt rock": "Alternative Rock",
+  "alt-rock": "Alternative Rock",
+  "alternative": "Alternative Rock",
+  "indie": "Indie Rock",
+  "indie rock": "Indie Rock",
+  "post punk": "Post-Punk",
+  "post-punk": "Post-Punk",
+  "postpunk": "Post-Punk",
+  "shoegaze": "Shoegaze",
+  "shoe gaze": "Shoegaze",
+  "dream pop": "Dream Pop",
+  "dreampop": "Dream Pop",
+  "lo-fi": "Lo-Fi",
+  "lofi": "Lo-Fi",
+  "lo fi": "Lo-Fi",
+  "heavy metal": "Heavy Metal",
+  "metal": "Metal",
+  "thrash metal": "Thrash Metal",
+  "thrash": "Thrash Metal",
+  "death metal": "Death Metal",
+  "black metal": "Black Metal",
+  "doom metal": "Doom Metal",
+  "nu metal": "Nu Metal",
+  "nu-metal": "Nu Metal",
+  "numetal": "Nu Metal",
+  "punk rock": "Punk",
+  "punk": "Punk",
+  "pop punk": "Pop Punk",
+  "pop-punk": "Pop Punk",
+  "classic rock": "Classic Rock",
+  "hard rock": "Hard Rock",
+  "hardrock": "Hard Rock",
+  "blues rock": "Blues Rock",
+  "southern rock": "Southern Rock",
+  "psychedelic rock": "Psychedelic Rock",
+  "psych rock": "Psychedelic Rock",
+  "psychedelic": "Psychedelic Rock",
+  "grunge": "Grunge",
+  "folk": "Folk",
+  "folk rock": "Folk Rock",
+  "country": "Country",
+  "bluegrass": "Bluegrass",
+  "jazz": "Jazz",
+  "smooth jazz": "Smooth Jazz",
+  "bebop": "Bebop",
+  "bossa nova": "Bossa Nova",
+  "soul": "Soul",
+  "funk": "Funk",
+  "disco": "Disco",
+  "reggae": "Reggae",
+  "ska": "Ska",
+  "dub": "Dub",
+  "dancehall": "Dancehall",
+  "classical": "Classical",
+  "orchestral": "Orchestral",
+  "chamber music": "Chamber Music",
+  "ambient": "Ambient",
+  "new age": "New Age",
+  "newage": "New Age",
+  "world": "World Music",
+  "world music": "World Music",
+  "latin": "Latin",
+  "bossa": "Bossa Nova",
+  "flamenco": "Flamenco",
+  "afrobeat": "Afrobeat",
+  "afro beat": "Afrobeat",
+  "k-pop": "K-Pop",
+  "kpop": "K-Pop",
+  "j-pop": "J-Pop",
+  "jpop": "J-Pop",
+  "j-rock": "J-Rock",
+  "jrock": "J-Rock",
+  "trip hop": "Trip-Hop",
+  "trip-hop": "Trip-Hop",
+  "triphop": "Trip-Hop",
+  "downtempo": "Downtempo",
+  "chillout": "Chillout",
+  "chill out": "Chillout",
+  "chill": "Chillout",
+  "idm": "IDM",
+  "industrial": "Industrial",
+  "ebm": "EBM",
+  "noise": "Noise",
+  "experimental": "Experimental",
+  "avant-garde": "Avant-Garde",
+  "avantgarde": "Avant-Garde",
+  "avant garde": "Avant-Garde",
+  "gospel": "Gospel",
+  "christian": "Christian",
+  "worship": "Worship",
+  "soundtrack": "Soundtrack",
+  "ost": "Soundtrack",
+  "film score": "Soundtrack",
+  "score": "Soundtrack",
+  "game music": "Video Game Music",
+  "video game": "Video Game Music",
+  "vgm": "Video Game Music",
+  "chiptune": "Chiptune",
+  "8-bit": "Chiptune",
+  "8bit": "Chiptune",
+  "garage rock": "Garage Rock",
+  "garage": "Garage Rock",
+  "math rock": "Math Rock",
+  "mathrock": "Math Rock",
+  "emo": "Emo",
+  "screamo": "Screamo",
+  "hardcore": "Hardcore",
+  "hardcore punk": "Hardcore",
+  "metalcore": "Metalcore",
+  "deathcore": "Deathcore",
+  "post rock": "Post-Rock",
+  "post-rock": "Post-Rock",
+  "postrock": "Post-Rock",
+  "stoner rock": "Stoner Rock",
+  "stoner": "Stoner Rock",
+  "sludge": "Sludge Metal",
+  "sludge metal": "Sludge Metal",
+  "progressive metal": "Progressive Metal",
+  "prog metal": "Progressive Metal",
+  "power metal": "Power Metal",
+  "symphonic metal": "Symphonic Metal",
+  "folk metal": "Folk Metal",
+  "viking metal": "Viking Metal",
+  "glam rock": "Glam Rock",
+  "glam": "Glam Rock",
+  "new wave": "New Wave",
+  "new-wave": "New Wave",
+  "darkwave": "Darkwave",
+  "dark wave": "Darkwave",
+  "goth": "Gothic",
+  "gothic": "Gothic",
+  "gothic rock": "Gothic Rock",
+  "trance": "Trance",
+  "psytrance": "Psytrance",
+  "psy trance": "Psytrance",
+  "hardstyle": "Hardstyle",
+  "dubstep": "Dubstep",
+  "brostep": "Dubstep",
+  "trap": "Trap",
+  "future bass": "Future Bass",
+  "vaporwave": "Vaporwave",
+  "mallsoft": "Vaporwave",
+  "witch house": "Witch House",
+  "cloud rap": "Cloud Rap",
+  "boom bap": "Boom Bap",
+  "gangsta rap": "Gangsta Rap",
+  "conscious hip-hop": "Conscious Hip-Hop",
+  "conscious rap": "Conscious Hip-Hop",
+  "neo soul": "Neo Soul",
+  "neo-soul": "Neo Soul",
+  "contemporary r&b": "Contemporary R&B",
+  "mpb": "MPB",
+  "samba": "Samba",
+  "cumbia": "Cumbia",
+  "reggaeton": "Reggaeton",
+  "bachata": "Bachata",
+  "salsa": "Salsa",
+  "merengue": "Merengue",
+  "tango": "Tango"
+};
+
+let synonyms: SynonymMap | null = null;
+
+function loadSynonyms(): SynonymMap {
+  if (synonyms) return synonyms;
+
+  try {
+    if (fs.existsSync(SYNONYMS_FILE)) {
+      const raw = fs.readFileSync(SYNONYMS_FILE, "utf8");
+      synonyms = JSON.parse(raw) as SynonymMap;
+      return synonyms;
+    }
+  } catch {
+    log.warn("Failed to load genre synonyms file, using defaults");
+  }
+
+  synonyms = { ...DEFAULT_SYNONYMS };
+  saveSynonyms();
+  return synonyms;
+}
+
+function saveSynonyms(): void {
+  if (!synonyms) return;
+
+  try {
+    fs.mkdirSync(path.dirname(SYNONYMS_FILE), { recursive: true });
+    const sorted = Object.fromEntries(
+      Object.entries(synonyms).sort(([a], [b]) => a.localeCompare(b))
+    );
+    fs.writeFileSync(SYNONYMS_FILE, JSON.stringify(sorted, null, 2), "utf8");
+  } catch (error) {
+    log.warn("Failed to save genre synonyms", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+export function normalizeGenreLabel(genre: string): string {
+  const map = loadSynonyms();
+  const key = genre.trim().toLowerCase();
+  return map[key] ?? genre.trim();
+}
+
+export function normalizeGenreLabels(genres: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const genre of genres) {
+    const normalized = normalizeGenreLabel(genre);
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(normalized);
+  }
+
+  return result;
+}
+
+export function getSynonyms(): SynonymMap {
+  return { ...loadSynonyms() };
+}
+
+export function setSynonym(from: string, to: string): void {
+  const map = loadSynonyms();
+  map[from.trim().toLowerCase()] = to.trim();
+  saveSynonyms();
+}
+
+export function removeSynonym(from: string): boolean {
+  const map = loadSynonyms();
+  const key = from.trim().toLowerCase();
+  if (!(key in map)) return false;
+  delete map[key];
+  saveSynonyms();
+  return true;
+}
+
+export function resetSynonymsToDefaults(): void {
+  synonyms = { ...DEFAULT_SYNONYMS };
+  saveSynonyms();
+}

--- a/backend/src/services/genre/musicBrainzService.ts
+++ b/backend/src/services/genre/musicBrainzService.ts
@@ -1,0 +1,219 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { cacheRoot } from "../../utils/paths";
+
+const log = createLogger("musicbrainz");
+
+const MB_BASE_URL = "https://musicbrainz.org/ws/2";
+const RATE_LIMIT_MS = 1100;
+const REQUEST_TIMEOUT_MS = 15_000;
+const CACHE_FILE = path.join(cacheRoot, "musicbrainz-genre-cache.json");
+
+function readVersion(): string {
+  try {
+    const pkgPath = path.resolve(process.cwd(), "package.json");
+    const raw = fs.readFileSync(pkgPath, "utf8");
+    const pkg = JSON.parse(raw) as { version?: string };
+    return pkg.version ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+const USER_AGENT = `flaque/${readVersion()} (https://github.com/Marma92/flaque)`;
+
+type GenreCache = Record<string, string[]>;
+
+let cache: GenreCache | null = null;
+let lastRequestTime = 0;
+let queue: Array<{
+  artist: string;
+  title: string;
+  resolve: (genres: string[]) => void;
+}> = [];
+let processing = false;
+
+function cacheKey(artist: string, title: string): string {
+  return `${artist.toLowerCase().trim()}|||${title.toLowerCase().trim()}`;
+}
+
+function loadCache(): GenreCache {
+  if (cache) return cache;
+
+  try {
+    if (fs.existsSync(CACHE_FILE)) {
+      const raw = fs.readFileSync(CACHE_FILE, "utf8");
+      cache = JSON.parse(raw) as GenreCache;
+      return cache;
+    }
+  } catch {
+    log.warn("Failed to load MusicBrainz genre cache, starting fresh");
+  }
+
+  cache = {};
+  return cache;
+}
+
+function saveCache(): void {
+  if (!cache) return;
+
+  try {
+    fs.mkdirSync(path.dirname(CACHE_FILE), { recursive: true });
+    fs.writeFileSync(CACHE_FILE, JSON.stringify(cache, null, 2), "utf8");
+  } catch (error) {
+    log.warn("Failed to save MusicBrainz genre cache", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+async function waitForRateLimit(): Promise<void> {
+  const now = Date.now();
+  const elapsed = now - lastRequestTime;
+  if (elapsed < RATE_LIMIT_MS) {
+    await new Promise((resolve) => setTimeout(resolve, RATE_LIMIT_MS - elapsed));
+  }
+  lastRequestTime = Date.now();
+}
+
+type MBRecording = {
+  id?: string;
+  tags?: Array<{ name?: string; count?: number }>;
+  genres?: Array<{ name?: string; count?: number }>;
+};
+
+type MBSearchResult = {
+  recordings?: MBRecording[];
+};
+
+type MBRecordingDetail = {
+  genres?: Array<{ name?: string; count?: number }>;
+  tags?: Array<{ name?: string; count?: number }>;
+};
+
+function extractGenres(recording: MBRecording | MBRecordingDetail): string[] {
+  const genres: string[] = [];
+  const seen = new Set<string>();
+
+  const sources = [recording.genres ?? [], recording.tags ?? []];
+  for (const source of sources) {
+    for (const entry of source) {
+      if (typeof entry.name !== "string" || !entry.name.trim()) continue;
+      const normalized = entry.name.trim().toLowerCase();
+      if (seen.has(normalized)) continue;
+      seen.add(normalized);
+      const titleCased = normalized
+        .split(/[\s-]+/)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(" ");
+      genres.push(titleCased);
+    }
+  }
+
+  return genres;
+}
+
+async function fetchGenresForRecording(artist: string, title: string): Promise<string[]> {
+  await waitForRateLimit();
+
+  const query = `recording:"${title}" AND artist:"${artist}"`;
+  const searchUrl = `${MB_BASE_URL}/recording?query=${encodeURIComponent(query)}&fmt=json&limit=3`;
+
+  try {
+    const searchResponse = await fetch(searchUrl, {
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    });
+
+    if (!searchResponse.ok) {
+      log.warn(`MusicBrainz search returned ${searchResponse.status}`, {
+        artist,
+        title
+      });
+      return [];
+    }
+
+    const searchData = (await searchResponse.json()) as MBSearchResult;
+    const recordings = searchData.recordings ?? [];
+
+    if (recordings.length === 0) return [];
+
+    const firstRecording = recordings[0]!;
+    const searchGenres = extractGenres(firstRecording);
+    if (searchGenres.length > 0) return searchGenres;
+
+    if (!firstRecording.id) return [];
+
+    await waitForRateLimit();
+
+    const detailUrl = `${MB_BASE_URL}/recording/${firstRecording.id}?inc=genres+tags&fmt=json`;
+    const detailResponse = await fetch(detailUrl, {
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    });
+
+    if (!detailResponse.ok) return [];
+
+    const detailData = (await detailResponse.json()) as MBRecordingDetail;
+    return extractGenres(detailData);
+  } catch (error) {
+    log.warn("MusicBrainz lookup failed", {
+      artist,
+      title,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return [];
+  }
+}
+
+async function processQueue(): Promise<void> {
+  if (processing) return;
+  processing = true;
+
+  while (queue.length > 0) {
+    const item = queue.shift()!;
+    const key = cacheKey(item.artist, item.title);
+    const c = loadCache();
+
+    if (key in c) {
+      item.resolve(c[key] ?? []);
+      continue;
+    }
+
+    const genres = await fetchGenresForRecording(item.artist, item.title);
+    c[key] = genres;
+    saveCache();
+    item.resolve(genres);
+  }
+
+  processing = false;
+}
+
+export function lookupGenre(artist: string, title: string): Promise<string[]> {
+  if (!artist.trim() || !title.trim()) {
+    return Promise.resolve([]);
+  }
+
+  const c = loadCache();
+  const key = cacheKey(artist, title);
+  if (key in c) {
+    return Promise.resolve(c[key] ?? []);
+  }
+
+  return new Promise<string[]>((resolve) => {
+    queue.push({ artist, title, resolve });
+    void processQueue();
+  });
+}
+
+export function getGenreCacheStats(): { entries: number } {
+  const c = loadCache();
+  return { entries: Object.keys(c).length };
+}
+
+export function clearGenreCache(): void {
+  cache = {};
+  saveCache();
+}

--- a/backend/src/services/indexer/metadataOverrideStore.ts
+++ b/backend/src/services/indexer/metadataOverrideStore.ts
@@ -6,6 +6,7 @@ export type TrackMetadataOverride = {
   artist?: string;
   album?: string;
   year?: number;
+  genre?: string[];
 };
 
 type TrackMetadataOverridesMap = Record<string, TrackMetadataOverride>;
@@ -26,6 +27,20 @@ function normalizeYear(value: unknown): number | undefined {
   return n;
 }
 
+function normalizeGenre(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value)) return undefined;
+
+  const genres: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const trimmed = item.trim();
+    if (trimmed) genres.push(trimmed);
+  }
+
+  return genres.length > 0 ? genres : undefined;
+}
+
 function normalizeOverride(override: unknown): TrackMetadataOverride | undefined {
   if (!override || typeof override !== "object") {
     return undefined;
@@ -36,8 +51,9 @@ function normalizeOverride(override: unknown): TrackMetadataOverride | undefined
   const album = normalizeField(record.album);
   const title = normalizeField(record.title);
   const year = normalizeYear(record.year);
+  const genre = normalizeGenre(record.genre);
 
-  if (!title && !artist && !album && year === undefined) {
+  if (!title && !artist && !album && year === undefined && !genre) {
     return undefined;
   }
 
@@ -45,7 +61,8 @@ function normalizeOverride(override: unknown): TrackMetadataOverride | undefined
     title,
     artist,
     album,
-    year
+    year,
+    genre
   };
 }
 
@@ -105,7 +122,8 @@ export async function mergeTrackMetadataOverrides(
       existing?.title === cleanOverride.title &&
       existing?.artist === cleanOverride.artist &&
       existing?.album === cleanOverride.album &&
-      existing?.year === cleanOverride.year
+      existing?.year === cleanOverride.year &&
+      JSON.stringify(existing?.genre) === JSON.stringify(cleanOverride.genre)
     ) {
       continue;
     }

--- a/backend/src/services/upload/uploadService.ts
+++ b/backend/src/services/upload/uploadService.ts
@@ -34,13 +34,14 @@ export type UploadMetadataOverride = {
   artist?: string;
   album?: string;
   year?: number;
+  genre?: string[];
 };
 
 export type ProcessedUpload = {
   trackId: string;
   track: Track;
   isNew: boolean;
-  overrides?: { title?: string; artist?: string; album?: string; year?: number };
+  overrides?: { title?: string; artist?: string; album?: string; year?: number; genre?: string[] };
 };
 
 export function sanitizeExtension(fileName: string): string {
@@ -76,17 +77,18 @@ function resolveEffectiveOverrides(
   manualArtist: string | undefined,
   manualAlbum: string | undefined,
   manualYear: number | undefined
-): { title?: string; artist?: string; album?: string; year?: number } | undefined {
+): { title?: string; artist?: string; album?: string; year?: number; genre?: string[] } | undefined {
   const effectiveTitle = override.title;
   const effectiveArtist = override.artist ?? manualArtist;
   const effectiveAlbum = override.album ?? manualAlbum;
   const effectiveYear = override.year ?? manualYear;
+  const effectiveGenre = override.genre;
 
-  if (!effectiveTitle && !effectiveArtist && !effectiveAlbum && effectiveYear === undefined) {
+  if (!effectiveTitle && !effectiveArtist && !effectiveAlbum && effectiveYear === undefined && !effectiveGenre) {
     return undefined;
   }
 
-  return { title: effectiveTitle, artist: effectiveArtist, album: effectiveAlbum, year: effectiveYear };
+  return { title: effectiveTitle, artist: effectiveArtist, album: effectiveAlbum, year: effectiveYear, genre: effectiveGenre };
 }
 
 async function ensureArtistDirectory(artistDir: string, artistName: string): Promise<void> {
@@ -188,7 +190,8 @@ export async function processUploadedFile(
     ...(overrides?.title ? { title: overrides.title } : {}),
     ...(overrides?.artist ? { artist: overrides.artist } : {}),
     ...(overrides?.album ? { album: overrides.album } : {}),
-    ...(overrides?.year !== undefined ? { year: overrides.year } : {})
+    ...(overrides?.year !== undefined ? { year: overrides.year } : {}),
+    ...(overrides?.genre ? { genre: overrides.genre } : {})
   };
 
   const track: Track = {

--- a/docs/roadmap-playlist-remake.md
+++ b/docs/roadmap-playlist-remake.md
@@ -1,0 +1,481 @@
+# Playlist Remake Roadmap
+
+**Target version**: 0.3.0
+**Codename**: TBD
+**Status**: Planning
+
+---
+
+## Overview
+
+A ground-up rethinking of how playlists work in flaque. The goal is to go from a flat list of user-created playlists to a rich, categorized experience with three distinct playlist families: personal playlists, community-curated popular playlists, and server-generated automatic playlists powered by genre and listening habits.
+
+This roadmap is organized in 7 phases. Each phase is designed to land as a shippable increment, but later phases depend on earlier ones being complete.
+
+---
+
+## Dependency graph
+
+```
+Phase 1 (Genre)  ──────────────────────────┐
+                                            ├──> Phase 5 (Auto playlists)
+Phase 2 (Play tracking) ──┬────────────────┤
+                           │                └──> Phase 6 (Smart "For You")
+                           ├──> Phase 3 (Hearts & listen counts)
+                           │         │
+                           │         └──> Phase 4 (Playlist view overhaul)
+                           │                        │
+Phase 7 (Drag-and-drop) ───────────────────────────┘
+```
+
+Phases 1 and 2 have no dependency on each other and can be worked in parallel.
+Phase 7 (drag-and-drop) is independent and can be done at any point.
+
+---
+
+## Resolved design decisions
+
+These were discussed during planning and are final:
+
+1. **Genre synonym mapping**: Hardcoded default shipped with a solid base mapping (usable as-is). Admin override available in settings for fine-tuning by server owners.
+2. **Auto playlist configuration**: Admin-configurable via settings — both the maximum number of auto playlists generated and the minimum number of tracks per playlist.
+3. **"For You" dismissal**: Users can dismiss a "For You" playlist. A dismissal is treated as a strong signal and recorded per-user. The dismissed playlist will not be suggested again for **3 months**, after which it may reappear if the user's listening habits still warrant it.
+4. **Playlist descriptions**: Added to scope. An optional `description` field on `playlist.json`, shown on the detail page. Users can write a short description for their playlists.
+5. **Custom playlist cover**: Added to scope. Users can upload a custom cover image for their playlist, replacing the automatic mosaic patchwork when set.
+6. **Collaborative playlists**: In scope architecturally. The playlist model will include a `collaborators: string[]` field from the start. Collaborators can add/remove/reorder tracks but cannot delete the playlist or change its settings. Full collaborative playlist features are a future milestone but the data model must accommodate them now.
+
+---
+
+## Phase 1 — Genre infrastructure
+
+**Goal**: Every track in the library has genre metadata, either extracted from the file, manually set, or enriched via MusicBrainz. This is the foundation for automatic playlists.
+
+### 1a. Extend metadata overrides to support genre
+
+**What changes**:
+- Add `genre?: string[]` to `TrackMetadataOverride` in `metadataOverrideStore.ts`
+- Add `genre?: string[]` to `TrackMetadataPatch` (the frontend-facing patch type)
+- Update `uploadService.ts` to pass genre through the override pipeline
+- Update the single-track and bulk metadata edit APIs to accept genre patches
+- Update the frontend metadata edit forms (single track edit in admin, bulk edit) to show and edit genre as a comma-separated tag input
+
+**What already exists**:
+- `TrackTags.genre` is already `string[]` — the type is ready
+- `audioProbe.ts` already extracts genre from file metadata via `music-metadata`
+- The override system works for title/artist/album/year — genre follows the same pattern
+
+**Considerations**:
+- Genre values from files are freeform strings (e.g. "Progressive Rock", "Prog Rock", "prog-rock"). A lightweight normalization step (trim, title-case) during extraction would reduce fragmentation without losing user intent.
+- No genre taxonomy is enforced — users can set any value. Normalization only applies to auto-extracted and MusicBrainz-enriched values.
+
+### 1b. MusicBrainz genre lookup service
+
+**What to build**:
+- New service: `backend/src/services/genre/musicBrainzService.ts`
+- Query the [MusicBrainz API](https://musicbrainz.org/doc/MusicBrainz_API) to find genre tags for a recording, searching by artist + title
+- Lookup chain: search recordings → fetch recording details → read genre/tag data
+- Must respect MusicBrainz rate limit: **1 request per second** (mandatory). Use a serial queue with delay.
+- Set a proper `User-Agent` header as required by MusicBrainz API policy (e.g. `flaque/<version> (https://github.com/Marma92/flaque)`)
+- Return normalized genre strings or an empty array if nothing is found
+- Cache results to disk (simple JSON map `artist+title → genres`) to avoid redundant lookups
+
+**Technical notes**:
+- MusicBrainz is fully open, no API key required for moderate usage — fits a self-hosted server perfectly
+- The lookup is best-effort: if MusicBrainz doesn't have the recording, the track simply stays without genre
+- Endpoint: `https://musicbrainz.org/ws/2/recording?query=artist:{artist}+recording:{title}&fmt=json`
+
+### 1c. Genre synonym mapping
+
+**What to build**:
+- A hardcoded default synonym map shipped with the server (e.g. `"prog rock" → "progressive rock"`, `"synth pop" → "synthpop"`, `"hiphop" → "hip-hop"`). The default must be solid enough to use as-is.
+- An admin settings UI to view, add, edit, or remove synonym entries — positioned as fine-tuning for server owners, not something regular users need to touch.
+- Storage: `data/config/genre-synonyms.json`. On first boot, seeded from the hardcoded defaults. Admin edits modify this file.
+- Applied during: MusicBrainz enrichment, auto playlist grouping, and genre display normalization. **Not** applied to raw file metadata or user-set overrides (those stay as-is; normalization is at read/display time).
+
+### 1d. Auto-enrichment pipeline
+
+**What to build**:
+- **On upload**: After metadata extraction, if `tags.genre` is empty or missing, queue the track for MusicBrainz lookup. If a result is found, store it via the metadata override system.
+- **Background scan**: A one-time (or on-demand) job that scans all existing tracks with missing genre and attempts MusicBrainz enrichment. This handles the existing library backlog.
+- Enriched genres are stored as metadata overrides, meaning they can be manually corrected by the user at any time.
+
+**Considerations**:
+- The background scan can be slow due to rate limiting (1 req/sec). For a library of 1000 tracks missing genre, that's ~17 minutes. This should run as a non-blocking background task with progress logging.
+- A "genre enrichment status" indicator in the admin panel would be useful (e.g. "342/1200 tracks have genre metadata").
+
+### 1e. Genre display in the UI
+
+**What to build**:
+- Show genre tags on the track detail displays (track list rows, album track views)
+- Show genre in upload preview (already extracted, just needs rendering)
+- Genre editing in the single-track metadata edit modal and bulk edit modal
+- Genre display as small pill/badge components (similar to the lyrics "L" badge pattern already in use)
+
+---
+
+## Phase 2 — Playback tracking
+
+**Goal**: Know what each user listens to and how much. This powers popular playlist ranking and personalized automatic playlists.
+
+### 2a. Per-user play counter store
+
+**What to build**:
+- New store: `backend/src/services/activity/playCountStore.ts`
+- Storage: one JSON file per user at `data/users/{userId}/play-counts.json`
+- Schema:
+  ```json
+  {
+    "tracks": {
+      "track-id-1": { "count": 42, "lastPlayedAt": "2026-04-12T10:30:00Z" },
+      "track-id-2": { "count": 7, "lastPlayedAt": "2026-04-11T22:15:00Z" }
+    }
+  }
+  ```
+- Functions: `incrementPlayCount(userId, trackId)`, `getUserPlayCounts(userId)`, `getUserTopArtists(userId, limit)`
+- `getUserTopArtists` aggregates play counts by artist name (from the track index) and returns the top N
+
+**Why `lastPlayedAt`**: It's lightweight to store alongside the counter and enables potential "recently played" features without needing a separate system.
+
+### 2b. Play event endpoint
+
+**What to build**:
+- New endpoint: `POST /api/tracks/:id/play`
+- Called by the frontend when a track starts playing (or after a short threshold, e.g. 10 seconds, to avoid counting skips)
+- Increments the per-user play counter
+- Authenticated — userId comes from the session
+- Returns 204 (no body) — fire-and-forget from the frontend's perspective
+
+**Frontend integration**:
+- The audio player component calls this endpoint when playback begins (with a small debounce to avoid double-counting on seek/restart)
+- No UI impact — this is a background signal
+
+### 2c. Play stats API
+
+**What to build**:
+- `GET /api/me/play-stats` — returns the current user's top tracks and top artists (derived from play counts)
+- Used later by the smart playlist generator (Phase 6) and potentially by an "About you" section in the account view
+
+---
+
+## Phase 3 — Playlist model expansion
+
+**Goal**: Playlists carry engagement data, rich metadata, and a collaboration-ready structure.
+
+**Depends on**: Phase 2 (play tracking provides the listen-count signal)
+
+### 3a. Extend playlist.json schema
+
+**What changes**:
+- Expand `playlist.json` on disk with new fields:
+  ```json
+  {
+    "name": "My Metal Playlist",
+    "visibility": "public",
+    "description": "The best of thrash and prog metal from my collection.",
+    "cover": "playlists/my-metal/cover.jpg",
+    "hearts": ["user-id-1", "user-id-2"],
+    "listenCount": 47,
+    "collaborators": []
+  }
+  ```
+- `description`: optional free-text string. Displayed on the playlist detail page.
+- `cover`: optional path to a custom cover image uploaded by the playlist owner. When set, replaces the automatic mosaic patchwork.
+- `hearts`: array of user IDs. One heart per user, enforced at the API level. Since flaque servers are small-scale, storing full user IDs is fine and enables reliable toggle behavior.
+- `listenCount`: integer, incremented when a user plays the playlist.
+- `collaborators`: array of user IDs who can add/remove/reorder tracks but cannot delete the playlist or change its settings. Initially empty for all playlists — the field exists to make the model future-proof.
+- Update `PlaylistMetadata` type in `playlistStore.ts` to include these fields.
+- Update `readPlaylistMetadata` to parse them (defaulting to `""`, `null`, `[]`, `0`, `[]` for existing playlists — seamless migration).
+- Update `writePlaylistContents` to persist them.
+
+### 3b. Update the Playlist type
+
+**What changes**:
+- Add to the shared `Playlist` type in `types/library.ts`:
+  ```typescript
+  description: string;
+  cover: string | null;
+  hearts: string[];
+  heartCount: number;      // derived, for convenience
+  listenCount: number;
+  collaborators: string[];
+  ```
+- Update `scanFilesystemPlaylists` to populate these fields
+- Update `mapPlaylistResponse` in `playlistRoutes.ts` to include them in API responses
+- Update the frontend `Playlist` type to match
+- Update `canManagePlaylist` to also return true if the user is in `collaborators` (for track editing only — not for settings or deletion)
+
+### 3c. Heart/unheart API
+
+**What to build**:
+- `POST /api/playlists/:id/heart` — toggles the heart for the current user (add if absent, remove if present)
+- Only works on **user-created playlists** (not automatic playlists)
+- Updates `playlist.json` on disk, refreshes the playlist index
+- Returns the updated heart count and whether the current user has hearted it
+- Only public playlists from other users can be hearted (you can't heart your own playlist)
+
+### 3d. Playlist listen count tracking
+
+**What to build**:
+- `POST /api/playlists/:id/listen` — increments the listen count
+- Called by the frontend when a user starts playing a playlist (first track begins)
+- Debounced: at most one listen per user per playlist per hour (to avoid inflation from repeated plays)
+- Updates `playlist.json` on disk
+
+### 3e. Playlist cover upload
+
+**What to build**:
+- `POST /api/playlists/:id/cover` — upload a custom cover image (multipart/form-data)
+- Only the playlist owner (or admin) can upload a cover
+- Store the image in the playlist directory (e.g. `playlists/{slug}/cover.jpg`)
+- Resize/optimize on upload (same approach as existing profile photo upload)
+- `DELETE /api/playlists/:id/cover` — remove the custom cover, reverting to auto mosaic
+- Update the `cover` field in `playlist.json`
+- Frontend: cover upload button in the playlist edit modal / detail view
+
+### 3f. Playlist description editing
+
+**What to build**:
+- Add `description` to the PATCH `/api/playlists/:id` endpoint (already partially supports arbitrary fields)
+- Frontend: text area in the playlist edit modal
+- Display on the playlist detail page (Phase 4), below the playlist name
+
+---
+
+## Phase 4 — Playlist view overhaul
+
+**Goal**: Replace the flat playlist list with a categorized layout and a dedicated detail page.
+
+**Depends on**: Phase 3 (hearts, listen counts, descriptions, and covers must exist)
+
+### 4a. Dedicated playlist detail route
+
+**What to build**:
+- New route: `/library/playlists/:id`
+- New page component: `PlaylistDetailView.tsx`
+- Content:
+  - Playlist cover: custom cover if set, otherwise auto mosaic (large)
+  - Playlist name, description (if set), author name, visibility badge
+  - Heart button with count (if public playlist from another user)
+  - Listen count display
+  - Track count and total duration
+  - Full track list with playback controls (play track, add to queue)
+  - Play all / Shuffle buttons
+  - Edit button (if owner, collaborator, or admin) — opens the edit modal
+  - Collaborator list (if any)
+  - Back navigation to playlist section
+- Clicking a playlist card anywhere in the app navigates to this route instead of expanding inline
+
+**Routing changes**:
+- Add `"library/playlists/:id"` to the `PATH_MAP` in `appUtils.ts`
+- The route parameter needs to be parsed by `getRouteFromLocation` — this may require a small refactor to support dynamic segments (currently all routes are static)
+- Alternative: use a query param approach (`/library/playlists?id=...`) to avoid refactoring the router. Both work; the clean URL is nicer.
+
+### 4b. Three-section playlist layout
+
+**What to build**:
+- Refactor `LibraryPlaylistSection.tsx` into three distinct sections:
+
+**"My Playlists"**:
+- Shows playlists where `authorId === currentUser.id` (both private and public)
+- Includes the "Create playlist" form (moved here from the top of the current section)
+- Playlist cards link to the detail view
+
+**"Popular Playlists"**:
+- Shows public playlists where `authorId !== currentUser.id`
+- Sorted by a composite score: `heartCount * 3 + listenCount` (hearts weigh more because they're intentional; listens accumulate passively)
+- Each card shows heart count and listen count badges
+- If no public playlists from other users exist, this section is hidden
+
+**"Automatic Playlists"**:
+- Shows server-generated playlists (Phase 5)
+- Different visual treatment (e.g. gradient or subtle background pattern to distinguish from user playlists)
+- Cannot be hearted
+- Placeholder until Phase 5 is implemented: "Automatic playlists will appear here once generated"
+
+### 4c. Playlist card redesign
+
+**What to build**:
+- Redesign playlist cards to work as navigation links rather than expandable containers
+- Show: cover (custom or mosaic), name, author, track count, heart count badge, listen count badge
+- Click navigates to `/library/playlists/:id`
+- Play button on hover/focus starts playback without navigating
+- Compact grid layout (2-3 columns on desktop) instead of the current stacked list
+
+---
+
+## Phase 5 — Automatic genre/decade playlists
+
+**Goal**: The server generates thematic playlists by combining genre and decade (e.g. "70s Rock", "90s Pop", "80s Disco"). Regenerated every 2 weeks, configurable by admins.
+
+**Depends on**: Phase 1 (genre infrastructure must be in place)
+
+### 5a. Playlist generation algorithm
+
+**What to build**:
+- New service: `backend/src/services/playlists/autoPlaylistService.ts`
+- Scan all tracks in the library, group by `(genre, decade)` pairs
+  - Decade derived from `tags.year`: `Math.floor(year / 10) * 10` → "70s", "80s", etc.
+  - Genre taken from the first entry of `tags.genre[]` (primary genre), normalized via the synonym map (Phase 1c)
+  - Tracks with no genre or no year are excluded
+- For each `(genre, decade)` pair with enough tracks (minimum threshold: **admin-configurable**, default 8), generate a playlist:
+  - Name: `"{Decade} {Genre}"` (e.g. "70s Rock", "90s Pop")
+  - Select tracks up to a configurable max (default 30) using a diversity algorithm (spread across artists, avoid same-album clustering — reuse ideas from the radio's `pickBestCandidate`)
+  - Store track IDs in order
+
+**Genre normalization**:
+- Apply the synonym map from Phase 1c before grouping
+- Title-case the display name
+
+### 5b. Admin configuration
+
+**What to build**:
+- New admin settings section or entries within the existing settings:
+  - **Maximum number of auto playlists**: caps how many genre/decade playlists are generated (default: unlimited / all qualifying pairs)
+  - **Minimum tracks per playlist**: the threshold below which a genre/decade pair is skipped (default: 8)
+  - **Tracks per playlist**: max tracks selected per auto playlist (default: 30)
+- Stored in `data/config/auto-playlist-config.json`
+- Exposed via admin API: `GET/PATCH /api/config/auto-playlists`
+
+### 5c. Storage and lifecycle
+
+**What to build**:
+- Storage directory: `data/auto-playlists/`
+- Each auto-playlist stored as a JSON file:
+  ```json
+  {
+    "id": "auto:70s-rock",
+    "name": "70s Rock",
+    "genre": "rock",
+    "decade": 1970,
+    "trackIds": ["track-1", "track-2", ...],
+    "generatedAt": "2026-04-12T00:00:00Z",
+    "trackCount": 25
+  }
+  ```
+- Metadata file: `data/auto-playlists/_meta.json` storing `{ lastGeneratedAt: string }`
+- **Regeneration schedule**: Every 2 weeks. On server boot, check if `lastGeneratedAt` is older than 14 days — if so, regenerate all auto playlists.
+- Regeneration replaces all auto playlists (full rebuild). This naturally picks up new tracks added since the last generation.
+- Admin API: `POST /api/playlists/automatic/regenerate` to force regeneration on demand
+
+### 5d. Auto playlist API
+
+**What to build**:
+- `GET /api/playlists/automatic` — list all auto playlists (returns id, name, genre, decade, trackCount, generatedAt)
+- `GET /api/playlists/automatic/:id` — get a single auto playlist with full track IDs (resolved against the index for track details)
+- Auto playlists are **read-only** — no edit, no delete, no heart
+- Auto playlists are visible to all authenticated users
+
+### 5e. Frontend integration
+
+**What to build**:
+- Fetch auto playlists via the API and display in the "Automatic Playlists" section
+- Auto playlist cards use a distinct visual style (genre-colored accent or icon)
+- Clicking navigates to a detail view (reuse `PlaylistDetailView` with a read-only mode flag)
+- Show "Generated on {date}" instead of an author name
+
+---
+
+## Phase 6 — Smart "For You" playlists
+
+**Goal**: Personalized automatic playlists based on what each user listens to most. "Because you listen to {Artist}" style.
+
+**Depends on**: Phase 1 (genre data) + Phase 2 (play tracking) + Phase 5 (auto playlist infrastructure)
+
+### 6a. User listening analysis
+
+**What to build**:
+- Extend `playCountStore.ts` with a `getUserTopArtists(userId, limit)` function:
+  - Read the user's play counts
+  - Join with the track index to get artist names
+  - Aggregate by artist, return top N by total play count
+- Minimum threshold: only generate a "For You" playlist if the user has at least **20 total plays** across at least **3 distinct artists** (avoids noisy recommendations for new users)
+
+### 6b. Similar-track matching
+
+**What to build**:
+- For each of the user's top 3 artists:
+  - Look up the artist's genre(s) and typical decade range from the library
+  - Find other tracks in the library that share the same genre and are within ±10 years
+  - Exclude tracks by the seed artist (they'll be mixed back in)
+- Build a playlist of ~25 tracks:
+  - ~40% from the seed artist
+  - ~60% from genre/era peers
+  - Use the same diversity algorithm as Phase 5 to avoid clustering
+
+### 6c. "For You" playlist generation
+
+**What to build**:
+- Generate one "For You" playlist per qualifying top artist, per user
+- Naming: `"Because you listen to {Artist}"`
+- Storage: alongside auto playlists in `data/auto-playlists/for-you/{userId}/`
+- Regenerated on the same 2-week schedule as genre/decade playlists
+- Displayed in the "Automatic Playlists" section, visually distinguished (e.g. "Made for you" label)
+
+### 6d. Dismissal system
+
+**What to build**:
+- Per-user dismissal store: `data/users/{userId}/dismissed-playlists.json`
+- Schema:
+  ```json
+  {
+    "dismissed": [
+      { "playlistId": "for-you:pink-floyd", "dismissedAt": "2026-04-12T10:00:00Z" }
+    ]
+  }
+  ```
+- When the user dismisses a "For You" playlist, record the dismissal with a timestamp
+- During playlist generation and display, skip playlists that were dismissed less than **3 months** ago
+- After 3 months, the dismissal expires and the playlist may reappear if listening habits still warrant it
+- Frontend: a dismiss/hide button on "For You" playlist cards (e.g. "×" or "Not interested")
+- Dismissals only apply to "For You" playlists, not genre/decade auto playlists
+
+### 6e. (Optional) MusicBrainz artist relationships
+
+**Enhancement** (can be deferred):
+- Query MusicBrainz for artists related to the seed artist
+- Cross-reference with the local library to find matching tracks
+- This improves recommendations when the library has artists that are related but don't share exact genre tags
+
+---
+
+## Phase 7 — Drag-and-drop track reordering
+
+**Goal**: Replace the move-up/move-down buttons in the playlist edit modal with drag-and-drop.
+
+**No dependencies** — can be done at any point.
+
+### 7a. Library selection
+
+**Recommended**: [`@dnd-kit`](https://dndkit.com/)
+- Modern, accessible, well-maintained
+- Built specifically for React
+- ~12 KB gzipped (core + sortable)
+- Supports keyboard reordering (accessibility)
+- Touch-friendly for mobile
+
+Alternative: `@atlaskit/pragmatic-drag-and-drop` (Atlassian's library). Heavier but very polished.
+
+### 7b. Implementation
+
+**What to build**:
+- Replace the move-up/move-down buttons in `EditModal` (inside `LibraryPlaylistSection.tsx`) with a `@dnd-kit` `SortableContext`
+- Each track row gets a drag handle (grip icon on the left)
+- Visual feedback: dragged item has a shadow/elevation, drop target shows an insertion indicator
+- On drop: update `trackIds` array in state
+- Keep the remove button per track
+- Mobile: touch-drag works out of the box with `@dnd-kit`
+- Keyboard: arrow keys to move items when focused on the drag handle (built into `@dnd-kit`)
+
+---
+
+## Summary table
+
+| Phase | Name | Depends on | Estimated scope |
+|-------|------|-----------|----------------|
+| 1 | Genre infrastructure | — | Medium |
+| 2 | Playback tracking | — | Small |
+| 3 | Playlist model expansion | Phase 2 | Medium |
+| 4 | Playlist view overhaul | Phase 3 | Large |
+| 5 | Automatic playlists | Phase 1 | Medium–Large |
+| 6 | Smart "For You" playlists | Phases 1, 2, 5 | Medium |
+| 7 | Drag-and-drop reordering | — | Small |

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -311,6 +311,7 @@ export type UploadTracksInput = {
     artist?: string;
     album?: string;
     year?: number;
+    genre?: string[];
   } | null>;
   onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
 };
@@ -349,6 +350,7 @@ type UploadSingleTrackInput = {
     artist?: string;
     album?: string;
     year?: number;
+    genre?: string[];
   } | null;
   onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
 };

--- a/frontend/src/components/ConfigView.tsx
+++ b/frontend/src/components/ConfigView.tsx
@@ -39,10 +39,12 @@ type BulkEditState = {
   artist: string;
   album: string;
   year: string;
+  genre: string;
   commonTitle: string | undefined;
   commonArtist: string | undefined;
   commonAlbum: string | undefined;
   commonYear: string | undefined;
+  commonGenre: string | undefined;
 };
 
 function computeCommonField(tracks: Track[], getter: (t: Track) => string | undefined): string | undefined {
@@ -156,7 +158,8 @@ export function ConfigView({
       title: track.tags.title ?? "",
       artist: track.tags.artist ?? "",
       album: track.tags.album ?? "",
-      year: track.tags.year != null ? String(track.tags.year) : ""
+      year: track.tags.year != null ? String(track.tags.year) : "",
+      genre: track.tags.genre?.join(", ") ?? ""
     });
   }
 
@@ -179,11 +182,17 @@ export function ConfigView({
       const yearValue = editState.year.trim();
       const parsedYear = yearValue ? Number(yearValue) : null;
 
+      const genreValue = editState.genre.trim();
+      const parsedGenre: string[] | null = genreValue
+        ? genreValue.split(",").map((g) => g.trim()).filter(Boolean)
+        : null;
+
       await onUpdateTrackMetadata(editState.track.id, {
         title: editState.title.trim() || null,
         artist: editState.artist.trim() || null,
         album: editState.album.trim() || null,
-        year: Number.isInteger(parsedYear) ? parsedYear : parsedYear === null ? null : undefined
+        year: Number.isInteger(parsedYear) ? parsedYear : parsedYear === null ? null : undefined,
+        genre: parsedGenre && parsedGenre.length > 0 ? parsedGenre : parsedGenre === null ? null : undefined
       });
       setEditState(null);
     } catch (error) {
@@ -237,6 +246,7 @@ export function ConfigView({
     const commonArtist = computeCommonField(selected, (t) => t.tags.artist);
     const commonAlbum = computeCommonField(selected, (t) => t.tags.album);
     const commonYear = computeCommonField(selected, (t) => t.tags.year != null ? String(t.tags.year) : undefined);
+    const commonGenre = computeCommonField(selected, (t) => t.tags.genre?.join(", "));
 
     setBulkEditState({
       trackIds: selected.map((t) => t.id),
@@ -244,10 +254,12 @@ export function ConfigView({
       artist: commonArtist ?? "",
       album: commonAlbum ?? "",
       year: commonYear ?? "",
+      genre: commonGenre ?? "",
       commonTitle,
       commonArtist,
       commonAlbum,
-      commonYear
+      commonYear,
+      commonGenre
     });
   }
 
@@ -270,8 +282,14 @@ export function ConfigView({
       const parsedYear = yearValue ? Number(yearValue) : null;
       patch.year = Number.isInteger(parsedYear) ? parsedYear : parsedYear === null ? null : undefined;
     }
+    if (bulkEditState.genre !== (bulkEditState.commonGenre ?? "")) {
+      const genreValue = bulkEditState.genre.trim();
+      patch.genre = genreValue
+        ? genreValue.split(",").map((g) => g.trim()).filter(Boolean)
+        : null;
+    }
 
-    const hasChanges = "title" in patch || "artist" in patch || "album" in patch || "year" in patch;
+    const hasChanges = "title" in patch || "artist" in patch || "album" in patch || "year" in patch || "genre" in patch;
     if (!hasChanges) {
       setBulkEditState(null);
       return;
@@ -684,6 +702,18 @@ export function ConfigView({
                 placeholder={bulkEditState.commonYear === undefined ? "Mixed values" : "e.g. 1979"}
                 onChange={(e) => setBulkEditState((s) => s ? { ...s, year: e.target.value } : s)}
               />
+            </label>
+
+            <label className="mt-3 block text-sm text-flaque-ink">
+              Genre
+              <input
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                type="text"
+                value={bulkEditState.genre}
+                placeholder={bulkEditState.commonGenre === undefined ? "Mixed values" : "e.g. Rock, Progressive Rock"}
+                onChange={(e) => setBulkEditState((s) => s ? { ...s, genre: e.target.value } : s)}
+              />
+              <span className="mt-0.5 block text-xs text-flaque-steel">Comma-separated</span>
             </label>
 
             <p className="mt-3 text-xs text-flaque-steel">

--- a/frontend/src/components/TrackEditModal.tsx
+++ b/frontend/src/components/TrackEditModal.tsx
@@ -9,6 +9,7 @@ export type EditTrackState = {
   artist: string;
   album: string;
   year: string;
+  genre: string;
 };
 
 type TrackEditModalProps = {
@@ -111,6 +112,27 @@ export function TrackEditModal({
               )
             }
           />
+        </label>
+
+        <label className="mt-3 block text-sm text-flaque-ink">
+          Genre
+          <input
+            className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+            type="text"
+            value={editState.genre}
+            placeholder="e.g. Rock, Progressive Rock"
+            onChange={(event) =>
+              onStateChange((current) =>
+                current
+                  ? {
+                      ...current,
+                      genre: event.target.value
+                    }
+                  : current
+              )
+            }
+          />
+          <span className="mt-0.5 block text-xs text-flaque-steel">Comma-separated</span>
         </label>
 
         <p className="mt-3 text-xs text-flaque-steel">

--- a/frontend/src/components/TrackList.tsx
+++ b/frontend/src/components/TrackList.tsx
@@ -64,6 +64,14 @@ export function TrackList({
     }`;
   }
 
+  function getGenrePillClassName(selected: boolean): string {
+    return `inline-block max-w-[7rem] truncate rounded-full px-1.5 py-px text-[10px] leading-tight ${
+      selected
+        ? "bg-flaque-cream/20 text-flaque-cream/90"
+        : "bg-flaque-ink/8 text-flaque-steel"
+    }`;
+  }
+
   return (
     <>
       <div className="space-y-3 p-4 md:hidden">
@@ -117,6 +125,16 @@ export function TrackList({
                   <p className={`truncate text-xs ${selected ? "text-flaque-cream/75" : "text-flaque-steel/80"}`}>
                     {trackAlbum}
                   </p>
+
+                  {track.tags.genre && track.tags.genre.length > 0 ? (
+                    <span className="mt-1 flex flex-wrap gap-1">
+                      {track.tags.genre.slice(0, 3).map((genre) => (
+                        <span key={genre} className={getGenrePillClassName(selected)} title={genre}>
+                          {genre}
+                        </span>
+                      ))}
+                    </span>
+                  ) : null}
 
                   <span
                     className={`mt-2 flex items-center justify-between text-[11px] uppercase tracking-[0.12em] ${
@@ -216,6 +234,15 @@ export function TrackList({
                         <span className="min-w-0 truncate" title={trackTitle}>
                           {trackTitle}
                         </span>
+                        {track.tags.genre && track.tags.genre.length > 0 ? (
+                          <>
+                            {track.tags.genre.slice(0, 2).map((genre) => (
+                              <span key={genre} className={getGenrePillClassName(selected)} title={genre}>
+                                {genre}
+                              </span>
+                            ))}
+                          </>
+                        ) : null}
                       </span>
                     </td>
                     <td className="px-4 py-3 text-flaque-steel">{trackArtist}</td>

--- a/frontend/src/components/UploadView.tsx
+++ b/frontend/src/components/UploadView.tsx
@@ -15,6 +15,7 @@ type UploadViewProps = {
       artist?: string;
       album?: string;
       year?: number;
+      genre?: string[];
     } | null>;
     onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
   }) => Promise<UploadTracksResult>;
@@ -79,7 +80,7 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
   const [previewByFileKey, setPreviewByFileKey] = useState<Record<string, PreviewState>>({});
   const [editableMetadataByFileKey, setEditableMetadataByFileKey] = useState<
-    Record<string, { title: string; artist: string; album: string; year: string }>
+    Record<string, { title: string; artist: string; album: string; year: string; genre: string }>
   >({});
   const [uploadArtist, setUploadArtist] = useState("");
   const [uploadAlbum, setUploadAlbum] = useState("");
@@ -204,7 +205,11 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
       const yearStr = editedMetadata.year.trim();
       const yearNum = yearStr ? Number(yearStr) : undefined;
       const year = yearNum && Number.isInteger(yearNum) && yearNum >= 1000 && yearNum <= 2999 ? yearNum : undefined;
-      if (!title && !artist && !album && year === undefined) {
+      const genreStr = editedMetadata.genre.trim();
+      const genre = genreStr
+        ? genreStr.split(",").map((g) => g.trim()).filter(Boolean)
+        : undefined;
+      if (!title && !artist && !album && year === undefined && !genre) {
         return null;
       }
 
@@ -212,7 +217,8 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
         title: title || undefined,
         artist: artist || undefined,
         album: album || undefined,
-        year
+        year,
+        genre: genre && genre.length > 0 ? genre : undefined
       };
     });
 
@@ -420,11 +426,13 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
               const year = extractYearFromTags(preview?.tags);
               const albumBase = preview?.tags.album?.trim() || "Unknown album";
               const album = year ? `${albumBase} (${year})` : albumBase;
+              const genreFromTags = preview?.tags.genre?.join(", ") ?? "";
               const editableMetadata = editableMetadataByFileKey[fileKey];
               const editableTitle = editableMetadata?.title ?? title;
               const editableArtist = editableMetadata?.artist ?? artist;
               const editableAlbum = editableMetadata?.album ?? albumBase;
               const editableYear = editableMetadata?.year ?? (year ?? "");
+              const editableGenre = editableMetadata?.genre ?? genreFromTags;
               const trackPosition =
                 typeof preview?.tags.trackNumber === "number"
                   ? `${preview.tags.trackNumber}${
@@ -467,7 +475,8 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
                                     title: nextTitle,
                                     artist: current[fileKey]?.artist ?? editableArtist,
                                     album: current[fileKey]?.album ?? editableAlbum,
-                                    year: current[fileKey]?.year ?? editableYear
+                                    year: current[fileKey]?.year ?? editableYear,
+                                    genre: current[fileKey]?.genre ?? editableGenre
                                   }
                                 }));
                               }}
@@ -487,7 +496,8 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
                                     title: current[fileKey]?.title ?? editableTitle,
                                     artist: nextArtist,
                                     album: current[fileKey]?.album ?? editableAlbum,
-                                    year: current[fileKey]?.year ?? editableYear
+                                    year: current[fileKey]?.year ?? editableYear,
+                                    genre: current[fileKey]?.genre ?? editableGenre
                                   }
                                 }));
                               }}
@@ -507,7 +517,8 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
                                     title: current[fileKey]?.title ?? editableTitle,
                                     artist: current[fileKey]?.artist ?? editableArtist,
                                     album: nextAlbum,
-                                    year: current[fileKey]?.year ?? editableYear
+                                    year: current[fileKey]?.year ?? editableYear,
+                                    genre: current[fileKey]?.genre ?? editableGenre
                                   }
                                 }));
                               }}
@@ -530,11 +541,36 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
                                     title: current[fileKey]?.title ?? editableTitle,
                                     artist: current[fileKey]?.artist ?? editableArtist,
                                     album: current[fileKey]?.album ?? editableAlbum,
-                                    year: nextYear
+                                    year: nextYear,
+                                    genre: current[fileKey]?.genre ?? editableGenre
                                   }
                                 }));
                               }}
                             />
+                          </label>
+
+                          <label className="text-flaque-steel">
+                            Genre
+                            <input
+                              className="mt-1 w-full rounded-lg border border-flaque-clay bg-white px-2 py-1 text-flaque-ink"
+                              value={editableGenre}
+                              disabled={uploading}
+                              placeholder="e.g. Rock, Progressive Rock"
+                              onChange={(event) => {
+                                const nextGenre = event.target.value;
+                                setEditableMetadataByFileKey((current) => ({
+                                  ...current,
+                                  [fileKey]: {
+                                    title: current[fileKey]?.title ?? editableTitle,
+                                    artist: current[fileKey]?.artist ?? editableArtist,
+                                    album: current[fileKey]?.album ?? editableAlbum,
+                                    year: current[fileKey]?.year ?? editableYear,
+                                    genre: nextGenre
+                                  }
+                                }));
+                              }}
+                            />
+                            <span className="mt-0.5 block text-[10px] text-flaque-steel/80">Comma-separated</span>
                           </label>
 
                           <p className="text-xs text-flaque-steel">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -112,6 +112,7 @@ export type TrackMetadataPatch = {
   artist?: string | null;
   album?: string | null;
   year?: number | null;
+  genre?: string[] | null;
 };
 
 export type RadioTrack = {


### PR DESCRIPTION
## Summary
- **Metadata overrides**: Extended the override system, upload pipeline, and API endpoints (single + bulk edit) to support `genre: string[]`
- **MusicBrainz service**: Rate-limited lookup (1 req/sec) with serial queue, disk cache, and proper User-Agent header
- **Genre synonym mapping**: 150+ hardcoded defaults seeded on first boot, admin CRUD API, stored in `data/config/genre-synonyms.json`
- **Auto-enrichment**: On-upload enrichment for tracks missing genre + admin-triggered background scan with progress tracking
- **Genre API routes**: Enrichment start/stop/status, synonym CRUD/reset, MusicBrainz cache stats/clear — all admin-only
- **Frontend**: Genre editing in single track modal, bulk edit modal, and upload preview; genre pills displayed in track lists (desktop + mobile)

## New files
- `backend/src/services/genre/musicBrainzService.ts`
- `backend/src/services/genre/genreSynonymService.ts`
- `backend/src/services/genre/genreEnrichmentService.ts`
- `backend/src/api/genreRoutes.ts`

## Test plan
- [x] TypeScript compiles cleanly (frontend + backend)
- [x] Full test suite passes (257/260 — 3 pre-existing flaky timeouts)
- [ ] Upload a track without genre → verify MusicBrainz enrichment fires in background
- [ ] Edit genre via single-track modal → verify override persists
- [ ] Bulk-edit genre on multiple tracks → verify all updated
- [ ] Trigger background enrichment via `POST /api/genre/enrichment/start` → check status
- [ ] Verify genre pills render on track list rows

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)