### PR TITLE
Expand playlist model with hearts, covers, and collaboration

### DIFF
--- a/backend/src/api/playlistRoutes.test.ts
+++ b/backend/src/api/playlistRoutes.test.ts
@@ -128,7 +128,12 @@ describe("playlistRoutes", () => {
     const metadataRaw = await fs.readFile(metadataPath, "utf8");
     expect(JSON.parse(metadataRaw)).toEqual({
       name: "My Playlist",
-      visibility: "private"
+      visibility: "private",
+      collaborators: [],
+      cover: null,
+      description: "",
+      hearts: [],
+      listenCount: 0
     });
 
     const updateResponse = await apiRequest(`/api/playlists/${encodeURIComponent(createdPlaylist.id)}`, {

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -1,16 +1,34 @@
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+
+import multer from "multer";
 import { Router } from "express";
 
 import { requireAuth } from "../auth/middleware";
 import { IndexStore } from "../services/indexer/indexStore";
+import { ensureDir } from "../utils/fs";
 import { createLogger } from "../utils/logger";
 
 const log = createLogger("playlists");
+
+const COVER_MAX_BYTES = 5 * 1024 * 1024;
+const COVER_FILE_NAME = "cover.webp";
+
+const coverUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: COVER_MAX_BYTES, files: 1 }
+});
 import {
   canManagePlaylist,
   createFilesystemPlaylist,
   deleteFilesystemPlaylist,
   filterPlayablePlaylists,
-  updateFilesystemPlaylist
+  getPlaylistDirectory,
+  incrementPlaylistListenCount,
+  togglePlaylistHeart,
+  updateFilesystemPlaylist,
+  updatePlaylistCover,
+  updatePlaylistDescription
 } from "../services/playlists/playlistStore";
 import type { Playlist, PlaylistVisibility, Track } from "../types/library";
 
@@ -305,6 +323,12 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
+      const description = typeof req.body?.description === "string" ? req.body.description : undefined;
+
+      if (description !== undefined) {
+        await updatePlaylistDescription(playlistId, description);
+      }
+
       const snapshot = indexStore.getSnapshot();
       await updateFilesystemPlaylist({
         id: playlistId,
@@ -377,6 +401,182 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
       });
 
       res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/playlists/:id/heart", requireAuth, async (req, res, next) => {
+    try {
+      const authUser = req.authUser;
+      const playlistId = req.params.id;
+      if (!authUser || !playlistId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlist = findPlaylistById(indexStore, playlistId);
+      if (!playlist) {
+        res.status(404).json({ error: "Playlist not found" });
+        return;
+      }
+
+      if (playlist.visibility !== "public") {
+        res.status(403).json({ error: "Only public playlists can be hearted" });
+        return;
+      }
+
+      if (playlist.authorId === authUser.id) {
+        res.status(400).json({ error: "Cannot heart your own playlist" });
+        return;
+      }
+
+      const result = await togglePlaylistHeart(playlistId, authUser.id);
+      await indexStore.refreshPlaylists();
+
+      log.info("Playlist heart toggled", {
+        playlistId,
+        userId: authUser.id,
+        hearted: result.hearted
+      });
+
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/playlists/:id/listen", requireAuth, async (req, res, next) => {
+    try {
+      const authUser = req.authUser;
+      const playlistId = req.params.id;
+      if (!authUser || !playlistId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlist = findPlaylistById(indexStore, playlistId);
+      if (!playlist) {
+        res.status(404).json({ error: "Playlist not found" });
+        return;
+      }
+
+      const listenCount = await incrementPlaylistListenCount(playlistId);
+      res.json({ listenCount });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post(
+    "/playlists/:id/cover",
+    requireAuth,
+    async (req, res, next) => {
+      try {
+        await new Promise<void>((resolve, reject) => {
+          coverUpload.single("cover")(req, res, (err: unknown) => (err ? reject(err) : resolve()));
+        });
+      } catch (error) {
+        if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+          res.status(400).json({ error: `Cover image must be <= ${Math.floor(COVER_MAX_BYTES / (1024 * 1024))} MB` });
+          return;
+        }
+        next(error);
+        return;
+      }
+
+      try {
+        const authUser = req.authUser;
+        const playlistId = req.params.id;
+        if (!authUser || !playlistId) {
+          res.status(401).json({ error: "Authentication required" });
+          return;
+        }
+
+        const playlist = findPlaylistById(indexStore, playlistId);
+        if (!playlist) {
+          res.status(404).json({ error: "Playlist not found" });
+          return;
+        }
+
+        if (!canManagePlaylist(playlist, authUser)) {
+          res.status(403).json({ error: "Not allowed to modify this playlist" });
+          return;
+        }
+
+        const file = req.file;
+        if (!file) {
+          res.status(400).json({ error: "cover image file is required" });
+          return;
+        }
+
+        if (!file.mimetype.toLowerCase().startsWith("image/")) {
+          res.status(400).json({ error: "Unsupported image format" });
+          return;
+        }
+
+        const sharp = (await import("sharp")).default;
+        let convertedBuffer: Buffer;
+        try {
+          convertedBuffer = await sharp(file.buffer)
+            .rotate()
+            .resize(512, 512, { fit: "cover", position: "centre" })
+            .webp({ quality: 85 })
+            .toBuffer();
+        } catch {
+          res.status(400).json({ error: "Invalid image file" });
+          return;
+        }
+
+        const playlistDir = getPlaylistDirectory(playlistId);
+        await ensureDir(playlistDir);
+
+        const tmpPath = path.join(playlistDir, `cover-upload.${process.pid}.${Date.now()}.tmp`);
+        const targetPath = path.join(playlistDir, COVER_FILE_NAME);
+
+        await fsPromises.writeFile(tmpPath, convertedBuffer);
+        await fsPromises.rename(tmpPath, targetPath);
+
+        await updatePlaylistCover(playlistId, targetPath);
+        await indexStore.refreshPlaylists();
+
+        log.info("Playlist cover uploaded", { playlistId, userId: authUser.id });
+        res.json({ ok: true, cover: targetPath });
+      } catch (error) {
+        next(error);
+      }
+    }
+  );
+
+  router.delete("/playlists/:id/cover", requireAuth, async (req, res, next) => {
+    try {
+      const authUser = req.authUser;
+      const playlistId = req.params.id;
+      if (!authUser || !playlistId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlist = findPlaylistById(indexStore, playlistId);
+      if (!playlist) {
+        res.status(404).json({ error: "Playlist not found" });
+        return;
+      }
+
+      if (!canManagePlaylist(playlist, authUser)) {
+        res.status(403).json({ error: "Not allowed to modify this playlist" });
+        return;
+      }
+
+      const playlistDir = getPlaylistDirectory(playlistId);
+      const coverPath = path.join(playlistDir, COVER_FILE_NAME);
+      await fsPromises.unlink(coverPath).catch(() => {});
+
+      await updatePlaylistCover(playlistId, null);
+      await indexStore.refreshPlaylists();
+
+      log.info("Playlist cover removed", { playlistId, userId: authUser.id });
+      res.json({ ok: true });
     } catch (error) {
       next(error);
     }

--- a/backend/src/services/indexer/indexStore.test.ts
+++ b/backend/src/services/indexer/indexStore.test.ts
@@ -67,7 +67,13 @@ function createPlaylist(id: string, trackIds: string[]): Playlist {
     name: id,
     authorId: "owner-1",
     visibility: "private",
-    trackIds
+    trackIds,
+    description: "",
+    cover: null,
+    hearts: [],
+    heartCount: 0,
+    listenCount: 0,
+    collaborators: []
   };
 }
 

--- a/backend/src/services/playlists/playlistStore.ts
+++ b/backend/src/services/playlists/playlistStore.ts
@@ -15,6 +15,11 @@ const PLAYLISTS_DIRECTORY_NAME = "playlists";
 type PlaylistMetadata = {
   name: string;
   visibility: PlaylistVisibility;
+  description: string;
+  cover: string | null;
+  hearts: string[];
+  listenCount: number;
+  collaborators: string[];
 };
 
 type CreatePlaylistInput = {
@@ -168,6 +173,10 @@ export function canManagePlaylist(playlist: Playlist, user: AuthUser): boolean {
   return playlist.authorId === user.id || user.role === "admin";
 }
 
+export function canEditPlaylistTracks(playlist: Playlist, user: AuthUser): boolean {
+  return canManagePlaylist(playlist, user) || playlist.collaborators.includes(user.id);
+}
+
 export function filterPlayablePlaylists(playlists: Playlist[], user: AuthUser): Playlist[] {
   return playlists.filter((playlist) => canViewPlaylist(playlist, user));
 }
@@ -209,13 +218,18 @@ async function listPlaylistDirectories(): Promise<string[]> {
   return directories;
 }
 
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
 async function readPlaylistMetadata(playlistId: string): Promise<PlaylistMetadata | null> {
   const { authorId, slug } = parsePlaylistIdOrThrow(playlistId);
   const filePath = getPlaylistMetadataPath(authorId, slug);
 
   try {
     const raw = await fs.readFile(filePath, "utf8");
-    const parsed = JSON.parse(raw) as Partial<PlaylistMetadata>;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
     const visibility = normalizeVisibility(parsed.visibility);
     const name = typeof parsed.name === "string" ? parsed.name.trim() : "";
     if (!name || !visibility) {
@@ -223,7 +237,14 @@ async function readPlaylistMetadata(playlistId: string): Promise<PlaylistMetadat
     }
     return {
       name,
-      visibility
+      visibility,
+      description: typeof parsed.description === "string" ? parsed.description : "",
+      cover: typeof parsed.cover === "string" && parsed.cover.trim() ? parsed.cover.trim() : null,
+      hearts: normalizeStringArray(parsed.hearts),
+      listenCount: typeof parsed.listenCount === "number" && Number.isFinite(parsed.listenCount)
+        ? Math.max(0, Math.floor(parsed.listenCount))
+        : 0,
+      collaborators: normalizeStringArray(parsed.collaborators)
     };
   } catch {
     return null;
@@ -301,7 +322,13 @@ export async function scanFilesystemPlaylists(tracks: Track[]): Promise<Playlist
       name: metadata.name,
       authorId,
       visibility: metadata.visibility,
-      trackIds
+      trackIds,
+      description: metadata.description,
+      cover: metadata.cover,
+      hearts: metadata.hearts,
+      heartCount: metadata.hearts.length,
+      listenCount: metadata.listenCount,
+      collaborators: metadata.collaborators
     });
   }
 
@@ -350,6 +377,11 @@ async function writePlaylistContents(input: {
   visibility: PlaylistVisibility;
   trackIds: string[];
   tracksById: Map<string, Track>;
+  description?: string;
+  cover?: string | null;
+  hearts?: string[];
+  listenCount?: number;
+  collaborators?: string[];
 }): Promise<void> {
   const playlistDir = getPlaylistDir(input.authorId, input.playlistSlug);
   await fs.mkdir(playlistDir, { recursive: true });
@@ -370,7 +402,12 @@ async function writePlaylistContents(input: {
 
   await writeJsonAtomic(getPlaylistMetadataPath(input.authorId, input.playlistSlug), {
     name: input.name,
-    visibility: input.visibility
+    visibility: input.visibility,
+    description: input.description ?? "",
+    cover: input.cover ?? null,
+    hearts: input.hearts ?? [],
+    listenCount: input.listenCount ?? 0,
+    collaborators: input.collaborators ?? []
   } satisfies PlaylistMetadata);
 }
 
@@ -435,13 +472,20 @@ export async function updateFilesystemPlaylist(input: UpdatePlaylistInput & { au
     await fs.rename(currentDir, nextDir);
   }
 
+  const existingMetadata = await readPlaylistMetadata(input.id);
+
   await writePlaylistContents({
     authorId: input.authorId,
     playlistSlug: nextSlug,
     name: nextName,
     visibility: input.visibility,
     trackIds: input.trackIds,
-    tracksById: input.tracksById
+    tracksById: input.tracksById,
+    description: existingMetadata?.description,
+    cover: existingMetadata?.cover,
+    hearts: existingMetadata?.hearts,
+    listenCount: existingMetadata?.listenCount,
+    collaborators: existingMetadata?.collaborators
   });
 }
 
@@ -449,4 +493,71 @@ export async function deleteFilesystemPlaylist(playlistId: string): Promise<void
   const { authorId, slug } = parsePlaylistIdOrThrow(playlistId);
   await fs.rm(getPlaylistDir(authorId, slug), { recursive: true, force: true });
   await fs.rm(getLegacyPlaylistDir(authorId, slug), { recursive: true, force: true });
+}
+
+async function patchPlaylistMetadataFile(
+  playlistId: string,
+  updater: (metadata: PlaylistMetadata) => PlaylistMetadata
+): Promise<PlaylistMetadata> {
+  const metadata = await readPlaylistMetadata(playlistId);
+  if (!metadata) {
+    throw new Error("Playlist metadata not found");
+  }
+
+  const updated = updater(metadata);
+  const { authorId, slug } = parsePlaylistIdOrThrow(playlistId);
+  await writeJsonAtomic(getPlaylistMetadataPath(authorId, slug), updated);
+  return updated;
+}
+
+export async function togglePlaylistHeart(
+  playlistId: string,
+  userId: string
+): Promise<{ hearted: boolean; heartCount: number }> {
+  const updated = await patchPlaylistMetadataFile(playlistId, (metadata) => {
+    const hearts = metadata.hearts.filter((id) => id !== userId);
+    const wasHearted = hearts.length < metadata.hearts.length;
+    if (!wasHearted) {
+      hearts.push(userId);
+    }
+    return { ...metadata, hearts };
+  });
+
+  return {
+    hearted: updated.hearts.includes(userId),
+    heartCount: updated.hearts.length
+  };
+}
+
+export async function incrementPlaylistListenCount(playlistId: string): Promise<number> {
+  const updated = await patchPlaylistMetadataFile(playlistId, (metadata) => ({
+    ...metadata,
+    listenCount: metadata.listenCount + 1
+  }));
+  return updated.listenCount;
+}
+
+export async function updatePlaylistDescription(
+  playlistId: string,
+  description: string
+): Promise<void> {
+  await patchPlaylistMetadataFile(playlistId, (metadata) => ({
+    ...metadata,
+    description
+  }));
+}
+
+export async function updatePlaylistCover(
+  playlistId: string,
+  coverPath: string | null
+): Promise<void> {
+  await patchPlaylistMetadataFile(playlistId, (metadata) => ({
+    ...metadata,
+    cover: coverPath
+  }));
+}
+
+export function getPlaylistDirectory(playlistId: string): string {
+  const { authorId, slug } = parsePlaylistIdOrThrow(playlistId);
+  return getPlaylistDir(authorId, slug);
 }

--- a/backend/src/types/library.ts
+++ b/backend/src/types/library.ts
@@ -52,6 +52,12 @@ export type Playlist = {
   authorId: string;
   visibility: PlaylistVisibility;
   trackIds: string[];
+  description: string;
+  cover: string | null;
+  hearts: string[];
+  heartCount: number;
+  listenCount: number;
+  collaborators: string[];
 };
 
 export type LibraryIndex = {

--- a/frontend/src/components/LibraryAlbumsSection.test.tsx
+++ b/frontend/src/components/LibraryAlbumsSection.test.tsx
@@ -174,7 +174,13 @@ describe("LibraryAlbumsSection", () => {
       name: "Workout",
       authorId: "user-1",
       visibility: "private" as const,
-      trackIds: []
+      trackIds: [],
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
     };
     const onTrackSelect = vi.fn();
     const onAddTrackToPlaylist = vi.fn().mockResolvedValue(undefined);

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -18,7 +18,13 @@ function createPlaylist(input: {
     name: input.name,
     authorId: input.authorId,
     visibility: input.visibility ?? "private",
-    trackIds: input.trackIds ?? []
+    trackIds: input.trackIds ?? [],
+    description: "",
+    cover: null,
+    hearts: [],
+    heartCount: 0,
+    listenCount: 0,
+    collaborators: []
   };
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -94,6 +94,12 @@ export type Playlist = {
   visibility: PlaylistVisibility;
   trackIds: string[];
   trackCount?: number;
+  description: string;
+  cover: string | null;
+  hearts: string[];
+  heartCount: number;
+  listenCount: number;
+  collaborators: string[];
 };
 
 export type LibraryResponse = {


### PR DESCRIPTION
## Summary
- Extend `Playlist` type (backend + frontend) with `description`, `cover`, `hearts`, `heartCount`, `listenCount`, and `collaborators` fields
- Add API endpoints: heart/unheart toggle (`POST /playlists/:id/heart`), listen count increment (`POST /playlists/:id/listen`), cover upload (`POST /playlists/:id/cover`) and delete (`DELETE /playlists/:id/cover`), description editing via existing PATCH
- Seamless migration: existing playlists get sensible defaults when read from disk
- Update all test fixtures across backend and frontend to include new required fields

## Test plan
- [x] Backend TypeScript check passes
- [x] Frontend TypeScript check passes
- [x] `playlistRoutes.test.ts` passes (metadata assertion updated)
- [x] `indexStore.test.ts` passes
- [x] `LibraryAlbumsSection.test.tsx` passes
- [x] `LibraryPlaylistSection.test.tsx` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)