### PR TITLE
Add smart For You playlists (Phase 6)

### DIFF
--- a/backend/src/api/forYouPlaylistRoutes.ts
+++ b/backend/src/api/forYouPlaylistRoutes.ts
@@ -1,0 +1,122 @@
+import { Router } from "express";
+
+import { createLogger } from "../utils/logger";
+import { requireAuth } from "../auth/middleware";
+import type { IndexStore } from "../services/indexer/indexStore";
+import {
+  loadForYouPlaylists,
+  getForYouPlaylistById,
+  regenerateForYouPlaylists,
+  dismissForYouPlaylist,
+  getUserDismissals
+} from "../services/playlists/forYouPlaylistService";
+
+const log = createLogger("for-you-routes");
+
+export function createForYouPlaylistRouter(indexStore: IndexStore): Router {
+  const router = Router();
+
+  router.get("/playlists/for-you", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlists = await loadForYouPlaylists(userId);
+      const dismissals = await getUserDismissals(userId);
+
+      const visible = playlists.filter((p) => !dismissals.has(p.id));
+
+      res.json({
+        playlists: visible.map((p) => ({
+          id: p.id,
+          name: p.name,
+          seedArtist: p.seedArtist,
+          trackCount: p.trackCount,
+          generatedAt: p.generatedAt
+        }))
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/playlists/for-you/:id", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const id = req.params.id;
+      if (!id) {
+        res.status(400).json({ error: "Playlist id is required" });
+        return;
+      }
+
+      const playlist = await getForYouPlaylistById(userId, id);
+      if (!playlist) {
+        res.status(404).json({ error: "For-you playlist not found" });
+        return;
+      }
+
+      const tracks = playlist.trackIds
+        .map((trackId) => indexStore.getTrackById(trackId))
+        .filter((t) => t !== undefined);
+
+      res.json({ playlist, tracks });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/playlists/for-you/regenerate", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlists = await regenerateForYouPlaylists(userId, indexStore);
+      log.info(`User ${userId} triggered for-you regeneration: ${playlists.length} playlist(s)`);
+      res.json({
+        regenerated: playlists.length,
+        playlists: playlists.map((p) => ({
+          id: p.id,
+          name: p.name,
+          seedArtist: p.seedArtist,
+          trackCount: p.trackCount
+        }))
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/playlists/for-you/:id/dismiss", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlistId = req.params.id;
+      if (!playlistId) {
+        res.status(400).json({ error: "Playlist id is required" });
+        return;
+      }
+
+      await dismissForYouPlaylist(userId, playlistId);
+      res.status(204).end();
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/backend/src/api/router.ts
+++ b/backend/src/api/router.ts
@@ -3,6 +3,7 @@ import { Router } from "express";
 import { IndexStore } from "../services/indexer/indexStore";
 import { createAutoPlaylistRouter } from "./autoPlaylistRoutes";
 import { createAuthRouter } from "./authRoutes";
+import { createForYouPlaylistRouter } from "./forYouPlaylistRoutes";
 import { createBackupRouter } from "./backupRoutes";
 import { createCoverRouter } from "./coverRoutes";
 import { createGenreRouter } from "./genreRoutes";
@@ -31,6 +32,7 @@ export function createApiRouter(indexStore: IndexStore): Router {
   router.use(createIndexRouter(indexStore));
   router.use(createGenreRouter(indexStore));
   router.use(createAutoPlaylistRouter(indexStore));
+  router.use(createForYouPlaylistRouter(indexStore));
   router.use(createUserRouter());
   router.use(createLogRouter());
   router.use(createServerRouter());

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -16,6 +16,8 @@ import { startBackupScheduler } from "./services/backup/backupService";
 import { startVersionCheckSchedule } from "./services/versionCheck";
 import { ensureBaseDirectories } from "./utils/fs";
 import { checkAndRegenerateOnBoot } from "./services/playlists/autoPlaylistService";
+import { checkAndRegenerateForYouOnBoot } from "./services/playlists/forYouPlaylistService";
+import { listUsers } from "./auth/db";
 
 const SESSION_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
 const SHUTDOWN_TIMEOUT_MS = 10_000;
@@ -90,6 +92,9 @@ async function bootstrap(): Promise<void> {
   startVersionCheckSchedule();
   void startBackupScheduler();
   void checkAndRegenerateOnBoot(indexStore.getSnapshot().tracks);
+  void Promise.all(
+    listUsers().map((user) => checkAndRegenerateForYouOnBoot(user.id, indexStore))
+  );
 }
 
 bootstrap().catch((error: unknown) => {

--- a/backend/src/services/playlists/forYouPlaylistService.test.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+let tmpDir: string;
+
+vi.mock("../../utils/paths", async () => {
+  return {
+    get dataRoot() { return path.join(tmpDir, "data"); },
+    get usersStorageRoot() { return path.join(tmpDir, "data", "storage", "users"); },
+    get configRoot() { return path.join(tmpDir, "data", "config"); }
+  };
+});
+
+vi.mock("../../utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+vi.mock("../genre/genreSynonymService", () => ({
+  normalizeGenreLabel: (g: string) => g
+}));
+
+import type { Track } from "../../types/library";
+import type { IndexStore } from "../indexer/indexStore";
+
+function makeTrack(overrides: Partial<Track> & { id: string }): Track {
+  return {
+    owner: "user-1",
+    path: `/music/${overrides.id}.flac`,
+    duration: 240,
+    mimeType: "audio/flac",
+    codec: "flac",
+    tags: {},
+    ...overrides
+  };
+}
+
+function makeMockIndexStore(tracks: Track[]): IndexStore {
+  const byId = new Map(tracks.map((t) => [t.id, t]));
+  const byArtist = new Map<string, Track[]>();
+  for (const t of tracks) {
+    const artist = (t.tags.artist ?? "Unknown").toLowerCase();
+    const list = byArtist.get(artist) ?? [];
+    list.push(t);
+    byArtist.set(artist, list);
+  }
+
+  return {
+    getSnapshot: () => ({ tracks, totalTracks: tracks.length, generatedAt: "", playlists: [] }),
+    getTrackById: (id: string) => byId.get(id),
+    getTracksByArtist: (artist: string) => byArtist.get(artist.toLowerCase()) ?? [],
+    hasTrack: (id: string) => byId.has(id)
+  } as unknown as IndexStore;
+}
+
+describe("forYouPlaylistService", () => {
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "foryou-test-"));
+    await fs.mkdir(path.join(tmpDir, "data", "config"), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, "data", "storage", "users"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("skips generation when user has too few plays", async () => {
+    const { generateForYouPlaylists } = await import("./forYouPlaylistService");
+
+    const tracks = Array.from({ length: 30 }, (_, i) =>
+      makeTrack({
+        id: `track-${i}`,
+        tags: { artist: `Artist ${i % 5}`, genre: ["Rock"], year: 2000 }
+      })
+    );
+    const indexStore = makeMockIndexStore(tracks);
+
+    const result = await generateForYouPlaylists("user-1", indexStore);
+    expect(result).toEqual([]);
+  });
+
+  it("generates playlists when user meets thresholds", async () => {
+    const { generateForYouPlaylists } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    const artists = ["Pink Floyd", "Led Zeppelin", "Deep Purple", "Black Sabbath", "Jethro Tull"];
+    const tracks: Track[] = [];
+
+    for (let i = 0; i < 60; i++) {
+      const artist = artists[i % 5]!;
+      tracks.push(
+        makeTrack({
+          id: `track-${i}`,
+          tags: { artist, genre: ["Rock"], year: 1970 + (i % 10) }
+        })
+      );
+    }
+
+    const indexStore = makeMockIndexStore(tracks);
+
+    const playCountsDir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(playCountsDir);
+
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 30; i++) {
+      playCounts[`track-${i}`] = { count: 2, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    }
+    await writeJsonAtomic(path.join(playCountsDir, "play-counts.json"), { tracks: playCounts });
+
+    const result = await generateForYouPlaylists("user-1", indexStore);
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.length).toBeLessThanOrEqual(3);
+
+    for (const playlist of result) {
+      expect(playlist.id).toMatch(/^for-you:/);
+      expect(playlist.name).toMatch(/^Because you listen to /);
+      expect(playlist.trackIds.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("dismisses and stores dismissal", async () => {
+    const { dismissForYouPlaylist, getUserDismissals } = await import("./forYouPlaylistService");
+
+    await dismissForYouPlaylist("user-1", "for-you:pink-floyd");
+
+    const dismissals = await getUserDismissals("user-1");
+    expect(dismissals.has("for-you:pink-floyd")).toBe(true);
+    expect(dismissals.has("for-you:led-zeppelin")).toBe(false);
+  });
+
+  it("saves and loads for-you playlists", async () => {
+    const { saveForYouPlaylists, loadForYouPlaylists } = await import("./forYouPlaylistService");
+
+    const playlists = [
+      {
+        id: "for-you:pink-floyd",
+        name: "Because you listen to Pink Floyd",
+        seedArtist: "Pink Floyd",
+        trackIds: ["t1", "t2", "t3"],
+        trackCount: 3,
+        generatedAt: "2026-04-01T00:00:00Z"
+      }
+    ];
+
+    await saveForYouPlaylists("user-1", playlists);
+    const loaded = await loadForYouPlaylists("user-1");
+
+    expect(loaded.length).toBe(1);
+    expect(loaded[0]!.id).toBe("for-you:pink-floyd");
+    expect(loaded[0]!.trackIds).toEqual(["t1", "t2", "t3"]);
+  });
+});

--- a/backend/src/services/playlists/forYouPlaylistService.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.ts
@@ -1,0 +1,401 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { dataRoot, usersStorageRoot } from "../../utils/paths";
+import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
+import { normalizeGenreLabel } from "../genre/genreSynonymService";
+import { getUserTopArtists, getUserPlayCounts } from "../activity/playCountStore";
+import type { IndexStore } from "../indexer/indexStore";
+import type { Track } from "../../types/library";
+
+const log = createLogger("for-you-playlists");
+
+const FOR_YOU_DIR = path.join(dataRoot, "auto-playlists", "for-you");
+const REGENERATION_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000;
+
+const MIN_TOTAL_PLAYS = 20;
+const MIN_DISTINCT_ARTISTS = 3;
+const MAX_TOP_ARTISTS = 3;
+const TRACKS_PER_PLAYLIST = 25;
+const SEED_ARTIST_RATIO = 0.4;
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export type ForYouPlaylist = {
+  id: string;
+  name: string;
+  seedArtist: string;
+  trackIds: string[];
+  trackCount: number;
+  generatedAt: string;
+};
+
+type ForYouMeta = {
+  lastGeneratedAt: string;
+};
+
+type DismissedEntry = {
+  playlistId: string;
+  dismissedAt: string;
+};
+
+type DismissedFile = {
+  dismissed: DismissedEntry[];
+};
+
+// ── Paths ──────────────────────────────────────────────────────────
+
+function userForYouDir(userId: string): string {
+  return path.join(FOR_YOU_DIR, userId);
+}
+
+function userForYouMetaPath(userId: string): string {
+  return path.join(userForYouDir(userId), "_meta.json");
+}
+
+function dismissedPath(userId: string): string {
+  return path.join(usersStorageRoot, userId, "dismissed-playlists.json");
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+// ── Diversity selection (reused from auto playlist service) ───────
+
+type ScoredTrack = {
+  track: Track;
+  artist: string;
+  album: string;
+};
+
+function selectDiverseTracks(candidates: ScoredTrack[], maxTracks: number): Track[] {
+  const pool = [...candidates].sort(() => Math.random() - 0.5);
+  const selected: ScoredTrack[] = [];
+
+  while (selected.length < maxTracks && pool.length > 0) {
+    let bestIndex = 0;
+    let bestScore = Number.NEGATIVE_INFINITY;
+
+    for (let i = 0; i < pool.length; i++) {
+      const candidate = pool[i]!;
+      let score = 100;
+
+      const prev = selected[selected.length - 1];
+      if (prev) {
+        if (prev.artist === candidate.artist) score -= 1000;
+        if (prev.album === candidate.album) score -= 500;
+      }
+
+      const recentArtists = selected.slice(-3).map((s) => s.artist);
+      if (recentArtists.includes(candidate.artist)) score -= 250;
+
+      score += Math.random() * 40;
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestIndex = i;
+      }
+    }
+
+    selected.push(pool[bestIndex]!);
+    pool.splice(bestIndex, 1);
+  }
+
+  return selected.map((s) => s.track);
+}
+
+// ── Dismissal store ───────────────────────────────────────────────
+
+const DISMISSAL_EXPIRY_MS = 90 * 24 * 60 * 60 * 1000; // 3 months
+
+async function readDismissals(userId: string): Promise<DismissedEntry[]> {
+  const data = await readJsonFile<DismissedFile>(dismissedPath(userId), { dismissed: [] });
+  if (!data || !Array.isArray(data.dismissed)) return [];
+  return data.dismissed;
+}
+
+async function writeDismissals(userId: string, entries: DismissedEntry[]): Promise<void> {
+  const filePath = dismissedPath(userId);
+  await ensureDir(path.dirname(filePath));
+  await writeJsonAtomic(filePath, { dismissed: entries });
+}
+
+function getActiveDismissals(entries: DismissedEntry[]): Set<string> {
+  const now = Date.now();
+  const active = new Set<string>();
+  for (const entry of entries) {
+    const dismissedAt = new Date(entry.dismissedAt).getTime();
+    if (!isNaN(dismissedAt) && now - dismissedAt < DISMISSAL_EXPIRY_MS) {
+      active.add(entry.playlistId);
+    }
+  }
+  return active;
+}
+
+export async function dismissForYouPlaylist(userId: string, playlistId: string): Promise<void> {
+  const entries = await readDismissals(userId);
+  const existing = entries.find((e) => e.playlistId === playlistId);
+  if (existing) {
+    existing.dismissedAt = new Date().toISOString();
+  } else {
+    entries.push({ playlistId, dismissedAt: new Date().toISOString() });
+  }
+  await writeDismissals(userId, entries);
+  log.info(`User ${userId} dismissed for-you playlist ${playlistId}`);
+}
+
+export async function getUserDismissals(userId: string): Promise<Set<string>> {
+  const entries = await readDismissals(userId);
+  return getActiveDismissals(entries);
+}
+
+// ── Playlist generation ───────────────────────────────────────────
+
+function getArtistProfile(
+  artist: string,
+  indexStore: IndexStore
+): { genres: string[]; minYear: number; maxYear: number } {
+  const tracks = indexStore.getTracksByArtist(artist);
+  const genres = new Set<string>();
+  let minYear = Infinity;
+  let maxYear = -Infinity;
+
+  for (const track of tracks) {
+    if (track.tags.genre) {
+      for (const g of track.tags.genre) {
+        genres.add(normalizeGenreLabel(g).toLowerCase());
+      }
+    }
+    if (track.tags.year) {
+      if (track.tags.year < minYear) minYear = track.tags.year;
+      if (track.tags.year > maxYear) maxYear = track.tags.year;
+    }
+  }
+
+  return {
+    genres: Array.from(genres),
+    minYear: minYear === Infinity ? 1970 : minYear,
+    maxYear: maxYear === -Infinity ? 2026 : maxYear
+  };
+}
+
+function findPeerTracks(
+  seedArtist: string,
+  profile: { genres: string[]; minYear: number; maxYear: number },
+  allTracks: Track[]
+): ScoredTrack[] {
+  const yearLow = profile.minYear - 10;
+  const yearHigh = profile.maxYear + 10;
+  const genreSet = new Set(profile.genres);
+  const seedArtistLower = seedArtist.toLowerCase();
+  const peers: ScoredTrack[] = [];
+
+  for (const track of allTracks) {
+    const trackArtist = (track.tags.artist ?? "").toLowerCase();
+    if (trackArtist === seedArtistLower) continue;
+
+    const year = track.tags.year;
+    if (year && (year < yearLow || year > yearHigh)) continue;
+
+    const trackGenres = track.tags.genre;
+    if (!trackGenres || trackGenres.length === 0) continue;
+
+    const hasMatchingGenre = trackGenres.some(
+      (g) => genreSet.has(normalizeGenreLabel(g).toLowerCase())
+    );
+    if (!hasMatchingGenre) continue;
+
+    peers.push({
+      track,
+      artist: trackArtist,
+      album: (track.tags.album ?? "").toLowerCase()
+    });
+  }
+
+  return peers;
+}
+
+function buildForYouPlaylist(
+  seedArtist: string,
+  indexStore: IndexStore,
+  allTracks: Track[]
+): ForYouPlaylist | null {
+  const profile = getArtistProfile(seedArtist, indexStore);
+  if (profile.genres.length === 0) return null;
+
+  const seedTracks = indexStore.getTracksByArtist(seedArtist);
+  const seedScored: ScoredTrack[] = seedTracks.map((t) => ({
+    track: t,
+    artist: (t.tags.artist ?? "").toLowerCase(),
+    album: (t.tags.album ?? "").toLowerCase()
+  }));
+
+  const peerTracks = findPeerTracks(seedArtist, profile, allTracks);
+  if (peerTracks.length < 3) return null;
+
+  const seedCount = Math.round(TRACKS_PER_PLAYLIST * SEED_ARTIST_RATIO);
+  const peerCount = TRACKS_PER_PLAYLIST - seedCount;
+
+  const selectedSeed = selectDiverseTracks(seedScored, seedCount);
+  const selectedPeers = selectDiverseTracks(peerTracks, peerCount);
+
+  const combined: ScoredTrack[] = [
+    ...selectedSeed.map((t) => ({
+      track: t,
+      artist: (t.tags.artist ?? "").toLowerCase(),
+      album: (t.tags.album ?? "").toLowerCase()
+    })),
+    ...selectedPeers.map((t) => ({
+      track: t,
+      artist: (t.tags.artist ?? "").toLowerCase(),
+      album: (t.tags.album ?? "").toLowerCase()
+    }))
+  ];
+
+  const finalTracks = selectDiverseTracks(combined, TRACKS_PER_PLAYLIST);
+  if (finalTracks.length < 5) return null;
+
+  const id = `for-you:${slugify(seedArtist)}`;
+  return {
+    id,
+    name: `Because you listen to ${seedArtist}`,
+    seedArtist,
+    trackIds: finalTracks.map((t) => t.id),
+    trackCount: finalTracks.length,
+    generatedAt: new Date().toISOString()
+  };
+}
+
+export async function generateForYouPlaylists(
+  userId: string,
+  indexStore: IndexStore
+): Promise<ForYouPlaylist[]> {
+  const playCounts = await getUserPlayCounts(userId);
+  const entries = Object.entries(playCounts);
+  const totalPlays = entries.reduce((sum, [, e]) => sum + e.count, 0);
+
+  if (totalPlays < MIN_TOTAL_PLAYS) {
+    log.debug(`User ${userId} has only ${totalPlays} plays, skipping for-you generation`);
+    return [];
+  }
+
+  const topArtists = await getUserTopArtists(userId, MAX_TOP_ARTISTS + 5, indexStore);
+  const distinctArtists = topArtists.length;
+
+  if (distinctArtists < MIN_DISTINCT_ARTISTS) {
+    log.debug(`User ${userId} has only ${distinctArtists} distinct artists, skipping`);
+    return [];
+  }
+
+  const dismissals = await getUserDismissals(userId);
+  const allTracks = indexStore.getSnapshot().tracks;
+  const playlists: ForYouPlaylist[] = [];
+
+  for (const entry of topArtists.slice(0, MAX_TOP_ARTISTS)) {
+    const candidateId = `for-you:${slugify(entry.artist)}`;
+    if (dismissals.has(candidateId)) continue;
+
+    const playlist = buildForYouPlaylist(entry.artist, indexStore, allTracks);
+    if (playlist) {
+      playlists.push(playlist);
+    }
+  }
+
+  return playlists;
+}
+
+// ── Storage ───────────────────────────────────────────────────────
+
+export async function saveForYouPlaylists(userId: string, playlists: ForYouPlaylist[]): Promise<void> {
+  const dir = userForYouDir(userId);
+  await ensureDir(dir);
+
+  const existing = await fs.readdir(dir).catch(() => []);
+  for (const file of existing) {
+    if (file.endsWith(".json") && file !== "_meta.json") {
+      await fs.unlink(path.join(dir, file)).catch(() => {});
+    }
+  }
+
+  for (const playlist of playlists) {
+    const fileName = `${slugify(playlist.seedArtist)}.json`;
+    await writeJsonAtomic(path.join(dir, fileName), playlist);
+  }
+
+  const meta: ForYouMeta = { lastGeneratedAt: new Date().toISOString() };
+  await writeJsonAtomic(userForYouMetaPath(userId), meta);
+
+  log.info(`Saved ${playlists.length} for-you playlist(s) for user ${userId}`);
+}
+
+export async function loadForYouPlaylists(userId: string): Promise<ForYouPlaylist[]> {
+  const dir = userForYouDir(userId);
+  await ensureDir(dir);
+
+  const files = await fs.readdir(dir).catch(() => []);
+  const playlists: ForYouPlaylist[] = [];
+
+  for (const file of files) {
+    if (!file.endsWith(".json") || file === "_meta.json") continue;
+    const data = await readJsonFile<ForYouPlaylist>(
+      path.join(dir, file),
+      null as unknown as ForYouPlaylist
+    );
+    if (data && data.id && data.trackIds) {
+      playlists.push(data);
+    }
+  }
+
+  return playlists.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getForYouPlaylistById(
+  userId: string,
+  playlistId: string
+): Promise<ForYouPlaylist | null> {
+  const all = await loadForYouPlaylists(userId);
+  return all.find((p) => p.id === playlistId) ?? null;
+}
+
+// ── Regeneration ──────────────────────────────────────────────────
+
+export async function needsForYouRegeneration(userId: string): Promise<boolean> {
+  const metaPath = userForYouMetaPath(userId);
+  const meta = await readJsonFile<ForYouMeta>(metaPath, { lastGeneratedAt: "" });
+  if (!meta.lastGeneratedAt) return true;
+
+  const lastGenerated = new Date(meta.lastGeneratedAt).getTime();
+  if (isNaN(lastGenerated)) return true;
+
+  return Date.now() - lastGenerated > REGENERATION_INTERVAL_MS;
+}
+
+export async function regenerateForYouPlaylists(
+  userId: string,
+  indexStore: IndexStore
+): Promise<ForYouPlaylist[]> {
+  log.info(`Regenerating for-you playlists for user ${userId}...`);
+  const playlists = await generateForYouPlaylists(userId, indexStore);
+  await saveForYouPlaylists(userId, playlists);
+  log.info(`Generated ${playlists.length} for-you playlist(s) for user ${userId}`);
+  return playlists;
+}
+
+export async function checkAndRegenerateForYouOnBoot(
+  userId: string,
+  indexStore: IndexStore
+): Promise<void> {
+  const shouldRegenerate = await needsForYouRegeneration(userId);
+  if (!shouldRegenerate) {
+    const existing = await loadForYouPlaylists(userId);
+    log.debug(`For-you playlists up to date for user ${userId} (${existing.length} playlist(s))`);
+    return;
+  }
+
+  await regenerateForYouPlaylists(userId, indexStore);
+}

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -20,6 +20,7 @@ import { usePlaybackCommands } from "./hooks/usePlaybackCommands";
 import { usePlaybackState } from "./hooks/usePlaybackState";
 import { useRecentlyUploaded } from "./hooks/useRecentlyUploaded";
 import { useAutoPlaylists } from "./hooks/useAutoPlaylists";
+import { useForYouPlaylists } from "./hooks/useForYouPlaylists";
 import { useRadioStation } from "./hooks/useRadioStation";
 
 type AuthenticatedAppProps = {
@@ -94,6 +95,7 @@ export function AuthenticatedApp({
   } = useInfiniteLibrary({ user, filters, pageSize: 30 });
 
   const { autoPlaylists, loading: loadingAutoPlaylists, refresh: refreshAutoPlaylists } = useAutoPlaylists();
+  const { forYouPlaylists, loading: loadingForYouPlaylists, dismiss: dismissForYouPlaylist } = useForYouPlaylists();
 
   const allTracksById = useMemo(
     () => new Map(allTracksLibrary.tracks.map((track) => [track.id, track])),
@@ -308,6 +310,9 @@ export function AuthenticatedApp({
         onReportPlaylistListen: handleReportPlaylistListen,
         autoPlaylists,
         loadingAutoPlaylists,
+        forYouPlaylists,
+        loadingForYouPlaylists,
+        onDismissForYouPlaylist: dismissForYouPlaylist,
         allTracksById,
         libraryMetadataError,
         loadingLibraryArtists,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,6 +3,8 @@ import type {
   ArtistEntry,
   AutoPlaylistDetail,
   AutoPlaylistSummary,
+  ForYouPlaylistDetail,
+  ForYouPlaylistSummary,
   LibraryResponse,
   Playlist,
   RadioCreateResponse,
@@ -723,6 +725,30 @@ export async function getAutoPlaylistDetail(id: string): Promise<{ playlist: Aut
 
 export async function regenerateAutoPlaylists(): Promise<{ regenerated: number }> {
   return requestJson<{ regenerated: number }>("/api/playlists/automatic/regenerate", {
+    method: "POST"
+  });
+}
+
+export async function getForYouPlaylists(): Promise<ForYouPlaylistSummary[]> {
+  const payload = await requestJson<{ playlists: ForYouPlaylistSummary[] }>("/api/playlists/for-you");
+  return payload.playlists;
+}
+
+export async function getForYouPlaylistDetail(id: string): Promise<{ playlist: ForYouPlaylistDetail; tracks: Track[] }> {
+  return requestJson<{ playlist: ForYouPlaylistDetail; tracks: Track[] }>(
+    `/api/playlists/for-you/${encodeURIComponent(id)}`
+  );
+}
+
+export async function dismissForYouPlaylist(playlistId: string): Promise<void> {
+  await requestJson<void>(
+    `/api/playlists/for-you/${encodeURIComponent(playlistId)}/dismiss`,
+    { method: "POST", skipJson: true }
+  );
+}
+
+export async function regenerateForYouPlaylists(): Promise<{ regenerated: number }> {
+  return requestJson<{ regenerated: number }>("/api/playlists/for-you/regenerate", {
     method: "POST"
   });
 }

--- a/frontend/src/components/ForYouPlaylistDetailView.tsx
+++ b/frontend/src/components/ForYouPlaylistDetailView.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { coverUrl, getForYouPlaylistDetail } from "../api";
+import type { ForYouPlaylistDetail, Playlist, Track } from "../types";
+import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+
+type ForYouPlaylistDetailViewProps = {
+  playlistId: string;
+  allTracksById: Map<string, Track>;
+  onBack: () => void;
+  onPlayTrack: (playlist: Playlist) => void;
+  onDismiss: (playlistId: string) => Promise<void>;
+};
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+export function ForYouPlaylistDetailView({
+  playlistId,
+  allTracksById,
+  onBack,
+  onPlayTrack,
+  onDismiss
+}: ForYouPlaylistDetailViewProps): JSX.Element {
+  const [detail, setDetail] = useState<ForYouPlaylistDetail | null>(null);
+  const [detailTracks, setDetailTracks] = useState<Track[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dismissing, setDismissing] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    getForYouPlaylistDetail(playlistId)
+      .then((result) => {
+        setDetail(result.playlist);
+        setDetailTracks(result.tracks);
+      })
+      .catch(() => {
+        setDetail(null);
+        setDetailTracks([]);
+      })
+      .finally(() => setLoading(false));
+  }, [playlistId]);
+
+  const tracks = useMemo(() => {
+    if (!detail) return detailTracks;
+    return detail.trackIds
+      .map((id) => detailTracks.find((t) => t.id === id) ?? allTracksById.get(id))
+      .filter((t): t is Track => t !== undefined);
+  }, [detail, detailTracks, allTracksById]);
+
+  const totalDuration = useMemo(() => tracks.reduce((sum, t) => sum + t.duration, 0), [tracks]);
+
+  function handlePlayAll(): void {
+    if (!detail || tracks.length === 0) return;
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: tracks.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
+  function handleShufflePlay(): void {
+    if (!detail || tracks.length === 0) return;
+    const shuffled = [...tracks].sort(() => Math.random() - 0.5);
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: shuffled.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
+  async function handleDismiss(): Promise<void> {
+    if (!detail || dismissing) return;
+    setDismissing(true);
+    try {
+      await onDismiss(detail.id);
+      onBack();
+    } finally {
+      setDismissing(false);
+    }
+  }
+
+  const backButton = (
+    <button
+      type="button"
+      className="flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+      onClick={onBack}
+    >
+      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+      </svg>
+      Back to playlists
+    </button>
+  );
+
+  if (loading) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        {backButton}
+        <p className="mt-4 text-sm text-flaque-steel">Loading...</p>
+      </section>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        {backButton}
+        <p className="mt-4 text-sm text-flaque-steel">For-you playlist not found.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="m-4 space-y-4">
+      {backButton}
+
+      {/* Header card */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/80 to-purple-50/60 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-col gap-5 sm:flex-row">
+          {/* Seed artist visual */}
+          <div className="flex h-48 w-48 shrink-0 items-center justify-center self-center overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-100/80 to-purple-100/60 sm:self-start">
+            <div className="text-center px-3">
+              <svg className="mx-auto h-8 w-8 text-indigo-400/70" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                  d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+              </svg>
+              <p className="mt-2 font-display text-lg font-bold text-flaque-ink/70 leading-tight">{detail.seedArtist}</p>
+            </div>
+          </div>
+
+          {/* Info */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <h2 className="font-display text-2xl text-flaque-ink">{detail.name}</h2>
+
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-flaque-steel">
+              <span className="rounded-full bg-indigo-100/70 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-indigo-600/80">
+                Made for you
+              </span>
+              <span>{detail.trackCount} track{detail.trackCount !== 1 ? "s" : ""}</span>
+              {totalDuration > 0 ? <span>{formatDuration(totalDuration)}</span> : null}
+              <span>Generated {new Date(detail.generatedAt).toLocaleDateString()}</span>
+            </div>
+
+            {/* Action buttons */}
+            <div className="mt-auto flex flex-wrap items-center gap-2 pt-4">
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black"
+                onClick={handlePlayAll}
+              >
+                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+                Play all
+              </button>
+
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
+                onClick={handleShufflePlay}
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4" />
+                </svg>
+                Shuffle
+              </button>
+
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl border border-red-200 px-4 py-2 text-sm text-red-500 transition hover:bg-red-50"
+                onClick={() => { void handleDismiss(); }}
+                disabled={dismissing}
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                {dismissing ? "Hiding..." : "Not interested"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Track list */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
+        {tracks.length === 0 ? (
+          <p className="px-5 py-4 text-sm text-flaque-steel">No playable tracks.</p>
+        ) : (
+          <ul>
+            {tracks.map((track, index) => (
+              <li
+                key={track.id}
+                className="flex items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+              >
+                <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
+                <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
+                  <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
+                    {track.tags.extra?.lyrics ? (
+                      <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
+                        L
+                      </span>
+                    ) : null}
+                    <span className="truncate">{getTrackDisplayTitle(track)}</span>
+                  </p>
+                  <p className="truncate text-xs text-flaque-steel">
+                    {getTrackDisplayArtist(track) ?? "Unknown artist"}
+                    {track.tags.album ? ` \u00b7 ${track.tags.album}` : ""}
+                  </p>
+                </div>
+                <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
+                  {formatDuration(track.duration)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -37,7 +37,10 @@ const defaultProps = {
   onNavigateToPlaylist: vi.fn(),
   onReportPlaylistListen: vi.fn().mockResolvedValue(undefined),
   autoPlaylists: [],
-  loadingAutoPlaylists: false
+  loadingAutoPlaylists: false,
+  forYouPlaylists: [],
+  loadingForYouPlaylists: false,
+  onDismissForYouPlaylist: vi.fn().mockResolvedValue(undefined)
 };
 
 describe("LibraryPlaylistSection", () => {

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useState } from "react";
 
 import { coverUrl, playlistCoverUrl } from "../api";
-import type { AutoPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
+import type { AutoPlaylistSummary, ForYouPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
 
 type LibraryPlaylistSectionProps = {
   availablePlaylists: Playlist[];
@@ -17,6 +17,9 @@ type LibraryPlaylistSectionProps = {
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
   autoPlaylists: AutoPlaylistSummary[];
   loadingAutoPlaylists: boolean;
+  forYouPlaylists: ForYouPlaylistSummary[];
+  loadingForYouPlaylists: boolean;
+  onDismissForYouPlaylist: (playlistId: string) => Promise<void>;
 };
 
 // ── Mosaic cover (compact) ─────────────────────────────────────────
@@ -172,7 +175,10 @@ export function LibraryPlaylistSection({
   onNavigateToPlaylist,
   onReportPlaylistListen,
   autoPlaylists,
-  loadingAutoPlaylists
+  loadingAutoPlaylists,
+  forYouPlaylists,
+  loadingForYouPlaylists,
+  onDismissForYouPlaylist
 }: LibraryPlaylistSectionProps): JSX.Element {
   const [playlistName, setPlaylistName] = useState("");
   const [playlistVisibility, setPlaylistVisibility] = useState<PlaylistVisibility>("private");
@@ -258,6 +264,56 @@ export function LibraryPlaylistSection({
           </div>
         )}
       </section>
+
+      {/* ── Made For You ────────────────────────────────────────── */}
+      {!loadingForYouPlaylists && forYouPlaylists.length > 0 ? (
+        <section className="rounded-xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/60 to-purple-50/40 p-5 shadow-panel backdrop-blur-sm">
+          <SectionHeader title="Made for you" />
+          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            {forYouPlaylists.map((fy) => (
+              <div
+                key={fy.id}
+                className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/80 to-purple-50/60 shadow-sm transition hover:shadow-md"
+                onClick={() => onNavigateToPlaylist(fy.id)}
+                role="link"
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === "Enter") onNavigateToPlaylist(fy.id); }}
+              >
+                <div className="flex aspect-square w-full items-center justify-center bg-gradient-to-br from-indigo-100/60 to-purple-100/40">
+                  <div className="text-center px-3">
+                    <svg className="mx-auto h-8 w-8 text-indigo-400/60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                        d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                    </svg>
+                    <p className="mt-1 font-display text-sm font-bold text-flaque-ink/70 leading-tight">{fy.seedArtist}</p>
+                  </div>
+                </div>
+                <div className="p-3">
+                  <p className="truncate text-sm font-semibold text-flaque-ink">{fy.name}</p>
+                  <p className="mt-0.5 text-xs text-flaque-steel">
+                    {fy.trackCount} track{fy.trackCount !== 1 ? "s" : ""}
+                  </p>
+                </div>
+
+                {/* Dismiss button */}
+                <button
+                  type="button"
+                  className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-flaque-steel opacity-0 shadow-sm transition hover:bg-white hover:text-red-500 group-hover:opacity-100"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void onDismissForYouPlaylist(fy.id);
+                  }}
+                  aria-label={`Hide ${fy.name}`}
+                >
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       {/* ── Popular Playlists ─────────────────────────────────────── */}
       {popularPlaylists.length > 0 ? (

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -3,9 +3,10 @@ import { LibraryAlbumsSection } from "./LibraryAlbumsSection";
 import { LibraryArtistsSection } from "./LibraryArtistsSection";
 import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
 import { AutoPlaylistDetailView } from "./AutoPlaylistDetailView";
+import { ForYouPlaylistDetailView } from "./ForYouPlaylistDetailView";
 import { PlaylistDetailView } from "./PlaylistDetailView";
 import { PaginatedLibrary } from "./PaginatedLibrary";
-import type { AlbumEntry, ArtistEntry, AutoPlaylistSummary, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
+import type { AlbumEntry, ArtistEntry, AutoPlaylistSummary, ForYouPlaylistSummary, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
 import type { LibraryFilters, LibrarySection } from "../types/library";
 import { navigateTo } from "../utils/appUtils";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
@@ -26,6 +27,9 @@ type LibraryWorkspaceProps = {
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
   autoPlaylists: AutoPlaylistSummary[];
   loadingAutoPlaylists: boolean;
+  forYouPlaylists: ForYouPlaylistSummary[];
+  loadingForYouPlaylists: boolean;
+  onDismissForYouPlaylist: (playlistId: string) => Promise<void>;
   allTracksById: Map<string, Track>;
   libraryMetadataError: string | null;
   loadingLibraryArtists: boolean;
@@ -99,6 +103,9 @@ export function LibraryWorkspace({
   onReportPlaylistListen,
   autoPlaylists,
   loadingAutoPlaylists,
+  forYouPlaylists,
+  loadingForYouPlaylists,
+  onDismissForYouPlaylist,
   allTracksById,
   libraryMetadataError,
   loadingLibraryArtists,
@@ -153,7 +160,15 @@ export function LibraryWorkspace({
   return (
     <div className="h-full min-h-0 space-y-4 overflow-y-auto">
       {activeLibrarySection === "playlists" ? (
-        playlistDetailId && playlistDetailId.startsWith("auto:") ? (
+        playlistDetailId && playlistDetailId.startsWith("for-you:") ? (
+          <ForYouPlaylistDetailView
+            playlistId={playlistDetailId}
+            allTracksById={allTracksById}
+            onBack={() => onPlaylistDetailNavigate(null)}
+            onPlayTrack={onPlayPlaylist}
+            onDismiss={onDismissForYouPlaylist}
+          />
+        ) : playlistDetailId && playlistDetailId.startsWith("auto:") ? (
           <AutoPlaylistDetailView
             playlistId={playlistDetailId}
             allTracksById={allTracksById}
@@ -190,6 +205,9 @@ export function LibraryWorkspace({
             onReportPlaylistListen={onReportPlaylistListen}
             autoPlaylists={autoPlaylists}
             loadingAutoPlaylists={loadingAutoPlaylists}
+            forYouPlaylists={forYouPlaylists}
+            loadingForYouPlaylists={loadingForYouPlaylists}
+            onDismissForYouPlaylist={onDismissForYouPlaylist}
           />
         )
       ) : null}

--- a/frontend/src/hooks/useForYouPlaylists.ts
+++ b/frontend/src/hooks/useForYouPlaylists.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { getForYouPlaylists, dismissForYouPlaylist as apiDismiss } from "../api";
+import type { ForYouPlaylistSummary } from "../types";
+
+type UseForYouPlaylistsResult = {
+  forYouPlaylists: ForYouPlaylistSummary[];
+  loading: boolean;
+  refresh: () => void;
+  dismiss: (playlistId: string) => Promise<void>;
+};
+
+export function useForYouPlaylists(): UseForYouPlaylistsResult {
+  const [forYouPlaylists, setForYouPlaylists] = useState<ForYouPlaylistSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetch = useCallback(() => {
+    setLoading(true);
+    getForYouPlaylists()
+      .then(setForYouPlaylists)
+      .catch(() => setForYouPlaylists([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  const dismiss = useCallback(async (playlistId: string) => {
+    await apiDismiss(playlistId);
+    setForYouPlaylists((prev) => prev.filter((p) => p.id !== playlistId));
+  }, []);
+
+  return { forYouPlaylists, loading, refresh: fetch, dismiss };
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -172,3 +172,15 @@ export type AutoPlaylistSummary = {
 export type AutoPlaylistDetail = AutoPlaylistSummary & {
   trackIds: string[];
 };
+
+export type ForYouPlaylistSummary = {
+  id: string;
+  name: string;
+  seedArtist: string;
+  trackCount: number;
+  generatedAt: string;
+};
+
+export type ForYouPlaylistDetail = ForYouPlaylistSummary & {
+  trackIds: string[];
+};


### PR DESCRIPTION
## Summary
- Personalized "Because you listen to {Artist}" playlists generated from each user's listening history
- Backend service analyzes play counts, finds top 3 artists, builds ~25-track playlists mixing seed artist tracks (40%) with genre/era peers (60%) using diversity algorithm
- Per-user storage with 2-week auto-regeneration and dismissal system (3-month expiry)
- API endpoints: list, detail, dismiss, and regenerate for-you playlists
- Frontend: "Made for you" section in playlist view with indigo/purple visual treatment, detail view with play/shuffle/dismiss actions
- Boot-time regeneration for all users

## New files
- `backend/src/services/playlists/forYouPlaylistService.ts` — generation, storage, dismissal logic
- `backend/src/api/forYouPlaylistRoutes.ts` — REST endpoints
- `frontend/src/components/ForYouPlaylistDetailView.tsx` — detail page
- `frontend/src/hooks/useForYouPlaylists.ts` — data hook with dismiss support

## Test plan
- [x] TypeScript compiles cleanly (backend + frontend)
- [x] All 34 frontend tests pass
- [x] 4 new service tests pass (threshold skip, generation, dismissal, persistence)
- [ ] Manual: verify "Made for you" section appears after sufficient play history
- [ ] Manual: verify dismiss button hides playlist and persists across reloads
- [ ] Manual: verify detail view plays all / shuffles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)