### PR TITLE
Implement playback tracking (Phase 2)

### DIFF
--- a/backend/src/api/playCountRoutes.ts
+++ b/backend/src/api/playCountRoutes.ts
@@ -1,0 +1,56 @@
+import { Router } from "express";
+
+import { requireAuth } from "../auth/middleware";
+import type { IndexStore } from "../services/indexer/indexStore";
+import { incrementPlayCount, getUserPlayStats } from "../services/activity/playCountStore";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("play-counts");
+
+export function createPlayCountRouter(indexStore: IndexStore): Router {
+  const router = Router();
+
+  router.post("/tracks/:id/play", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const trackId = req.params.id;
+      if (!trackId) {
+        res.status(400).json({ error: "Track id is required" });
+        return;
+      }
+
+      if (!indexStore.hasTrack(trackId)) {
+        res.status(404).json({ error: "Track not found" });
+        return;
+      }
+
+      await incrementPlayCount(userId, trackId);
+      log.debug("Play recorded", { userId, trackId });
+      res.status(204).end();
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/me/play-stats", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const stats = await getUserPlayStats(userId, indexStore);
+      res.json(stats);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/backend/src/api/router.ts
+++ b/backend/src/api/router.ts
@@ -8,6 +8,7 @@ import { createGenreRouter } from "./genreRoutes";
 import { createIndexRouter } from "./indexRoutes";
 import { createLibraryRouter } from "./libraryRoutes";
 import { createLogRouter } from "./logRoutes";
+import { createPlayCountRouter } from "./playCountRoutes";
 import { createPlaylistRouter } from "./playlistRoutes";
 import { createRadioRouter } from "./radioRoutes";
 import { createServerRouter } from "./serverRoutes";
@@ -24,6 +25,7 @@ export function createApiRouter(indexStore: IndexStore): Router {
   router.use(createPlaylistRouter(indexStore));
   router.use(createRadioRouter(indexStore));
   router.use(createStreamingRouter(indexStore));
+  router.use(createPlayCountRouter(indexStore));
   router.use(createCoverRouter(indexStore));
   router.use(createIndexRouter(indexStore));
   router.use(createGenreRouter(indexStore));

--- a/backend/src/services/activity/playCountStore.ts
+++ b/backend/src/services/activity/playCountStore.ts
@@ -1,0 +1,128 @@
+import path from "node:path";
+
+import { readJsonFile, writeJsonAtomic, ensureDir } from "../../utils/fs";
+import { usersStorageRoot } from "../../utils/paths";
+import type { IndexStore } from "../indexer/indexStore";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("play-counts");
+
+type TrackPlayCount = {
+  count: number;
+  lastPlayedAt: string;
+};
+
+type PlayCountsFile = {
+  tracks: Record<string, TrackPlayCount>;
+};
+
+function playCountsPath(userId: string): string {
+  return path.join(usersStorageRoot, userId, "play-counts.json");
+}
+
+async function readPlayCounts(userId: string): Promise<PlayCountsFile> {
+  const filePath = playCountsPath(userId);
+  const data = await readJsonFile<PlayCountsFile>(filePath, { tracks: {} });
+  if (!data || typeof data !== "object" || !data.tracks) {
+    return { tracks: {} };
+  }
+  return data;
+}
+
+async function writePlayCounts(userId: string, data: PlayCountsFile): Promise<void> {
+  const filePath = playCountsPath(userId);
+  await ensureDir(path.dirname(filePath));
+  await writeJsonAtomic(filePath, data);
+}
+
+export async function incrementPlayCount(userId: string, trackId: string): Promise<void> {
+  const data = await readPlayCounts(userId);
+  const existing = data.tracks[trackId];
+  data.tracks[trackId] = {
+    count: (existing?.count ?? 0) + 1,
+    lastPlayedAt: new Date().toISOString()
+  };
+  await writePlayCounts(userId, data);
+}
+
+export async function getUserPlayCounts(
+  userId: string
+): Promise<Record<string, TrackPlayCount>> {
+  const data = await readPlayCounts(userId);
+  return data.tracks;
+}
+
+export type TopTrackEntry = {
+  trackId: string;
+  count: number;
+  lastPlayedAt: string;
+};
+
+export async function getUserTopTracks(
+  userId: string,
+  limit: number
+): Promise<TopTrackEntry[]> {
+  const counts = await getUserPlayCounts(userId);
+  return Object.entries(counts)
+    .map(([trackId, entry]) => ({ trackId, count: entry.count, lastPlayedAt: entry.lastPlayedAt }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit);
+}
+
+export type TopArtistEntry = {
+  artist: string;
+  playCount: number;
+};
+
+export async function getUserTopArtists(
+  userId: string,
+  limit: number,
+  indexStore: IndexStore
+): Promise<TopArtistEntry[]> {
+  const counts = await getUserPlayCounts(userId);
+  const artistPlayCounts = new Map<string, number>();
+
+  for (const [trackId, entry] of Object.entries(counts)) {
+    const track = indexStore.getTrackById(trackId);
+    if (!track) continue;
+
+    const artist = track.tags.artist ?? "Unknown";
+    artistPlayCounts.set(artist, (artistPlayCounts.get(artist) ?? 0) + entry.count);
+  }
+
+  return Array.from(artistPlayCounts.entries())
+    .map(([artist, playCount]) => ({ artist, playCount }))
+    .sort((a, b) => b.playCount - a.playCount)
+    .slice(0, limit);
+}
+
+export type PlayStatsResponse = {
+  topTracks: TopTrackEntry[];
+  topArtists: TopArtistEntry[];
+  totalPlays: number;
+  uniqueTracksPlayed: number;
+};
+
+export async function getUserPlayStats(
+  userId: string,
+  indexStore: IndexStore
+): Promise<PlayStatsResponse> {
+  const counts = await getUserPlayCounts(userId);
+  const entries = Object.entries(counts);
+
+  const totalPlays = entries.reduce((sum, [, entry]) => sum + entry.count, 0);
+
+  const topTracks = entries
+    .map(([trackId, entry]) => ({ trackId, count: entry.count, lastPlayedAt: entry.lastPlayedAt }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 20);
+
+  const topArtists = await getUserTopArtists(userId, 15, indexStore);
+
+  return {
+    topTracks,
+    topArtists,
+    totalPlays,
+    uniqueTracksPlayed: entries.length
+  };
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -886,6 +886,24 @@ export function coverUrl(trackId: string, coverPath?: string): string {
   return withApiBase(`/api/covers/${trackId}`);
 }
 
+export async function reportTrackPlay(trackId: string): Promise<void> {
+  await fetch(withApiBase(`/api/tracks/${encodeURIComponent(trackId)}/play`), {
+    method: "POST",
+    credentials: "include"
+  });
+}
+
+export type PlayStatsResponse = {
+  topTracks: Array<{ trackId: string; count: number; lastPlayedAt: string }>;
+  topArtists: Array<{ artist: string; playCount: number }>;
+  totalPlays: number;
+  uniqueTracksPlayed: number;
+};
+
+export async function getMyPlayStats(): Promise<PlayStatsResponse> {
+  return requestJson<PlayStatsResponse>("/api/me/play-stats");
+}
+
 // ── Admin: Server Logs ────────────────────────────────────────────────
 
 export type LogFile = {

--- a/frontend/src/hooks/usePlaybackState.ts
+++ b/frontend/src/hooks/usePlaybackState.ts
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
 
+import { reportTrackPlay } from "../api";
 import type { RepeatMode, TranscodeMode } from "../components/AudioPlayer";
 import type { Track, User } from "../types";
 import { isTrackLike, parseStoredQueueSnapshot, readShuffleMode, readTranscodeMode, type StoredQueueSnapshot } from "../utils/appUtils";
@@ -55,6 +56,7 @@ export function usePlaybackState({
   const [shuffleEnabled, setShuffleEnabled] = useState<boolean>(() => readShuffleMode(SHUFFLE_MODE_STORAGE_KEY));
   const [queueRestoredFromStorage, setQueueRestoredFromStorage] = useState(false);
   const [recentTracks, setRecentTracks] = useState<Track[]>([]);
+  const lastPlayReportRef = useRef<{ trackId: string; at: number } | null>(null);
 
   const selectedTrackRefreshed = useMemo(() => {
     if (!selectedTrack) {
@@ -244,6 +246,17 @@ export function usePlaybackState({
       const withoutCurrent = current.filter((entry) => entry.id !== track.id);
       return [track, ...withoutCurrent].slice(0, MAX_RECENT_TRACKS);
     });
+
+    if (track.owner === "radio") return;
+
+    const now = Date.now();
+    const last = lastPlayReportRef.current;
+    const isSameTrack = last?.trackId === track.id;
+    const withinDebounce = isSameTrack && now - last.at < 10_000;
+    if (withinDebounce) return;
+
+    lastPlayReportRef.current = { trackId: track.id, at: now };
+    void reportTrackPlay(track.id).catch(() => {});
   }, []);
 
   const removeTrackFromPlayback = useCallback((trackId: string): void => {


### PR DESCRIPTION
## Summary
- **Per-user play counter store**: `playCountStore.ts` — JSON file per user at `data/users/{userId}/play-counts.json`, tracks play count and `lastPlayedAt` per track
- **Play event endpoint**: `POST /api/tracks/:id/play` — authenticated, fire-and-forget, returns 204
- **Play stats API**: `GET /api/me/play-stats` — returns top 20 tracks, top 15 artists, total plays, and unique tracks played
- **Frontend integration**: `recordTrackPlayed` now fires `reportTrackPlay()` with a 10-second debounce to avoid counting seeks, quality swaps, or restarts as separate plays. Radio tracks are excluded.

## New files
- `backend/src/services/activity/playCountStore.ts`
- `backend/src/api/playCountRoutes.ts`

## Test plan
- [x] TypeScript compiles cleanly (frontend + backend)
- [x] Full test suite passes (258/260 — 2 pre-existing flaky timeouts)
- [ ] Play a track → verify `play-counts.json` is created with correct data
- [ ] Play the same track again → verify count increments
- [ ] Seek within 10 seconds → verify no double count
- [ ] Call `GET /api/me/play-stats` → verify top tracks and artists returned
- [ ] Radio tracks do not trigger play reports

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)