### PR TITLE
Overhaul playlist view with detail page and three-section layout

### DIFF
--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -548,6 +548,27 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
     }
   );
 
+  router.get("/playlists/:id/cover", requireAuth, async (req, res, next) => {
+    try {
+      const playlistId = req.params.id;
+      if (!playlistId) {
+        res.status(400).json({ error: "Playlist id is required" });
+        return;
+      }
+
+      const playlist = findPlaylistById(indexStore, playlistId);
+      if (!playlist || !playlist.cover) {
+        res.status(404).json({ error: "Cover not found" });
+        return;
+      }
+
+      res.setHeader("Cache-Control", "private, max-age=86400");
+      res.sendFile(playlist.cover);
+    } catch (error) {
+      next(error);
+    }
+  });
+
   router.delete("/playlists/:id/cover", requireAuth, async (req, res, next) => {
     try {
       const authUser = req.authUser;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ export default function App(): JSX.Element {
     activeView, setActiveView,
     activeLibrarySection, setActiveLibrarySection,
     activeConfigSection, setActiveConfigSection,
+    playlistDetailId, setPlaylistDetailId,
     handleLogin, notifyAuthStateChanged
   } = useSessionRoutingState();
 
@@ -37,6 +38,8 @@ export default function App(): JSX.Element {
       setActiveLibrarySection={setActiveLibrarySection}
       activeConfigSection={activeConfigSection}
       setActiveConfigSection={setActiveConfigSection}
+      playlistDetailId={playlistDetailId}
+      setPlaylistDetailId={setPlaylistDetailId}
       notifyAuthStateChanged={notifyAuthStateChanged}
     />
   );

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -5,7 +5,7 @@ import { AppShell } from "./components/AppShell";
 import type { ConfigSection } from "./components/ConfigView";
 import type { Track, User } from "./types";
 import type { LibrarySection } from "./types/library";
-import type { ViewName } from "./utils/appUtils";
+import { navigateTo, type ViewName } from "./utils/appUtils";
 import { useAccountActions } from "./hooks/useAccountActions";
 import { useAdminBackup } from "./hooks/useAdminBackup";
 import { useAdminCommands } from "./hooks/useAdminCommands";
@@ -30,6 +30,8 @@ type AuthenticatedAppProps = {
   setActiveLibrarySection: Dispatch<SetStateAction<LibrarySection>>;
   activeConfigSection: ConfigSection;
   setActiveConfigSection: Dispatch<SetStateAction<ConfigSection>>;
+  playlistDetailId: string | null;
+  setPlaylistDetailId: Dispatch<SetStateAction<string | null>>;
   notifyAuthStateChanged: (kind: "login" | "logout" | "session-change") => void;
 };
 
@@ -42,6 +44,8 @@ export function AuthenticatedApp({
   setActiveLibrarySection,
   activeConfigSection,
   setActiveConfigSection,
+  playlistDetailId,
+  setPlaylistDetailId,
   notifyAuthStateChanged
 }: AuthenticatedAppProps): JSX.Element {
   // ── UI state ──────────────────────────────────────────────────────────
@@ -198,7 +202,8 @@ export function AuthenticatedApp({
     handleDeleteTrack, handleUpdateTrackMetadata,
     handleBulkDeleteTracks, handleBulkUpdateTrackMetadata,
     handleCreatePlaylist, handleAddTrackToPlaylist,
-    handlePatchPlaylist, handleDeletePlaylist
+    handlePatchPlaylist, handleDeletePlaylist,
+    handleHeartPlaylist, handleReportPlaylistListen
   } = useLibraryCommands({
     manageablePlaylists, refreshCurrentLibrary, refreshAllTracks,
     refreshRecentlyUploaded, refreshPaginatedLibrary,
@@ -286,10 +291,18 @@ export function AuthenticatedApp({
         onSectionChange: setActiveLibrarySection,
         availablePlaylists,
         ownerNameById,
+        user,
+        playlistDetailId,
+        onPlaylistDetailNavigate: (id: string | null) => {
+          setPlaylistDetailId(id);
+          navigateTo("library", "playlists", id);
+        },
         onCreatePlaylist: handleCreatePlaylist,
         onPlayPlaylist: handlePlayPlaylist,
         onPatchPlaylist: handlePatchPlaylist,
         onDeletePlaylist: handleDeletePlaylist,
+        onHeartPlaylist: handleHeartPlaylist,
+        onReportPlaylistListen: handleReportPlaylistListen,
         allTracksById,
         libraryMetadataError,
         loadingLibraryArtists,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -691,6 +691,23 @@ export async function deletePlaylist(playlistId: string): Promise<void> {
   });
 }
 
+export async function heartPlaylist(playlistId: string): Promise<{ hearted: boolean; heartCount: number }> {
+  return requestJson<{ hearted: boolean; heartCount: number }>(
+    `/api/playlists/${encodeURIComponent(playlistId)}/heart`,
+    { method: "POST" }
+  );
+}
+
+export async function reportPlaylistListen(playlistId: string): Promise<void> {
+  await requestJson(`/api/playlists/${encodeURIComponent(playlistId)}/listen`, {
+    method: "POST"
+  }).catch(() => {});
+}
+
+export function playlistCoverUrl(playlistId: string): string {
+  return withApiBase(`/api/playlists/${encodeURIComponent(playlistId)}/cover`);
+}
+
 export async function getUsers(): Promise<User[]> {
   const payload = await requestJson<{ users: User[] }>("/api/users");
   return payload.users;

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -31,8 +31,11 @@ function createPlaylist(input: {
 const defaultProps = {
   manageablePlaylists: [] as Playlist[],
   allTracksById: new Map(),
+  user: { id: "user-1", username: "Alice", email: "alice@test.local", role: "user" as const },
   onPatchPlaylist: vi.fn().mockResolvedValue(undefined),
-  onDeletePlaylist: vi.fn().mockResolvedValue(undefined)
+  onDeletePlaylist: vi.fn().mockResolvedValue(undefined),
+  onNavigateToPlaylist: vi.fn(),
+  onReportPlaylistListen: vi.fn().mockResolvedValue(undefined)
 };
 
 describe("LibraryPlaylistSection", () => {

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -1,26 +1,27 @@
-import { FormEvent, useEffect, useRef, useState } from "react";
+import { FormEvent, useState } from "react";
 
-import { coverUrl } from "../api";
-import type { Playlist, PlaylistVisibility, Track } from "../types";
-import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+import { coverUrl, playlistCoverUrl } from "../api";
+import type { Playlist, PlaylistVisibility, Track, User } from "../types";
 
 type LibraryPlaylistSectionProps = {
   availablePlaylists: Playlist[];
   manageablePlaylists: Playlist[];
   ownerNameById: Record<string, string>;
   allTracksById: Map<string, Track>;
+  user: User;
   onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
   onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
+  onNavigateToPlaylist: (playlistId: string) => void;
+  onReportPlaylistListen: (playlistId: string) => Promise<void>;
 };
 
-// ── Mosaic cover ────────────────────────────────────────────────────
+// ── Mosaic cover (compact) ─────────────────────────────────────────
 
 function getPlaylistMosaicTracks(trackIds: string[], allTracksById: Map<string, Track>): Track[] {
   const seen = new Set<string>();
   const result: Track[] = [];
-
   for (const id of trackIds) {
     if (result.length >= 4) break;
     const track = allTracksById.get(id);
@@ -31,7 +32,6 @@ function getPlaylistMosaicTracks(trackIds: string[], allTracksById: Map<string, 
       result.push(track);
     }
   }
-
   return result;
 }
 
@@ -50,14 +50,8 @@ function PlaylistMosaic({ tracks }: { tracks: Track[] }): JSX.Element {
   }
 
   if (tracks.length === 1) {
-    const track = tracks[0]!;
     return (
-      <img
-        src={coverUrl(track.id)}
-        alt=""
-        className="h-full w-full object-cover"
-        loading="lazy"
-      />
+      <img src={coverUrl(tracks[0]!.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
     );
   }
 
@@ -65,13 +59,7 @@ function PlaylistMosaic({ tracks }: { tracks: Track[] }): JSX.Element {
     <div className="grid h-full w-full grid-cols-2 grid-rows-2">
       {slots.map((track, i) =>
         track ? (
-          <img
-            key={i}
-            src={coverUrl(track.id)}
-            alt=""
-            className="h-full w-full object-cover"
-            loading="lazy"
-          />
+          <img key={i} src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
         ) : (
           <div key={i} className="bg-flaque-clay/20" />
         )
@@ -80,444 +68,117 @@ function PlaylistMosaic({ tracks }: { tracks: Track[] }): JSX.Element {
   );
 }
 
-// ── Dropdown menu ───────────────────────────────────────────────────
-
-type PlaylistMenuProps = {
-  canManage: boolean;
-  onEdit: () => void;
-  onDownload: () => void;
-  onDelete: () => void;
-};
-
-function PlaylistMenu({ canManage, onEdit, onDownload, onDelete }: PlaylistMenuProps): JSX.Element {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent): void {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
-
-  return (
-    <div ref={ref} className="relative">
-      <button
-        type="button"
-        className="flex h-7 w-7 items-center justify-center rounded-lg text-flaque-steel transition hover:bg-flaque-clay/30 hover:text-flaque-ink"
-        onClick={(e) => { e.stopPropagation(); setOpen((v) => !v); }}
-        aria-label="Playlist options"
-      >
-        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
-          <circle cx="10" cy="4" r="1.5" />
-          <circle cx="10" cy="10" r="1.5" />
-          <circle cx="10" cy="16" r="1.5" />
-        </svg>
-      </button>
-
-      {open ? (
-        <div className="absolute bottom-full right-0 z-20 mb-1 min-w-[160px] overflow-hidden rounded-xl border border-flaque-clay/60 bg-white shadow-lg">
-          {canManage ? (
-            <button
-              type="button"
-              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-flaque-ink transition hover:bg-flaque-cream"
-              onClick={(e) => { e.stopPropagation(); setOpen(false); onEdit(); }}
-            >
-              <svg className="h-4 w-4 shrink-0 text-flaque-steel" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-              Edit playlist
-            </button>
-          ) : null}
-          <button
-            type="button"
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-flaque-ink transition hover:bg-flaque-cream"
-            onClick={(e) => { e.stopPropagation(); setOpen(false); onDownload(); }}
-          >
-            <svg className="h-4 w-4 shrink-0 text-flaque-steel" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-            </svg>
-            Download playlist
-          </button>
-          {canManage ? (
-            <button
-              type="button"
-              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-red-600 transition hover:bg-red-50"
-              onClick={(e) => { e.stopPropagation(); setOpen(false); onDelete(); }}
-            >
-              <svg className="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-              Delete playlist
-            </button>
-          ) : null}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-// ── Edit modal ──────────────────────────────────────────────────────
-
-type EditModalProps = {
-  playlist: Playlist;
-  allTracksById: Map<string, Track>;
-  saving: boolean;
-  onSave: (patch: { name?: string; trackIds?: string[] }) => Promise<void>;
-  onClose: () => void;
-};
-
-function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditModalProps): JSX.Element {
-  const [name, setName] = useState(playlist.name);
-  const [trackIds, setTrackIds] = useState<string[]>([...playlist.trackIds]);
-
-  function removeTrack(id: string): void {
-    setTrackIds((prev) => prev.filter((t) => t !== id));
-  }
-
-  function moveTrack(index: number, direction: -1 | 1): void {
-    const next = [...trackIds];
-    const target = index + direction;
-    if (target < 0 || target >= next.length) return;
-    [next[index], next[target]] = [next[target]!, next[index]!];
-    setTrackIds(next);
-  }
-
-  async function handleSubmit(e: FormEvent): Promise<void> {
-    e.preventDefault();
-    await onSave({ name: name.trim() || playlist.name, trackIds });
-  }
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      <div className="flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-flaque-clay/60 bg-white shadow-xl">
-        <div className="flex items-center justify-between border-b border-flaque-clay/30 px-5 py-4">
-          <h3 className="font-display text-lg text-flaque-ink">Edit playlist</h3>
-          <button
-            type="button"
-            className="rounded-lg p-1 text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-
-        <form className="flex flex-1 flex-col overflow-hidden" onSubmit={(e) => { void handleSubmit(e); }}>
-          <div className="px-5 pt-4">
-            <label className="block text-sm font-medium text-flaque-ink">Name</label>
-            <input
-              className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              disabled={saving}
-            />
-          </div>
-
-          <div className="mt-4 flex-1 overflow-y-auto px-5">
-            <p className="text-sm font-medium text-flaque-ink">
-              Tracks <span className="text-flaque-steel">({trackIds.length})</span>
-            </p>
-            {trackIds.length === 0 ? (
-              <p className="mt-2 text-sm text-flaque-steel">No tracks in this playlist.</p>
-            ) : (
-              <ul className="mt-2 space-y-1">
-                {trackIds.map((id, index) => {
-                  const track = allTracksById.get(id);
-                  return (
-                    <li key={id} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-2 py-1.5">
-                      <div className="h-8 w-8 shrink-0 overflow-hidden rounded-md">
-                        {track ? (
-                          <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-                        ) : (
-                          <div className="h-full w-full bg-flaque-clay/30" />
-                        )}
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-xs font-medium text-flaque-ink">
-                          {track ? getTrackDisplayTitle(track) : id}
-                        </p>
-                        {track ? (
-                          <p className="truncate text-[10px] text-flaque-steel">
-                            {getTrackDisplayArtist(track) ?? "Unknown artist"}
-                          </p>
-                        ) : null}
-                      </div>
-                      <div className="flex shrink-0 items-center gap-1">
-                        <button
-                          type="button"
-                          className="rounded p-0.5 text-flaque-steel transition hover:text-flaque-ink disabled:opacity-30"
-                          onClick={() => moveTrack(index, -1)}
-                          disabled={index === 0 || saving}
-                          aria-label="Move up"
-                        >
-                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 15l7-7 7 7" />
-                          </svg>
-                        </button>
-                        <button
-                          type="button"
-                          className="rounded p-0.5 text-flaque-steel transition hover:text-flaque-ink disabled:opacity-30"
-                          onClick={() => moveTrack(index, 1)}
-                          disabled={index === trackIds.length - 1 || saving}
-                          aria-label="Move down"
-                        >
-                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" />
-                          </svg>
-                        </button>
-                        <button
-                          type="button"
-                          className="rounded p-0.5 text-red-400 transition hover:text-red-600 disabled:opacity-30"
-                          onClick={() => removeTrack(id)}
-                          disabled={saving}
-                          aria-label="Remove track"
-                        >
-                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
-                          </svg>
-                        </button>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </div>
-
-          <div className="flex justify-end gap-2 border-t border-flaque-clay/30 px-5 py-4">
-            <button
-              type="button"
-              className="rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-steel transition hover:bg-flaque-cream"
-              onClick={onClose}
-              disabled={saving}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              className="rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-flaque-cream transition hover:bg-black disabled:opacity-60"
-              disabled={saving}
-            >
-              {saving ? "Saving…" : "Save"}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
-
-// ── Playlist card ───────────────────────────────────────────────────
+// ── Playlist card (grid) ───────────────────────────────────────────
 
 type PlaylistCardProps = {
   playlist: Playlist;
-  canManage: boolean;
   allTracksById: Map<string, Track>;
   ownerNameById: Record<string, string>;
+  onNavigate: () => void;
   onPlay: () => void;
-  onPatch: (patch: { name?: string; trackIds?: string[] }) => Promise<void>;
-  onDelete: () => void;
+  showBadges?: boolean;
 };
 
-function formatDuration(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = Math.floor(seconds % 60);
-  if (h > 0) return `${h}h ${m}m`;
-  if (m > 0) return `${m}m ${s}s`;
-  return `${s}s`;
-}
-
-function PlaylistCard({
-  playlist,
-  canManage,
-  allTracksById,
-  ownerNameById,
-  onPlay,
-  onPatch,
-  onDelete
-}: PlaylistCardProps): JSX.Element {
-  const [expanded, setExpanded] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [saving, setSaving] = useState(false);
-
-  const tracks = playlist.trackIds.map((id) => allTracksById.get(id)).filter((t): t is Track => t !== undefined);
+function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPlay, showBadges }: PlaylistCardProps): JSX.Element {
   const mosaicTracks = getPlaylistMosaicTracks(playlist.trackIds, allTracksById);
-  const totalDuration = tracks.reduce((sum, t) => sum + t.duration, 0);
   const owner = ownerNameById[playlist.authorId] ?? playlist.authorId;
 
-  function downloadPlaylist(): void {
-    const data = {
-      id: playlist.id,
-      name: playlist.name,
-      visibility: playlist.visibility,
-      tracks: tracks.map((t) => ({
-        id: t.id,
-        title: getTrackDisplayTitle(t),
-        artist: getTrackDisplayArtist(t),
-        album: t.tags.album,
-        duration: t.duration
-      }))
-    };
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${playlist.name}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
-  }
-
-  async function handleSave(patch: { name?: string; trackIds?: string[] }): Promise<void> {
-    setSaving(true);
-    try {
-      await onPatch(patch);
-      setEditOpen(false);
-    } finally {
-      setSaving(false);
-    }
-  }
-
   return (
-    <>
-      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-sm">
-        {/* Header row — cover + info + buttons */}
-        <div
-          className="flex cursor-pointer items-center gap-3 p-3 transition hover:bg-flaque-cream/50"
-          onClick={() => setExpanded((v) => !v)}
-          role="button"
-          tabIndex={0}
-          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setExpanded((v) => !v); }}
-          aria-expanded={expanded}
+    <div
+      className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-sm transition hover:shadow-md"
+      onClick={onNavigate}
+      role="link"
+      tabIndex={0}
+      onKeyDown={(e) => { if (e.key === "Enter") onNavigate(); }}
+    >
+      {/* Cover */}
+      <div className="relative aspect-square w-full overflow-hidden">
+        {playlist.cover ? (
+          <img src={playlistCoverUrl(playlist.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+        ) : (
+          <PlaylistMosaic tracks={mosaicTracks} />
+        )}
+
+        {/* Play button overlay */}
+        <button
+          type="button"
+          className="absolute bottom-2 right-2 flex h-10 w-10 items-center justify-center rounded-full bg-flaque-ink text-white opacity-0 shadow-lg transition group-hover:opacity-100"
+          onClick={(e) => { e.stopPropagation(); onPlay(); }}
+          aria-label={`Play ${playlist.name}`}
         >
-          {/* Mosaic */}
-          <div className="h-14 w-14 shrink-0 overflow-hidden rounded-xl">
-            <PlaylistMosaic tracks={mosaicTracks} />
-          </div>
+          <svg className="h-5 w-5 translate-x-px" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        </button>
+      </div>
 
-          {/* Info */}
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-semibold text-flaque-ink">{playlist.name}</p>
-            <p className="truncate text-xs text-flaque-steel">
-              {playlist.trackIds.length} track{playlist.trackIds.length !== 1 ? "s" : ""}
-              {totalDuration > 0 ? ` · ${formatDuration(totalDuration)}` : ""}
-              {" · "}{owner}
-            </p>
-          </div>
+      {/* Info */}
+      <div className="flex flex-1 flex-col p-3">
+        <p className="truncate text-sm font-semibold text-flaque-ink">{playlist.name}</p>
+        {playlist.description ? (
+          <p className="mt-0.5 line-clamp-1 text-xs text-flaque-steel">{playlist.description}</p>
+        ) : null}
+        <p className="mt-1 truncate text-xs text-flaque-steel">
+          {owner} &middot; {playlist.trackIds.length} track{playlist.trackIds.length !== 1 ? "s" : ""}
+        </p>
 
-          {/* Actions */}
-          <div className="flex shrink-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
-            <button
-              type="button"
-              className="flex h-8 w-8 items-center justify-center rounded-xl bg-flaque-ink text-white transition hover:bg-black"
-              onClick={onPlay}
-              aria-label={`Play ${playlist.name}`}
-            >
-              <svg className="h-4 w-4 translate-x-px" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M8 5v14l11-7z" />
-              </svg>
-            </button>
-
-            <PlaylistMenu
-              canManage={canManage}
-              onEdit={() => setEditOpen(true)}
-              onDownload={downloadPlaylist}
-              onDelete={onDelete}
-            />
-
-            {/* Chevron */}
-            <svg
-              className={`h-4 w-4 shrink-0 text-flaque-steel/60 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
-              fill="none" viewBox="0 0 24 24" stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg>
-          </div>
-        </div>
-
-        {/* Expanded track list */}
-        {expanded ? (
-          <div className="overflow-hidden rounded-b-2xl border-t border-flaque-clay/30">
-            {tracks.length === 0 ? (
-              <p className="px-4 py-3 text-sm text-flaque-steel">No playable tracks.</p>
-            ) : (
-              <ul>
-                {tracks.map((track, index) => (
-                  <li
-                    key={track.id}
-                    className="flex items-center gap-3 border-b border-flaque-clay/20 px-3 py-2 last:border-b-0"
-                  >
-                    <span className="w-5 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
-                    <div className="h-8 w-8 shrink-0 overflow-hidden rounded-md">
-                      <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <p className="flex items-center gap-1 truncate text-xs font-medium text-flaque-ink">
-                        {track.tags.extra?.lyrics ? (
-                          <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
-                            L
-                          </span>
-                        ) : null}
-                        <span className="truncate">{getTrackDisplayTitle(track)}</span>
-                      </p>
-                      <p className="truncate text-[10px] text-flaque-steel">
-                        {getTrackDisplayArtist(track) ?? "Unknown artist"}
-                        {track.tags.album ? ` · ${track.tags.album}` : ""}
-                      </p>
-                    </div>
-                    <span className="shrink-0 font-mono text-[10px] text-flaque-steel/60">
-                      {formatDuration(track.duration)}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            )}
+        {/* Badges */}
+        {showBadges ? (
+          <div className="mt-1.5 flex items-center gap-2">
+            {playlist.heartCount > 0 ? (
+              <span className="flex items-center gap-0.5 text-[10px] text-red-400">
+                <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                </svg>
+                {playlist.heartCount}
+              </span>
+            ) : null}
+            {playlist.listenCount > 0 ? (
+              <span className="flex items-center gap-0.5 text-[10px] text-flaque-steel">
+                <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                {playlist.listenCount}
+              </span>
+            ) : null}
           </div>
         ) : null}
       </div>
-
-      {editOpen ? (
-        <EditModal
-          playlist={playlist}
-          allTracksById={allTracksById}
-          saving={saving}
-          onSave={handleSave}
-          onClose={() => setEditOpen(false)}
-        />
-      ) : null}
-    </>
+    </div>
   );
 }
 
-// ── Main section ────────────────────────────────────────────────────
+// ── Section header ─────────────────────────────────────────────────
+
+function SectionHeader({ title }: { title: string }): JSX.Element {
+  return <h3 className="font-display text-lg text-flaque-ink">{title}</h3>;
+}
+
+// ── Main section ───────────────────────────────────────────────────
 
 export function LibraryPlaylistSection({
   availablePlaylists,
   manageablePlaylists,
   ownerNameById,
   allTracksById,
+  user,
   onCreatePlaylist,
   onPlayPlaylist,
-  onPatchPlaylist,
-  onDeletePlaylist
+  onPatchPlaylist: _onPatchPlaylist,
+  onDeletePlaylist: _onDeletePlaylist,
+  onNavigateToPlaylist,
+  onReportPlaylistListen
 }: LibraryPlaylistSectionProps): JSX.Element {
   const [playlistName, setPlaylistName] = useState("");
   const [playlistVisibility, setPlaylistVisibility] = useState<PlaylistVisibility>("private");
   const [submitting, setSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
-  const manageableIds = new Set(manageablePlaylists.map((p) => p.id));
+  const myPlaylists = availablePlaylists.filter((p) => p.authorId === user.id);
+  const popularPlaylists = availablePlaylists
+    .filter((p) => p.visibility === "public" && p.authorId !== user.id)
+    .sort((a, b) => (b.heartCount * 3 + b.listenCount) - (a.heartCount * 3 + a.listenCount));
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
@@ -535,58 +196,92 @@ export function LibraryPlaylistSection({
     }
   }
 
+  function handlePlay(playlist: Playlist): void {
+    void onReportPlaylistListen(playlist.id);
+    onPlayPlaylist(playlist);
+  }
+
   return (
-    <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
-      <h2 className="font-display text-xl text-flaque-ink">Playlists</h2>
+    <div className="m-4 space-y-6">
+      {/* ── My Playlists ──────────────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <SectionHeader title="My Playlists" />
 
-      <form
-        className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]"
-        onSubmit={(event) => { void handleSubmit(event); }}
-      >
-        <input
-          className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-          type="text"
-          placeholder="New playlist name"
-          value={playlistName}
-          onChange={(event) => setPlaylistName(event.target.value)}
-        />
-        <select
-          className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-          value={playlistVisibility}
-          onChange={(event) => setPlaylistVisibility(event.target.value as PlaylistVisibility)}
+        <form
+          className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]"
+          onSubmit={(event) => { void handleSubmit(event); }}
         >
-          <option value="private">Private</option>
-          <option value="public">Public</option>
-        </select>
-        <button
-          className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
-          type="submit"
-          disabled={submitting || !playlistName.trim()}
-        >
-          {submitting ? "Creating…" : "Create"}
-        </button>
-      </form>
+          <input
+            className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+            type="text"
+            placeholder="New playlist name"
+            value={playlistName}
+            onChange={(event) => setPlaylistName(event.target.value)}
+          />
+          <select
+            className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+            value={playlistVisibility}
+            onChange={(event) => setPlaylistVisibility(event.target.value as PlaylistVisibility)}
+          >
+            <option value="private">Private</option>
+            <option value="public">Public</option>
+          </select>
+          <button
+            className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+            type="submit"
+            disabled={submitting || !playlistName.trim()}
+          >
+            {submitting ? "Creating..." : "Create"}
+          </button>
+        </form>
 
-      {statusMessage ? <p className="mt-2 text-sm text-flaque-steel">{statusMessage}</p> : null}
+        {statusMessage ? <p className="mt-2 text-sm text-flaque-steel">{statusMessage}</p> : null}
 
-      <div className="mt-4">
-        {availablePlaylists.length === 0 ? (
-          <p className="text-sm text-flaque-steel">No playlists yet.</p>
+        {myPlaylists.length === 0 ? (
+          <p className="mt-4 text-sm text-flaque-steel">No playlists yet.</p>
         ) : (
-          availablePlaylists.map((playlist) => (
-            <PlaylistCard
-              key={playlist.id}
-              playlist={playlist}
-              canManage={manageableIds.has(playlist.id)}
-              allTracksById={allTracksById}
-              ownerNameById={ownerNameById}
-              onPlay={() => onPlayPlaylist(playlist)}
-              onPatch={(patch) => onPatchPlaylist(playlist.id, patch)}
-              onDelete={() => { void onDeletePlaylist(playlist.id); }}
-            />
-          ))
+          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            {myPlaylists.map((playlist) => (
+              <PlaylistCard
+                key={playlist.id}
+                playlist={playlist}
+                allTracksById={allTracksById}
+                ownerNameById={ownerNameById}
+                onNavigate={() => onNavigateToPlaylist(playlist.id)}
+                onPlay={() => handlePlay(playlist)}
+              />
+            ))}
+          </div>
         )}
-      </div>
-    </section>
+      </section>
+
+      {/* ── Popular Playlists ─────────────────────────────────────── */}
+      {popularPlaylists.length > 0 ? (
+        <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+          <SectionHeader title="Popular Playlists" />
+          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            {popularPlaylists.map((playlist) => (
+              <PlaylistCard
+                key={playlist.id}
+                playlist={playlist}
+                allTracksById={allTracksById}
+                ownerNameById={ownerNameById}
+                onNavigate={() => onNavigateToPlaylist(playlist.id)}
+                onPlay={() => handlePlay(playlist)}
+                showBadges
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {/* ── Automatic Playlists (placeholder) ─────────────────────── */}
+      <section className="rounded-xl border border-dashed border-flaque-clay/60 bg-white/60 p-5 backdrop-blur-sm">
+        <SectionHeader title="Automatic Playlists" />
+        <p className="mt-2 text-sm text-flaque-steel">
+          Automatic playlists will appear here once generated.
+        </p>
+      </section>
+    </div>
   );
 }

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -2,8 +2,9 @@ import { HomePanels } from "./HomePanels";
 import { LibraryAlbumsSection } from "./LibraryAlbumsSection";
 import { LibraryArtistsSection } from "./LibraryArtistsSection";
 import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
+import { PlaylistDetailView } from "./PlaylistDetailView";
 import { PaginatedLibrary } from "./PaginatedLibrary";
-import type { AlbumEntry, ArtistEntry, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track } from "../types";
+import type { AlbumEntry, ArtistEntry, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
 import type { LibraryFilters, LibrarySection } from "../types/library";
 import { navigateTo } from "../utils/appUtils";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
@@ -13,10 +14,15 @@ type LibraryWorkspaceProps = {
   onSectionChange: (section: LibrarySection) => void;
   availablePlaylists: Playlist[];
   ownerNameById: Record<string, string>;
+  user: User;
+  playlistDetailId: string | null;
+  onPlaylistDetailNavigate: (id: string | null) => void;
   onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
   onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
+  onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
+  onReportPlaylistListen: (playlistId: string) => Promise<void>;
   allTracksById: Map<string, Track>;
   libraryMetadataError: string | null;
   loadingLibraryArtists: boolean;
@@ -79,10 +85,15 @@ export function LibraryWorkspace({
   onSectionChange,
   availablePlaylists,
   ownerNameById,
+  user,
+  playlistDetailId,
+  onPlaylistDetailNavigate,
   onCreatePlaylist,
   onPlayPlaylist,
   onPatchPlaylist,
   onDeletePlaylist,
+  onHeartPlaylist,
+  onReportPlaylistListen,
   allTracksById,
   libraryMetadataError,
   loadingLibraryArtists,
@@ -137,16 +148,36 @@ export function LibraryWorkspace({
   return (
     <div className="h-full min-h-0 space-y-4 overflow-y-auto">
       {activeLibrarySection === "playlists" ? (
-        <LibraryPlaylistSection
-          availablePlaylists={availablePlaylists}
-          manageablePlaylists={manageablePlaylists}
-          ownerNameById={ownerNameById}
-          allTracksById={allTracksById}
-          onCreatePlaylist={onCreatePlaylist}
-          onPlayPlaylist={onPlayPlaylist}
-          onPatchPlaylist={onPatchPlaylist}
-          onDeletePlaylist={onDeletePlaylist}
-        />
+        playlistDetailId ? (
+          <PlaylistDetailView
+            playlistId={playlistDetailId}
+            availablePlaylists={availablePlaylists}
+            manageablePlaylists={manageablePlaylists}
+            allTracksById={allTracksById}
+            ownerNameById={ownerNameById}
+            user={user}
+            onBack={() => onPlaylistDetailNavigate(null)}
+            onPlay={onPlayPlaylist}
+            onPatch={onPatchPlaylist}
+            onDelete={onDeletePlaylist}
+            onHeart={onHeartPlaylist}
+            onReportListen={onReportPlaylistListen}
+          />
+        ) : (
+          <LibraryPlaylistSection
+            availablePlaylists={availablePlaylists}
+            manageablePlaylists={manageablePlaylists}
+            ownerNameById={ownerNameById}
+            allTracksById={allTracksById}
+            user={user}
+            onCreatePlaylist={onCreatePlaylist}
+            onPlayPlaylist={onPlayPlaylist}
+            onPatchPlaylist={onPatchPlaylist}
+            onDeletePlaylist={onDeletePlaylist}
+            onNavigateToPlaylist={onPlaylistDetailNavigate}
+            onReportPlaylistListen={onReportPlaylistListen}
+          />
+        )
       ) : null}
 
       {activeLibrarySection === "artists" ? (

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -1,0 +1,590 @@
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+
+import { coverUrl, playlistCoverUrl } from "../api";
+import type { Playlist, PlaylistVisibility, Track, User } from "../types";
+import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+
+type PlaylistDetailViewProps = {
+  playlistId: string;
+  availablePlaylists: Playlist[];
+  manageablePlaylists: Playlist[];
+  allTracksById: Map<string, Track>;
+  ownerNameById: Record<string, string>;
+  user: User;
+  onBack: () => void;
+  onPlay: (playlist: Playlist) => void;
+  onPatch: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string }) => Promise<void>;
+  onDelete: (playlistId: string) => Promise<void>;
+  onHeart: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
+  onReportListen: (playlistId: string) => Promise<void>;
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+function getPlaylistMosaicTracks(trackIds: string[], allTracksById: Map<string, Track>): Track[] {
+  const seen = new Set<string>();
+  const result: Track[] = [];
+  for (const id of trackIds) {
+    if (result.length >= 4) break;
+    const track = allTracksById.get(id);
+    if (!track) continue;
+    const albumKey = track.tags.album ?? track.id;
+    if (!seen.has(albumKey)) {
+      seen.add(albumKey);
+      result.push(track);
+    }
+  }
+  return result;
+}
+
+// ── Large cover display ────────────────────────────────────────────
+
+function PlaylistCover({ playlist, mosaicTracks }: { playlist: Playlist; mosaicTracks: Track[] }): JSX.Element {
+  if (playlist.cover) {
+    return (
+      <img
+        src={playlistCoverUrl(playlist.id)}
+        alt={playlist.name}
+        className="h-full w-full rounded-2xl object-cover"
+      />
+    );
+  }
+
+  const slots = Array.from({ length: 4 }, (_, i) => mosaicTracks[i] ?? null);
+
+  if (mosaicTracks.length === 0) {
+    return (
+      <div className="flex h-full w-full items-center justify-center rounded-2xl bg-flaque-clay/20">
+        <svg className="h-16 w-16 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+            d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+        </svg>
+      </div>
+    );
+  }
+
+  if (mosaicTracks.length === 1) {
+    return (
+      <img
+        src={coverUrl(mosaicTracks[0]!.id)}
+        alt=""
+        className="h-full w-full rounded-2xl object-cover"
+      />
+    );
+  }
+
+  return (
+    <div className="grid h-full w-full grid-cols-2 grid-rows-2 overflow-hidden rounded-2xl">
+      {slots.map((track, i) =>
+        track ? (
+          <img key={i} src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+        ) : (
+          <div key={i} className="bg-flaque-clay/20" />
+        )
+      )}
+    </div>
+  );
+}
+
+// ── Edit modal ─────────────────────────────────────────────────────
+
+type EditModalProps = {
+  playlist: Playlist;
+  allTracksById: Map<string, Track>;
+  saving: boolean;
+  onSave: (patch: { name?: string; trackIds?: string[]; description?: string }) => Promise<void>;
+  onClose: () => void;
+};
+
+function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditModalProps): JSX.Element {
+  const [name, setName] = useState(playlist.name);
+  const [description, setDescription] = useState(playlist.description);
+  const [trackIds, setTrackIds] = useState<string[]>([...playlist.trackIds]);
+
+  function removeTrack(id: string): void {
+    setTrackIds((prev) => prev.filter((t) => t !== id));
+  }
+
+  function moveTrack(index: number, direction: -1 | 1): void {
+    const next = [...trackIds];
+    const target = index + direction;
+    if (target < 0 || target >= next.length) return;
+    [next[index], next[target]] = [next[target]!, next[index]!];
+    setTrackIds(next);
+  }
+
+  async function handleSubmit(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    await onSave({
+      name: name.trim() || playlist.name,
+      description: description.trim(),
+      trackIds
+    });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-flaque-clay/60 bg-white shadow-xl">
+        <div className="flex items-center justify-between border-b border-flaque-clay/30 px-5 py-4">
+          <h3 className="font-display text-lg text-flaque-ink">Edit playlist</h3>
+          <button
+            type="button"
+            className="rounded-lg p-1 text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <form className="flex flex-1 flex-col overflow-hidden" onSubmit={(e) => { void handleSubmit(e); }}>
+          <div className="space-y-3 px-5 pt-4">
+            <div>
+              <label className="block text-sm font-medium text-flaque-ink">Name</label>
+              <input
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                disabled={saving}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-flaque-ink">Description</label>
+              <textarea
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                rows={3}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                disabled={saving}
+                placeholder="Add a description..."
+              />
+            </div>
+          </div>
+
+          <div className="mt-4 flex-1 overflow-y-auto px-5">
+            <p className="text-sm font-medium text-flaque-ink">
+              Tracks <span className="text-flaque-steel">({trackIds.length})</span>
+            </p>
+            {trackIds.length === 0 ? (
+              <p className="mt-2 text-sm text-flaque-steel">No tracks in this playlist.</p>
+            ) : (
+              <ul className="mt-2 space-y-1">
+                {trackIds.map((id, index) => {
+                  const track = allTracksById.get(id);
+                  return (
+                    <li key={id} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-2 py-1.5">
+                      <div className="h-8 w-8 shrink-0 overflow-hidden rounded-md">
+                        {track ? (
+                          <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+                        ) : (
+                          <div className="h-full w-full bg-flaque-clay/30" />
+                        )}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-xs font-medium text-flaque-ink">
+                          {track ? getTrackDisplayTitle(track) : id}
+                        </p>
+                        {track ? (
+                          <p className="truncate text-[10px] text-flaque-steel">
+                            {getTrackDisplayArtist(track) ?? "Unknown artist"}
+                          </p>
+                        ) : null}
+                      </div>
+                      <div className="flex shrink-0 items-center gap-1">
+                        <button
+                          type="button"
+                          className="rounded p-0.5 text-flaque-steel transition hover:text-flaque-ink disabled:opacity-30"
+                          onClick={() => moveTrack(index, -1)}
+                          disabled={index === 0 || saving}
+                          aria-label="Move up"
+                        >
+                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 15l7-7 7 7" />
+                          </svg>
+                        </button>
+                        <button
+                          type="button"
+                          className="rounded p-0.5 text-flaque-steel transition hover:text-flaque-ink disabled:opacity-30"
+                          onClick={() => moveTrack(index, 1)}
+                          disabled={index === trackIds.length - 1 || saving}
+                          aria-label="Move down"
+                        >
+                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" />
+                          </svg>
+                        </button>
+                        <button
+                          type="button"
+                          className="rounded p-0.5 text-red-400 transition hover:text-red-600 disabled:opacity-30"
+                          onClick={() => removeTrack(id)}
+                          disabled={saving}
+                          aria-label="Remove track"
+                        >
+                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                          </svg>
+                        </button>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 border-t border-flaque-clay/30 px-5 py-4">
+            <button
+              type="button"
+              className="rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-steel transition hover:bg-flaque-cream"
+              onClick={onClose}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-flaque-cream transition hover:bg-black disabled:opacity-60"
+              disabled={saving}
+            >
+              {saving ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────
+
+export function PlaylistDetailView({
+  playlistId,
+  availablePlaylists,
+  manageablePlaylists,
+  allTracksById,
+  ownerNameById,
+  user,
+  onBack,
+  onPlay,
+  onPatch,
+  onDelete,
+  onHeart,
+  onReportListen
+}: PlaylistDetailViewProps): JSX.Element {
+  const playlist = availablePlaylists.find((p) => p.id === playlistId);
+  const [editOpen, setEditOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [hearting, setHearting] = useState(false);
+  const listenReportedRef = useRef(false);
+
+  const canManage = useMemo(() => {
+    if (!playlist) return false;
+    return manageablePlaylists.some((p) => p.id === playlist.id);
+  }, [playlist, manageablePlaylists]);
+
+  const canEdit = useMemo(() => {
+    if (!playlist) return false;
+    return canManage || playlist.collaborators.includes(user.id);
+  }, [playlist, canManage, user.id]);
+
+  const canHeart = useMemo(() => {
+    if (!playlist) return false;
+    return playlist.visibility === "public" && playlist.authorId !== user.id;
+  }, [playlist, user.id]);
+
+  const hasHearted = useMemo(() => {
+    if (!playlist) return false;
+    return playlist.hearts.includes(user.id);
+  }, [playlist, user.id]);
+
+  const tracks = useMemo(() => {
+    if (!playlist) return [];
+    return playlist.trackIds
+      .map((id) => allTracksById.get(id))
+      .filter((t): t is Track => t !== undefined);
+  }, [playlist, allTracksById]);
+
+  const mosaicTracks = useMemo(() => {
+    if (!playlist) return [];
+    return getPlaylistMosaicTracks(playlist.trackIds, allTracksById);
+  }, [playlist, allTracksById]);
+
+  const totalDuration = useMemo(() => tracks.reduce((sum, t) => sum + t.duration, 0), [tracks]);
+  const owner = playlist ? (ownerNameById[playlist.authorId] ?? playlist.authorId) : "";
+
+  useEffect(() => {
+    listenReportedRef.current = false;
+  }, [playlistId]);
+
+  if (!playlist) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <button
+          type="button"
+          className="mb-4 flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+          onClick={onBack}
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to playlists
+        </button>
+        <p className="text-sm text-flaque-steel">Playlist not found.</p>
+      </section>
+    );
+  }
+
+  function handlePlayAll(): void {
+    if (!playlist) return;
+    if (!listenReportedRef.current) {
+      listenReportedRef.current = true;
+      void onReportListen(playlist.id);
+    }
+    onPlay(playlist);
+  }
+
+  function handleShufflePlay(): void {
+    if (!playlist || tracks.length === 0) return;
+    if (!listenReportedRef.current) {
+      listenReportedRef.current = true;
+      void onReportListen(playlist.id);
+    }
+    const shuffled = [...tracks].sort(() => Math.random() - 0.5);
+    const shuffledPlaylist: Playlist = { ...playlist, trackIds: shuffled.map((t) => t.id) };
+    onPlay(shuffledPlaylist);
+  }
+
+  async function handleHeart(): Promise<void> {
+    if (hearting) return;
+    setHearting(true);
+    try {
+      await onHeart(playlist!.id);
+    } finally {
+      setHearting(false);
+    }
+  }
+
+  async function handleSave(patch: { name?: string; trackIds?: string[]; description?: string }): Promise<void> {
+    setSaving(true);
+    try {
+      await onPatch(playlist!.id, patch);
+      setEditOpen(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(): Promise<void> {
+    await onDelete(playlist!.id);
+    onBack();
+  }
+
+  return (
+    <section className="m-4 space-y-4">
+      {/* Back button */}
+      <button
+        type="button"
+        className="flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+        onClick={onBack}
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        Back to playlists
+      </button>
+
+      {/* Header card */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-col gap-5 sm:flex-row">
+          {/* Cover */}
+          <div className="h-48 w-48 shrink-0 self-center overflow-hidden sm:self-start">
+            <PlaylistCover playlist={playlist} mosaicTracks={mosaicTracks} />
+          </div>
+
+          {/* Info */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <div className="flex items-start gap-2">
+              <h2 className="font-display text-2xl text-flaque-ink">{playlist.name}</h2>
+              <span className={`mt-1 shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+                playlist.visibility === "public"
+                  ? "bg-green-100 text-green-700"
+                  : "bg-flaque-clay/30 text-flaque-steel"
+              }`}>
+                {playlist.visibility}
+              </span>
+            </div>
+
+            {playlist.description ? (
+              <p className="mt-1 text-sm text-flaque-steel">{playlist.description}</p>
+            ) : null}
+
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-flaque-steel">
+              <span>by {owner}</span>
+              <span>{playlist.trackIds.length} track{playlist.trackIds.length !== 1 ? "s" : ""}</span>
+              {totalDuration > 0 ? <span>{formatDuration(totalDuration)}</span> : null}
+              {playlist.listenCount > 0 ? (
+                <span className="flex items-center gap-0.5">
+                  <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  {playlist.listenCount}
+                </span>
+              ) : null}
+            </div>
+
+            {playlist.collaborators.length > 0 ? (
+              <div className="mt-2 flex flex-wrap gap-1">
+                <span className="text-xs text-flaque-steel">Collaborators:</span>
+                {playlist.collaborators.map((collab) => (
+                  <span key={collab} className="rounded-full bg-flaque-cream px-2 py-0.5 text-[10px] font-medium text-flaque-ink">
+                    {ownerNameById[collab] ?? collab}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+
+            {/* Action buttons */}
+            <div className="mt-auto flex flex-wrap items-center gap-2 pt-4">
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black"
+                onClick={handlePlayAll}
+              >
+                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+                Play all
+              </button>
+
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
+                onClick={handleShufflePlay}
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4" />
+                </svg>
+                Shuffle
+              </button>
+
+              {canHeart ? (
+                <button
+                  type="button"
+                  className={`flex items-center gap-1 rounded-xl border px-3 py-2 text-sm transition ${
+                    hasHearted
+                      ? "border-red-200 bg-red-50 text-red-600 hover:bg-red-100"
+                      : "border-flaque-clay text-flaque-steel hover:bg-flaque-cream hover:text-flaque-ink"
+                  }`}
+                  onClick={() => { void handleHeart(); }}
+                  disabled={hearting}
+                >
+                  <svg className="h-4 w-4" fill={hasHearted ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                  </svg>
+                  {playlist.heartCount > 0 ? playlist.heartCount : ""}
+                </button>
+              ) : playlist.heartCount > 0 ? (
+                <span className="flex items-center gap-1 text-xs text-flaque-steel">
+                  <svg className="h-3.5 w-3.5 text-red-400" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                  </svg>
+                  {playlist.heartCount}
+                </span>
+              ) : null}
+
+              {canEdit ? (
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-3 py-2 text-sm text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
+                  onClick={() => setEditOpen(true)}
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                  Edit
+                </button>
+              ) : null}
+
+              {canManage ? (
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 rounded-xl border border-red-200 px-3 py-2 text-sm text-red-500 transition hover:bg-red-50 hover:text-red-600"
+                  onClick={() => { void handleDelete(); }}
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                  Delete
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Track list */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
+        {tracks.length === 0 ? (
+          <p className="px-5 py-4 text-sm text-flaque-steel">No playable tracks.</p>
+        ) : (
+          <ul>
+            {tracks.map((track, index) => (
+              <li
+                key={track.id}
+                className="flex items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+              >
+                <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
+                <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
+                  <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
+                    {track.tags.extra?.lyrics ? (
+                      <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
+                        L
+                      </span>
+                    ) : null}
+                    <span className="truncate">{getTrackDisplayTitle(track)}</span>
+                  </p>
+                  <p className="truncate text-xs text-flaque-steel">
+                    {getTrackDisplayArtist(track) ?? "Unknown artist"}
+                    {track.tags.album ? ` \u00b7 ${track.tags.album}` : ""}
+                  </p>
+                </div>
+                <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
+                  {formatDuration(track.duration)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Edit modal */}
+      {editOpen ? (
+        <EditModal
+          playlist={playlist}
+          allTracksById={allTracksById}
+          saving={saving}
+          onSave={handleSave}
+          onClose={() => setEditOpen(false)}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/hooks/useLibraryCommands.ts
+++ b/frontend/src/hooks/useLibraryCommands.ts
@@ -6,8 +6,10 @@ import {
   createPlaylist,
   deletePlaylist,
   deleteTrackFile,
+  heartPlaylist,
   patchPlaylist,
   rebuildIndex,
+  reportPlaylistListen,
   updateTrackMetadata,
   uploadTracks,
   type UploadTrackPreview,
@@ -54,6 +56,8 @@ type UseLibraryCommandsResult = {
   handleDeletePlaylist: (playlistId: string) => Promise<void>;
   handleBulkDeleteTracks: (trackIds: string[]) => Promise<void>;
   handleBulkUpdateTrackMetadata: (trackIds: string[], patch: TrackMetadataPatch) => Promise<void>;
+  handleHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
+  handleReportPlaylistListen: (playlistId: string) => Promise<void>;
 };
 
 /**
@@ -232,6 +236,16 @@ export function useLibraryCommands({
     refreshPaginatedLibrary();
   }
 
+  async function handleHeartPlaylist(playlistId: string): Promise<{ hearted: boolean; heartCount: number }> {
+    const result = await heartPlaylist(playlistId);
+    await refreshCurrentLibrary();
+    return result;
+  }
+
+  async function handleReportPlaylistListen(playlistId: string): Promise<void> {
+    await reportPlaylistListen(playlistId);
+  }
+
   return {
     handleUpload,
     handleInspectUploadFile,
@@ -243,6 +257,8 @@ export function useLibraryCommands({
     handleCreatePlaylist,
     handleAddTrackToPlaylist,
     handlePatchPlaylist,
-    handleDeletePlaylist
+    handleDeletePlaylist,
+    handleHeartPlaylist,
+    handleReportPlaylistListen
   };
 }

--- a/frontend/src/hooks/useSessionRoutingState.ts
+++ b/frontend/src/hooks/useSessionRoutingState.ts
@@ -25,6 +25,8 @@ type UseSessionRoutingStateResult = {
   setActiveLibrarySection: Dispatch<SetStateAction<LibrarySection>>;
   activeConfigSection: ConfigSection;
   setActiveConfigSection: Dispatch<SetStateAction<ConfigSection>>;
+  playlistDetailId: string | null;
+  setPlaylistDetailId: Dispatch<SetStateAction<string | null>>;
   handleLogin: (login: string, password: string) => Promise<void>;
   notifyAuthStateChanged: (kind: AuthSyncEvent["kind"]) => void;
 };
@@ -52,6 +54,10 @@ export function useSessionRoutingState(): UseSessionRoutingStateResult {
     return route.view === "config" && route.section
       ? (route.section as ConfigSection)
       : "index";
+  });
+  const [playlistDetailId, setPlaylistDetailId] = useState<string | null>(() => {
+    const route = getRouteFromLocation();
+    return route.view === "library" && route.section === "playlists" ? route.param : null;
   });
 
   const sourceIdRef = useRef(createTabId());
@@ -151,6 +157,9 @@ export function useSessionRoutingState(): UseSessionRoutingStateResult {
 
       if (route.view === "library" && route.section) {
         setActiveLibrarySection(route.section as LibrarySection);
+        setPlaylistDetailId(route.section === "playlists" ? route.param : null);
+      } else {
+        setPlaylistDetailId(null);
       }
       if (route.view === "config" && route.section) {
         setActiveConfigSection(route.section as ConfigSection);
@@ -179,8 +188,11 @@ export function useSessionRoutingState(): UseSessionRoutingStateResult {
       : resolvedView === "config"
         ? activeConfigSection
         : null;
-    syncRouteToLocation(resolvedView, section);
-  }, [activeView, activeLibrarySection, activeConfigSection, sessionChecked, user?.role]);
+    const param = resolvedView === "library" && activeLibrarySection === "playlists"
+      ? playlistDetailId
+      : null;
+    syncRouteToLocation(resolvedView, section, param);
+  }, [activeView, activeLibrarySection, activeConfigSection, playlistDetailId, sessionChecked, user?.role]);
 
   async function handleLogin(loginValue: string, password: string): Promise<void> {
     const authenticatedUser = await login(loginValue, password);
@@ -200,6 +212,8 @@ export function useSessionRoutingState(): UseSessionRoutingStateResult {
     setActiveLibrarySection,
     activeConfigSection,
     setActiveConfigSection,
+    playlistDetailId,
+    setPlaylistDetailId,
     handleLogin,
     notifyAuthStateChanged
   };

--- a/frontend/src/utils/appUtils.test.ts
+++ b/frontend/src/utils/appUtils.test.ts
@@ -81,29 +81,37 @@ describe("appUtils", () => {
     expect(buildPathForRoute("upload")).toBe("/upload");
     expect(buildPathForRoute("player")).toBe("/player");
     expect(buildPathForRoute("account")).toBe("/account");
+    expect(buildPathForRoute("library", "playlists", "user-1:my-playlist")).toBe("/library/playlists/user-1%3Amy-playlist");
+    expect(buildPathForRoute("library", "playlists", null)).toBe("/library/playlists");
   });
 
   it("reads route from location pathname", () => {
     window.history.replaceState({}, "", "/settings/server");
-    expect(getRouteFromLocation()).toEqual({ view: "config", section: "server" });
+    expect(getRouteFromLocation()).toEqual({ view: "config", section: "server", param: null });
 
     window.history.replaceState({}, "", "/library/artists");
-    expect(getRouteFromLocation()).toEqual({ view: "library", section: "artists" });
+    expect(getRouteFromLocation()).toEqual({ view: "library", section: "artists", param: null });
 
     window.history.replaceState({}, "", "/upload");
-    expect(getRouteFromLocation()).toEqual({ view: "upload", section: null });
+    expect(getRouteFromLocation()).toEqual({ view: "upload", section: null, param: null });
 
     window.history.replaceState({}, "", "/");
-    expect(getRouteFromLocation()).toEqual({ view: "library", section: "home" });
+    expect(getRouteFromLocation()).toEqual({ view: "library", section: "home", param: null });
 
     window.history.replaceState({}, "", "/unknown-path");
-    expect(getRouteFromLocation()).toEqual({ view: "library", section: "home" });
+    expect(getRouteFromLocation()).toEqual({ view: "library", section: "home", param: null });
+  });
+
+  it("parses playlist detail route with dynamic segment", () => {
+    window.history.replaceState({}, "", "/library/playlists/user-1%3Amy-playlist");
+    const route = getRouteFromLocation();
+    expect(route).toEqual({ view: "library", section: "playlists", param: "user-1:my-playlist" });
   });
 
   it("redirects legacy view query param to path", () => {
     window.history.replaceState({}, "", "/?view=config");
     const route = getRouteFromLocation();
-    expect(route).toEqual({ view: "config", section: "index" });
+    expect(route).toEqual({ view: "config", section: "index", param: null });
     expect(window.location.pathname).toBe("/settings");
     expect(window.location.search).toBe("");
   });

--- a/frontend/src/utils/appUtils.ts
+++ b/frontend/src/utils/appUtils.ts
@@ -6,6 +6,7 @@ export type ViewName = "library" | "upload" | "player" | "config" | "account";
 export type AppRoute = {
   view: ViewName;
   section: string | null;
+  param: string | null;
 };
 
 export type StoredQueueSnapshot = {
@@ -159,32 +160,39 @@ export function getAdjacentTrackInQueue(
 }
 
 const PATH_MAP: Record<string, AppRoute> = {
-  "": { view: "library", section: "home" },
-  "library": { view: "library", section: "home" },
-  "library/home": { view: "library", section: "home" },
-  "library/music": { view: "library", section: "music" },
-  "library/artists": { view: "library", section: "artists" },
-  "library/albums": { view: "library", section: "albums" },
-  "library/playlists": { view: "library", section: "playlists" },
-  "upload": { view: "upload", section: null },
-  "player": { view: "player", section: null },
-  "account": { view: "account", section: null },
-  "settings": { view: "config", section: "index" },
-  "settings/index": { view: "config", section: "index" },
-  "settings/files": { view: "config", section: "files" },
-  "settings/users": { view: "config", section: "users" },
-  "settings/server": { view: "config", section: "server" },
-  "settings/backup": { view: "config", section: "backup" }
+  "": { view: "library", section: "home", param: null },
+  "library": { view: "library", section: "home", param: null },
+  "library/home": { view: "library", section: "home", param: null },
+  "library/music": { view: "library", section: "music", param: null },
+  "library/artists": { view: "library", section: "artists", param: null },
+  "library/albums": { view: "library", section: "albums", param: null },
+  "library/playlists": { view: "library", section: "playlists", param: null },
+  "upload": { view: "upload", section: null, param: null },
+  "player": { view: "player", section: null, param: null },
+  "account": { view: "account", section: null, param: null },
+  "settings": { view: "config", section: "index", param: null },
+  "settings/index": { view: "config", section: "index", param: null },
+  "settings/files": { view: "config", section: "files", param: null },
+  "settings/users": { view: "config", section: "users", param: null },
+  "settings/server": { view: "config", section: "server", param: null },
+  "settings/backup": { view: "config", section: "backup", param: null }
 };
+
+const DYNAMIC_PREFIXES: Array<{ prefix: string; route: Omit<AppRoute, "param"> }> = [
+  { prefix: "library/playlists/", route: { view: "library", section: "playlists" } }
+];
 
 const VALID_VIEWS = new Set<string>(["library", "upload", "player", "config", "account"]);
 
 /**
  * Build a URL path for a given view and optional section.
  */
-export function buildPathForRoute(view: ViewName, section?: string | null): string {
+export function buildPathForRoute(view: ViewName, section?: string | null, param?: string | null): string {
   if (view === "library") {
     const s = section ?? "home";
+    if (s === "playlists" && param) {
+      return `/library/playlists/${encodeURIComponent(param)}`;
+    }
     return s === "home" ? "/" : `/library/${s}`;
   }
   if (view === "config") {
@@ -200,7 +208,7 @@ export function buildPathForRoute(view: ViewName, section?: string | null): stri
  */
 export function getRouteFromLocation(): AppRoute {
   if (typeof window === "undefined") {
-    return { view: "library", section: "home" };
+    return { view: "library", section: "home", param: null };
   }
 
   const params = new URLSearchParams(window.location.search);
@@ -212,24 +220,36 @@ export function getRouteFromLocation(): AppRoute {
     window.history.replaceState(null, "", `${path}${search}${window.location.hash}`);
     return {
       view: legacyView as ViewName,
-      section: legacyView === "config" ? "index" : legacyView === "library" ? "home" : null
+      section: legacyView === "config" ? "index" : legacyView === "library" ? "home" : null,
+      param: null
     };
   }
 
   const raw = window.location.pathname.replace(/^\/+/, "").replace(/\/+$/, "");
-  return PATH_MAP[raw] ?? { view: "library", section: "home" };
+
+  const exact = PATH_MAP[raw];
+  if (exact) return exact;
+
+  for (const { prefix, route } of DYNAMIC_PREFIXES) {
+    if (raw.startsWith(prefix)) {
+      const param = decodeURIComponent(raw.slice(prefix.length));
+      if (param) return { ...route, param };
+    }
+  }
+
+  return { view: "library", section: "home", param: null };
 }
 
 /**
  * Synchronize app route state to the URL pathname via replaceState.
  * Preserves existing query params and hash.
  */
-export function syncRouteToLocation(view: ViewName, section?: string | null): void {
+export function syncRouteToLocation(view: ViewName, section?: string | null, param?: string | null): void {
   if (typeof window === "undefined") {
     return;
   }
 
-  const targetPath = buildPathForRoute(view, section);
+  const targetPath = buildPathForRoute(view, section, param);
   if (window.location.pathname === targetPath) {
     return;
   }
@@ -241,12 +261,12 @@ export function syncRouteToLocation(view: ViewName, section?: string | null): vo
  * Navigate to a route via pushState (adds a history entry for back/forward).
  * Preserves existing query params and hash.
  */
-export function navigateTo(view: ViewName, section?: string | null): void {
+export function navigateTo(view: ViewName, section?: string | null, param?: string | null): void {
   if (typeof window === "undefined") {
     return;
   }
 
-  const targetPath = buildPathForRoute(view, section);
+  const targetPath = buildPathForRoute(view, section, param);
   if (window.location.pathname === targetPath) {
     return;
   }


### PR DESCRIPTION
## Summary
- Add dedicated playlist detail route (`/library/playlists/:id`) with full metadata display, heart toggle, listen count, track list, play all/shuffle, and edit modal with description support
- Refactor `LibraryPlaylistSection` into three sections: **My Playlists** (with create form), **Popular Playlists** (sorted by composite score), and **Automatic Playlists** (Phase 5 placeholder)
- Redesign playlist cards as compact grid navigation links with cover/mosaic, hover play button, and heart/listen badges
- Extend router (`appUtils.ts`) with dynamic segment support for parameterized routes
- Add `heartPlaylist`, `reportPlaylistListen`, `playlistCoverUrl` API functions
- Add `GET /api/playlists/:id/cover` backend endpoint to serve playlist cover images

## Test plan
- [x] Backend TypeScript check passes
- [x] Frontend TypeScript check passes
- [x] `appUtils.test.ts` passes (including new dynamic route parsing test)
- [x] `LibraryPlaylistSection.test.tsx` passes (updated for new props)
- [x] `LibraryAlbumsSection.test.tsx` passes
- [x] `indexStore.test.ts` passes
- [x] `playlistRoutes.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)