### PR TITLE
Add automatic genre/decade playlist generation

### DIFF
--- a/backend/src/api/autoPlaylistRoutes.ts
+++ b/backend/src/api/autoPlaylistRoutes.ts
@@ -1,0 +1,98 @@
+import { Router } from "express";
+
+import { createLogger } from "../utils/logger";
+import { requireAdmin, requireAuth } from "../auth/middleware";
+import type { IndexStore } from "../services/indexer/indexStore";
+import {
+  getAutoPlaylistConfig,
+  updateAutoPlaylistConfig,
+  loadAutoPlaylists,
+  getAutoPlaylistById,
+  regenerateAutoPlaylists
+} from "../services/playlists/autoPlaylistService";
+
+const log = createLogger("auto-playlist-routes");
+
+export function createAutoPlaylistRouter(indexStore: IndexStore): Router {
+  const router = Router();
+
+  router.get("/config/auto-playlists", requireAdmin, async (_req, res, next) => {
+    try {
+      const config = await getAutoPlaylistConfig();
+      res.json(config);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.patch("/config/auto-playlists", requireAdmin, async (req, res, next) => {
+    try {
+      const body = req.body as Record<string, unknown>;
+      const patch: Record<string, number> = {};
+
+      if (typeof body.maxPlaylists === "number") patch.maxPlaylists = body.maxPlaylists;
+      if (typeof body.minTracksPerPlaylist === "number") patch.minTracksPerPlaylist = body.minTracksPerPlaylist;
+      if (typeof body.tracksPerPlaylist === "number") patch.tracksPerPlaylist = body.tracksPerPlaylist;
+
+      const updated = await updateAutoPlaylistConfig(patch);
+      res.json(updated);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/playlists/automatic", requireAuth, async (_req, res, next) => {
+    try {
+      const playlists = await loadAutoPlaylists();
+      res.json({
+        playlists: playlists.map((p) => ({
+          id: p.id,
+          name: p.name,
+          genre: p.genre,
+          decade: p.decade,
+          trackCount: p.trackCount,
+          generatedAt: p.generatedAt
+        }))
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/playlists/automatic/:id", requireAuth, async (req, res, next) => {
+    try {
+      const id = req.params.id;
+      if (!id) {
+        res.status(400).json({ error: "Playlist id is required" });
+        return;
+      }
+
+      const playlist = await getAutoPlaylistById(id);
+      if (!playlist) {
+        res.status(404).json({ error: "Auto playlist not found" });
+        return;
+      }
+
+      const tracks = playlist.trackIds
+        .map((trackId) => indexStore.getTrackById(trackId))
+        .filter((t) => t !== undefined);
+
+      res.json({ playlist, tracks });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/playlists/automatic/regenerate", requireAdmin, async (_req, res, next) => {
+    try {
+      const allTracks = indexStore.getSnapshot().tracks;
+      const playlists = await regenerateAutoPlaylists(allTracks);
+      log.info(`Admin triggered auto playlist regeneration: ${playlists.length} playlist(s)`);
+      res.json({ regenerated: playlists.length, playlists: playlists.map((p) => ({ id: p.id, name: p.name, trackCount: p.trackCount })) });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/backend/src/api/router.ts
+++ b/backend/src/api/router.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 import { IndexStore } from "../services/indexer/indexStore";
+import { createAutoPlaylistRouter } from "./autoPlaylistRoutes";
 import { createAuthRouter } from "./authRoutes";
 import { createBackupRouter } from "./backupRoutes";
 import { createCoverRouter } from "./coverRoutes";
@@ -29,6 +30,7 @@ export function createApiRouter(indexStore: IndexStore): Router {
   router.use(createCoverRouter(indexStore));
   router.use(createIndexRouter(indexStore));
   router.use(createGenreRouter(indexStore));
+  router.use(createAutoPlaylistRouter(indexStore));
   router.use(createUserRouter());
   router.use(createLogRouter());
   router.use(createServerRouter());

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -15,6 +15,7 @@ import { migratePerUserUploadsToSharedMusic } from "./services/storage/storageSe
 import { startBackupScheduler } from "./services/backup/backupService";
 import { startVersionCheckSchedule } from "./services/versionCheck";
 import { ensureBaseDirectories } from "./utils/fs";
+import { checkAndRegenerateOnBoot } from "./services/playlists/autoPlaylistService";
 
 const SESSION_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
 const SHUTDOWN_TIMEOUT_MS = 10_000;
@@ -88,6 +89,7 @@ async function bootstrap(): Promise<void> {
 
   startVersionCheckSchedule();
   void startBackupScheduler();
+  void checkAndRegenerateOnBoot(indexStore.getSnapshot().tracks);
 }
 
 bootstrap().catch((error: unknown) => {

--- a/backend/src/services/playlists/autoPlaylistService.ts
+++ b/backend/src/services/playlists/autoPlaylistService.ts
@@ -1,0 +1,266 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { dataRoot } from "../../utils/paths";
+import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
+import { normalizeGenreLabel } from "../genre/genreSynonymService";
+import type { Track } from "../../types/library";
+
+const log = createLogger("auto-playlists");
+
+const AUTO_PLAYLISTS_DIR = path.join(dataRoot, "auto-playlists");
+const META_FILE = path.join(AUTO_PLAYLISTS_DIR, "_meta.json");
+const CONFIG_FILE = path.join(dataRoot, "config", "auto-playlist-config.json");
+
+const REGENERATION_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000;
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export type AutoPlaylist = {
+  id: string;
+  name: string;
+  genre: string;
+  decade: number;
+  trackIds: string[];
+  trackCount: number;
+  generatedAt: string;
+};
+
+export type AutoPlaylistConfig = {
+  maxPlaylists: number;
+  minTracksPerPlaylist: number;
+  tracksPerPlaylist: number;
+};
+
+type AutoPlaylistMeta = {
+  lastGeneratedAt: string;
+};
+
+// ── Config ─────────────────────────────────────────────────────────
+
+const DEFAULT_CONFIG: AutoPlaylistConfig = {
+  maxPlaylists: 0,
+  minTracksPerPlaylist: 8,
+  tracksPerPlaylist: 30
+};
+
+export async function getAutoPlaylistConfig(): Promise<AutoPlaylistConfig> {
+  const raw = await readJsonFile<Partial<AutoPlaylistConfig>>(CONFIG_FILE, {});
+  return {
+    maxPlaylists: typeof raw.maxPlaylists === "number" && raw.maxPlaylists >= 0
+      ? raw.maxPlaylists : DEFAULT_CONFIG.maxPlaylists,
+    minTracksPerPlaylist: typeof raw.minTracksPerPlaylist === "number" && raw.minTracksPerPlaylist >= 1
+      ? raw.minTracksPerPlaylist : DEFAULT_CONFIG.minTracksPerPlaylist,
+    tracksPerPlaylist: typeof raw.tracksPerPlaylist === "number" && raw.tracksPerPlaylist >= 1
+      ? raw.tracksPerPlaylist : DEFAULT_CONFIG.tracksPerPlaylist
+  };
+}
+
+export async function updateAutoPlaylistConfig(patch: Partial<AutoPlaylistConfig>): Promise<AutoPlaylistConfig> {
+  const current = await getAutoPlaylistConfig();
+  const next: AutoPlaylistConfig = {
+    maxPlaylists: typeof patch.maxPlaylists === "number" && patch.maxPlaylists >= 0
+      ? patch.maxPlaylists : current.maxPlaylists,
+    minTracksPerPlaylist: typeof patch.minTracksPerPlaylist === "number" && patch.minTracksPerPlaylist >= 1
+      ? patch.minTracksPerPlaylist : current.minTracksPerPlaylist,
+    tracksPerPlaylist: typeof patch.tracksPerPlaylist === "number" && patch.tracksPerPlaylist >= 1
+      ? patch.tracksPerPlaylist : current.tracksPerPlaylist
+  };
+  await writeJsonAtomic(CONFIG_FILE, next);
+  return next;
+}
+
+// ── Diversity selection ────────────────────────────────────────────
+
+type ScoredTrack = {
+  track: Track;
+  artist: string;
+  album: string;
+};
+
+function selectDiverseTracks(candidates: ScoredTrack[], maxTracks: number): Track[] {
+  const pool = [...candidates].sort(() => Math.random() - 0.5);
+  const selected: ScoredTrack[] = [];
+
+  while (selected.length < maxTracks && pool.length > 0) {
+    let bestIndex = 0;
+    let bestScore = Number.NEGATIVE_INFINITY;
+
+    for (let i = 0; i < pool.length; i++) {
+      const candidate = pool[i]!;
+      let score = 100;
+
+      const prev = selected[selected.length - 1];
+      if (prev) {
+        if (prev.artist === candidate.artist) score -= 1000;
+        if (prev.album === candidate.album) score -= 500;
+      }
+
+      const recentArtists = selected.slice(-3).map((s) => s.artist);
+      if (recentArtists.includes(candidate.artist)) score -= 250;
+
+      score += Math.random() * 40;
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestIndex = i;
+      }
+    }
+
+    selected.push(pool[bestIndex]!);
+    pool.splice(bestIndex, 1);
+  }
+
+  return selected.map((s) => s.track);
+}
+
+// ── Generation ─────────────────────────────────────────────────────
+
+function toDecadeLabel(decade: number): string {
+  return `${decade % 100 === 0 ? decade : decade % 100}s`;
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export async function generateAutoPlaylists(tracks: Track[]): Promise<AutoPlaylist[]> {
+  const config = await getAutoPlaylistConfig();
+
+  const groups = new Map<string, { genre: string; decade: number; tracks: ScoredTrack[] }>();
+
+  for (const track of tracks) {
+    const genres = track.tags.genre;
+    const year = track.tags.year;
+    if (!genres || genres.length === 0 || !year) continue;
+
+    const primaryGenre = normalizeGenreLabel(genres[0]!);
+    const decade = Math.floor(year / 10) * 10;
+    const key = `${decade}:${primaryGenre.toLowerCase()}`;
+
+    let group = groups.get(key);
+    if (!group) {
+      group = { genre: primaryGenre, decade, tracks: [] };
+      groups.set(key, group);
+    }
+
+    group.tracks.push({
+      track,
+      artist: (track.tags.artist ?? "").toLowerCase(),
+      album: (track.tags.album ?? "").toLowerCase()
+    });
+  }
+
+  let qualifyingGroups = Array.from(groups.values())
+    .filter((g) => g.tracks.length >= config.minTracksPerPlaylist)
+    .sort((a, b) => b.tracks.length - a.tracks.length);
+
+  if (config.maxPlaylists > 0) {
+    qualifyingGroups = qualifyingGroups.slice(0, config.maxPlaylists);
+  }
+
+  const generatedAt = new Date().toISOString();
+  const playlists: AutoPlaylist[] = [];
+
+  for (const group of qualifyingGroups) {
+    const decadeLabel = toDecadeLabel(group.decade);
+    const name = `${decadeLabel} ${group.genre}`;
+    const id = `auto:${slugify(name)}`;
+    const selectedTracks = selectDiverseTracks(group.tracks, config.tracksPerPlaylist);
+
+    playlists.push({
+      id,
+      name,
+      genre: group.genre,
+      decade: group.decade,
+      trackIds: selectedTracks.map((t) => t.id),
+      trackCount: selectedTracks.length,
+      generatedAt
+    });
+  }
+
+  return playlists;
+}
+
+// ── Storage ────────────────────────────────────────────────────────
+
+export async function saveAutoPlaylists(playlists: AutoPlaylist[]): Promise<void> {
+  await ensureDir(AUTO_PLAYLISTS_DIR);
+
+  const existing = await fs.readdir(AUTO_PLAYLISTS_DIR).catch(() => []);
+  for (const file of existing) {
+    if (file.endsWith(".json") && file !== "_meta.json") {
+      await fs.unlink(path.join(AUTO_PLAYLISTS_DIR, file)).catch(() => {});
+    }
+  }
+
+  for (const playlist of playlists) {
+    const fileName = `${slugify(playlist.name)}.json`;
+    await writeJsonAtomic(path.join(AUTO_PLAYLISTS_DIR, fileName), playlist);
+  }
+
+  const meta: AutoPlaylistMeta = { lastGeneratedAt: new Date().toISOString() };
+  await writeJsonAtomic(META_FILE, meta);
+
+  log.info(`Saved ${playlists.length} auto playlist(s)`);
+}
+
+export async function loadAutoPlaylists(): Promise<AutoPlaylist[]> {
+  await ensureDir(AUTO_PLAYLISTS_DIR);
+
+  const files = await fs.readdir(AUTO_PLAYLISTS_DIR).catch(() => []);
+  const playlists: AutoPlaylist[] = [];
+
+  for (const file of files) {
+    if (!file.endsWith(".json") || file === "_meta.json") continue;
+    const data = await readJsonFile<AutoPlaylist>(
+      path.join(AUTO_PLAYLISTS_DIR, file),
+      null as unknown as AutoPlaylist
+    );
+    if (data && data.id && data.trackIds) {
+      playlists.push(data);
+    }
+  }
+
+  return playlists.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getAutoPlaylistById(id: string): Promise<AutoPlaylist | null> {
+  const all = await loadAutoPlaylists();
+  return all.find((p) => p.id === id) ?? null;
+}
+
+// ── Regeneration check ─────────────────────────────────────────────
+
+export async function needsRegeneration(): Promise<boolean> {
+  const meta = await readJsonFile<AutoPlaylistMeta>(META_FILE, { lastGeneratedAt: "" });
+  if (!meta.lastGeneratedAt) return true;
+
+  const lastGenerated = new Date(meta.lastGeneratedAt).getTime();
+  if (isNaN(lastGenerated)) return true;
+
+  return Date.now() - lastGenerated > REGENERATION_INTERVAL_MS;
+}
+
+export async function regenerateAutoPlaylists(tracks: Track[]): Promise<AutoPlaylist[]> {
+  log.info("Regenerating auto playlists...");
+  const playlists = await generateAutoPlaylists(tracks);
+  await saveAutoPlaylists(playlists);
+  log.info(`Generated ${playlists.length} auto playlist(s)`);
+  return playlists;
+}
+
+export async function checkAndRegenerateOnBoot(tracks: Track[]): Promise<void> {
+  const shouldRegenerate = await needsRegeneration();
+  if (!shouldRegenerate) {
+    const existing = await loadAutoPlaylists();
+    log.info(`Auto playlists up to date (${existing.length} playlist(s))`);
+    return;
+  }
+
+  await regenerateAutoPlaylists(tracks);
+}

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -19,6 +19,7 @@ import { useLibraryData } from "./hooks/useLibraryData";
 import { usePlaybackCommands } from "./hooks/usePlaybackCommands";
 import { usePlaybackState } from "./hooks/usePlaybackState";
 import { useRecentlyUploaded } from "./hooks/useRecentlyUploaded";
+import { useAutoPlaylists } from "./hooks/useAutoPlaylists";
 import { useRadioStation } from "./hooks/useRadioStation";
 
 type AuthenticatedAppProps = {
@@ -91,6 +92,8 @@ export function AuthenticatedApp({
     sentinelRef: paginatedSentinelRef,
     refresh: refreshPaginatedLibrary
   } = useInfiniteLibrary({ user, filters, pageSize: 30 });
+
+  const { autoPlaylists, loading: loadingAutoPlaylists, refresh: refreshAutoPlaylists } = useAutoPlaylists();
 
   const allTracksById = useMemo(
     () => new Map(allTracksLibrary.tracks.map((track) => [track.id, track])),
@@ -303,6 +306,8 @@ export function AuthenticatedApp({
         onDeletePlaylist: handleDeletePlaylist,
         onHeartPlaylist: handleHeartPlaylist,
         onReportPlaylistListen: handleReportPlaylistListen,
+        autoPlaylists,
+        loadingAutoPlaylists,
         allTracksById,
         libraryMetadataError,
         loadingLibraryArtists,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,8 @@
 import type {
   AlbumEntry,
   ArtistEntry,
+  AutoPlaylistDetail,
+  AutoPlaylistSummary,
   LibraryResponse,
   Playlist,
   RadioCreateResponse,
@@ -706,6 +708,23 @@ export async function reportPlaylistListen(playlistId: string): Promise<void> {
 
 export function playlistCoverUrl(playlistId: string): string {
   return withApiBase(`/api/playlists/${encodeURIComponent(playlistId)}/cover`);
+}
+
+export async function getAutoPlaylists(): Promise<AutoPlaylistSummary[]> {
+  const payload = await requestJson<{ playlists: AutoPlaylistSummary[] }>("/api/playlists/automatic");
+  return payload.playlists;
+}
+
+export async function getAutoPlaylistDetail(id: string): Promise<{ playlist: AutoPlaylistDetail; tracks: Track[] }> {
+  return requestJson<{ playlist: AutoPlaylistDetail; tracks: Track[] }>(
+    `/api/playlists/automatic/${encodeURIComponent(id)}`
+  );
+}
+
+export async function regenerateAutoPlaylists(): Promise<{ regenerated: number }> {
+  return requestJson<{ regenerated: number }>("/api/playlists/automatic/regenerate", {
+    method: "POST"
+  });
 }
 
 export async function getUsers(): Promise<User[]> {

--- a/frontend/src/components/AutoPlaylistDetailView.tsx
+++ b/frontend/src/components/AutoPlaylistDetailView.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { coverUrl, getAutoPlaylistDetail } from "../api";
+import type { AutoPlaylistDetail, Playlist, Track } from "../types";
+import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+
+type AutoPlaylistDetailViewProps = {
+  playlistId: string;
+  allTracksById: Map<string, Track>;
+  onBack: () => void;
+  onPlayTrack: (playlist: Playlist) => void;
+};
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+export function AutoPlaylistDetailView({
+  playlistId,
+  allTracksById,
+  onBack,
+  onPlayTrack
+}: AutoPlaylistDetailViewProps): JSX.Element {
+  const [detail, setDetail] = useState<AutoPlaylistDetail | null>(null);
+  const [detailTracks, setDetailTracks] = useState<Track[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    getAutoPlaylistDetail(playlistId)
+      .then((result) => {
+        setDetail(result.playlist);
+        setDetailTracks(result.tracks);
+      })
+      .catch(() => {
+        setDetail(null);
+        setDetailTracks([]);
+      })
+      .finally(() => setLoading(false));
+  }, [playlistId]);
+
+  const tracks = useMemo(() => {
+    if (!detail) return detailTracks;
+    return detail.trackIds
+      .map((id) => detailTracks.find((t) => t.id === id) ?? allTracksById.get(id))
+      .filter((t): t is Track => t !== undefined);
+  }, [detail, detailTracks, allTracksById]);
+
+  const totalDuration = useMemo(() => tracks.reduce((sum, t) => sum + t.duration, 0), [tracks]);
+
+  function handlePlayAll(): void {
+    if (!detail || tracks.length === 0) return;
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: tracks.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
+  function handleShufflePlay(): void {
+    if (!detail || tracks.length === 0) return;
+    const shuffled = [...tracks].sort(() => Math.random() - 0.5);
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: shuffled.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
+  if (loading) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <button
+          type="button"
+          className="mb-4 flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+          onClick={onBack}
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to playlists
+        </button>
+        <p className="text-sm text-flaque-steel">Loading...</p>
+      </section>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <button
+          type="button"
+          className="mb-4 flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+          onClick={onBack}
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to playlists
+        </button>
+        <p className="text-sm text-flaque-steel">Auto playlist not found.</p>
+      </section>
+    );
+  }
+
+  const decadeLabel = detail.decade % 100 === 0 ? `${detail.decade}` : `${detail.decade % 100}s`;
+
+  return (
+    <section className="m-4 space-y-4">
+      {/* Back button */}
+      <button
+        type="button"
+        className="flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+        onClick={onBack}
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        Back to playlists
+      </button>
+
+      {/* Header card */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-white/85 to-flaque-cream/40 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-col gap-5 sm:flex-row">
+          {/* Genre/decade visual */}
+          <div className="flex h-48 w-48 shrink-0 items-center justify-center self-center overflow-hidden rounded-2xl bg-gradient-to-br from-flaque-sand/50 to-flaque-clay/30 sm:self-start">
+            <div className="text-center">
+              <p className="font-display text-5xl font-bold text-flaque-ink/60">{decadeLabel}</p>
+              <p className="mt-1 text-sm font-medium text-flaque-steel">{detail.genre}</p>
+            </div>
+          </div>
+
+          {/* Info */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <h2 className="font-display text-2xl text-flaque-ink">{detail.name}</h2>
+
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-flaque-steel">
+              <span className="rounded-full bg-flaque-sand/50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-flaque-ink/70">
+                Auto-generated
+              </span>
+              <span>{detail.trackCount} track{detail.trackCount !== 1 ? "s" : ""}</span>
+              {totalDuration > 0 ? <span>{formatDuration(totalDuration)}</span> : null}
+              <span>Generated {new Date(detail.generatedAt).toLocaleDateString()}</span>
+            </div>
+
+            {/* Action buttons */}
+            <div className="mt-auto flex flex-wrap items-center gap-2 pt-4">
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black"
+                onClick={handlePlayAll}
+              >
+                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+                Play all
+              </button>
+
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
+                onClick={handleShufflePlay}
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4" />
+                </svg>
+                Shuffle
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Track list */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
+        {tracks.length === 0 ? (
+          <p className="px-5 py-4 text-sm text-flaque-steel">No playable tracks.</p>
+        ) : (
+          <ul>
+            {tracks.map((track, index) => (
+              <li
+                key={track.id}
+                className="flex items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+              >
+                <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
+                <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
+                  <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
+                    {track.tags.extra?.lyrics ? (
+                      <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
+                        L
+                      </span>
+                    ) : null}
+                    <span className="truncate">{getTrackDisplayTitle(track)}</span>
+                  </p>
+                  <p className="truncate text-xs text-flaque-steel">
+                    {getTrackDisplayArtist(track) ?? "Unknown artist"}
+                    {track.tags.album ? ` \u00b7 ${track.tags.album}` : ""}
+                  </p>
+                </div>
+                <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
+                  {formatDuration(track.duration)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -35,7 +35,9 @@ const defaultProps = {
   onPatchPlaylist: vi.fn().mockResolvedValue(undefined),
   onDeletePlaylist: vi.fn().mockResolvedValue(undefined),
   onNavigateToPlaylist: vi.fn(),
-  onReportPlaylistListen: vi.fn().mockResolvedValue(undefined)
+  onReportPlaylistListen: vi.fn().mockResolvedValue(undefined),
+  autoPlaylists: [],
+  loadingAutoPlaylists: false
 };
 
 describe("LibraryPlaylistSection", () => {

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useState } from "react";
 
 import { coverUrl, playlistCoverUrl } from "../api";
-import type { Playlist, PlaylistVisibility, Track, User } from "../types";
+import type { AutoPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
 
 type LibraryPlaylistSectionProps = {
   availablePlaylists: Playlist[];
@@ -15,6 +15,8 @@ type LibraryPlaylistSectionProps = {
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onNavigateToPlaylist: (playlistId: string) => void;
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
+  autoPlaylists: AutoPlaylistSummary[];
+  loadingAutoPlaylists: boolean;
 };
 
 // ── Mosaic cover (compact) ─────────────────────────────────────────
@@ -168,7 +170,9 @@ export function LibraryPlaylistSection({
   onPatchPlaylist: _onPatchPlaylist,
   onDeletePlaylist: _onDeletePlaylist,
   onNavigateToPlaylist,
-  onReportPlaylistListen
+  onReportPlaylistListen,
+  autoPlaylists,
+  loadingAutoPlaylists
 }: LibraryPlaylistSectionProps): JSX.Element {
   const [playlistName, setPlaylistName] = useState("");
   const [playlistVisibility, setPlaylistVisibility] = useState<PlaylistVisibility>("private");
@@ -275,12 +279,43 @@ export function LibraryPlaylistSection({
         </section>
       ) : null}
 
-      {/* ── Automatic Playlists (placeholder) ─────────────────────── */}
-      <section className="rounded-xl border border-dashed border-flaque-clay/60 bg-white/60 p-5 backdrop-blur-sm">
+      {/* ── Automatic Playlists ────────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-gradient-to-br from-white/85 to-flaque-cream/40 p-5 shadow-panel backdrop-blur-sm">
         <SectionHeader title="Automatic Playlists" />
-        <p className="mt-2 text-sm text-flaque-steel">
-          Automatic playlists will appear here once generated.
-        </p>
+        {loadingAutoPlaylists ? (
+          <p className="mt-2 text-sm text-flaque-steel">Loading...</p>
+        ) : autoPlaylists.length === 0 ? (
+          <p className="mt-2 text-sm text-flaque-steel">
+            Automatic playlists will appear here once generated.
+          </p>
+        ) : (
+          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            {autoPlaylists.map((ap) => (
+              <div
+                key={ap.id}
+                className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-flaque-ink/5 to-flaque-sand/30 shadow-sm transition hover:shadow-md"
+                onClick={() => onNavigateToPlaylist(ap.id)}
+                role="link"
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === "Enter") onNavigateToPlaylist(ap.id); }}
+              >
+                <div className="flex aspect-square w-full items-center justify-center bg-gradient-to-br from-flaque-sand/40 to-flaque-clay/20">
+                  <div className="text-center">
+                    <p className="font-display text-2xl font-bold text-flaque-ink/70">{ap.decade % 100 === 0 ? ap.decade : `${ap.decade % 100}s`}</p>
+                    <p className="mt-0.5 text-xs font-medium text-flaque-steel">{ap.genre}</p>
+                  </div>
+                </div>
+                <div className="p-3">
+                  <p className="truncate text-sm font-semibold text-flaque-ink">{ap.name}</p>
+                  <p className="mt-0.5 text-xs text-flaque-steel">
+                    {ap.trackCount} track{ap.trackCount !== 1 ? "s" : ""}
+                    {" \u00b7 "}Generated {new Date(ap.generatedAt).toLocaleDateString()}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </section>
     </div>
   );

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -2,9 +2,10 @@ import { HomePanels } from "./HomePanels";
 import { LibraryAlbumsSection } from "./LibraryAlbumsSection";
 import { LibraryArtistsSection } from "./LibraryArtistsSection";
 import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
+import { AutoPlaylistDetailView } from "./AutoPlaylistDetailView";
 import { PlaylistDetailView } from "./PlaylistDetailView";
 import { PaginatedLibrary } from "./PaginatedLibrary";
-import type { AlbumEntry, ArtistEntry, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
+import type { AlbumEntry, ArtistEntry, AutoPlaylistSummary, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
 import type { LibraryFilters, LibrarySection } from "../types/library";
 import { navigateTo } from "../utils/appUtils";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
@@ -23,6 +24,8 @@ type LibraryWorkspaceProps = {
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
+  autoPlaylists: AutoPlaylistSummary[];
+  loadingAutoPlaylists: boolean;
   allTracksById: Map<string, Track>;
   libraryMetadataError: string | null;
   loadingLibraryArtists: boolean;
@@ -94,6 +97,8 @@ export function LibraryWorkspace({
   onDeletePlaylist,
   onHeartPlaylist,
   onReportPlaylistListen,
+  autoPlaylists,
+  loadingAutoPlaylists,
   allTracksById,
   libraryMetadataError,
   loadingLibraryArtists,
@@ -148,7 +153,14 @@ export function LibraryWorkspace({
   return (
     <div className="h-full min-h-0 space-y-4 overflow-y-auto">
       {activeLibrarySection === "playlists" ? (
-        playlistDetailId ? (
+        playlistDetailId && playlistDetailId.startsWith("auto:") ? (
+          <AutoPlaylistDetailView
+            playlistId={playlistDetailId}
+            allTracksById={allTracksById}
+            onBack={() => onPlaylistDetailNavigate(null)}
+            onPlayTrack={onPlayPlaylist}
+          />
+        ) : playlistDetailId ? (
           <PlaylistDetailView
             playlistId={playlistDetailId}
             availablePlaylists={availablePlaylists}
@@ -176,6 +188,8 @@ export function LibraryWorkspace({
             onDeletePlaylist={onDeletePlaylist}
             onNavigateToPlaylist={onPlaylistDetailNavigate}
             onReportPlaylistListen={onReportPlaylistListen}
+            autoPlaylists={autoPlaylists}
+            loadingAutoPlaylists={loadingAutoPlaylists}
           />
         )
       ) : null}

--- a/frontend/src/hooks/useAutoPlaylists.ts
+++ b/frontend/src/hooks/useAutoPlaylists.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { getAutoPlaylists } from "../api";
+import type { AutoPlaylistSummary } from "../types";
+
+type UseAutoPlaylistsResult = {
+  autoPlaylists: AutoPlaylistSummary[];
+  loading: boolean;
+  refresh: () => void;
+};
+
+export function useAutoPlaylists(): UseAutoPlaylistsResult {
+  const [autoPlaylists, setAutoPlaylists] = useState<AutoPlaylistSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetch = useCallback(() => {
+    setLoading(true);
+    getAutoPlaylists()
+      .then(setAutoPlaylists)
+      .catch(() => setAutoPlaylists([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { autoPlaylists, loading, refresh: fetch };
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -159,3 +159,16 @@ export type RadioQueueResponse = {
     trackList: RadioTrack[];
   } | null;
 };
+
+export type AutoPlaylistSummary = {
+  id: string;
+  name: string;
+  genre: string;
+  decade: number;
+  trackCount: number;
+  generatedAt: string;
+};
+
+export type AutoPlaylistDetail = AutoPlaylistSummary & {
+  trackIds: string[];
+};


### PR DESCRIPTION
## Summary
- Implement `autoPlaylistService.ts` that scans tracks, groups by primary genre + decade, and selects diverse track lists using artist/album penalty scoring (adapted from radio's `pickBestCandidate`)
- Admin-configurable via `GET/PATCH /api/config/auto-playlists` (maxPlaylists, minTracksPerPlaylist, tracksPerPlaylist)
- Storage in `data/auto-playlists/` with 14-day regeneration schedule; boot-time staleness check triggers auto-regeneration
- Read-only API: `GET /api/playlists/automatic` (list), `GET /api/playlists/automatic/:id` (detail with resolved tracks), `POST /api/playlists/automatic/regenerate` (admin force-regen)
- Frontend: `AutoPlaylistSummary`/`AutoPlaylistDetail` types, `useAutoPlaylists` hook, genre/decade visual cards in Automatic Playlists section, dedicated `AutoPlaylistDetailView` with play all/shuffle

## Test plan
- [x] Backend TypeScript check passes
- [x] Frontend TypeScript check passes
- [x] `playlistRoutes.test.ts` passes
- [x] `indexStore.test.ts` passes
- [x] `LibraryPlaylistSection.test.tsx` passes (updated for new props)
- [x] `appUtils.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)