### PR TITLE
Address 10 playlist blind spots from roadmap audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage/
 
 runtime/
 
+data/backups/
 data/config/users.db
 data/config/users.db-*
 data/storage/users/*

--- a/backend/src/api/autoPlaylistRoutes.ts
+++ b/backend/src/api/autoPlaylistRoutes.ts
@@ -1,0 +1,98 @@
+import { Router } from "express";
+
+import { createLogger } from "../utils/logger";
+import { requireAdmin, requireAuth } from "../auth/middleware";
+import type { IndexStore } from "../services/indexer/indexStore";
+import {
+  getAutoPlaylistConfig,
+  updateAutoPlaylistConfig,
+  loadAutoPlaylists,
+  getAutoPlaylistById,
+  regenerateAutoPlaylists
+} from "../services/playlists/autoPlaylistService";
+
+const log = createLogger("auto-playlist-routes");
+
+export function createAutoPlaylistRouter(indexStore: IndexStore): Router {
+  const router = Router();
+
+  router.get("/config/auto-playlists", requireAdmin, async (_req, res, next) => {
+    try {
+      const config = await getAutoPlaylistConfig();
+      res.json(config);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.patch("/config/auto-playlists", requireAdmin, async (req, res, next) => {
+    try {
+      const body = req.body as Record<string, unknown>;
+      const patch: Record<string, number> = {};
+
+      if (typeof body.maxPlaylists === "number") patch.maxPlaylists = body.maxPlaylists;
+      if (typeof body.minTracksPerPlaylist === "number") patch.minTracksPerPlaylist = body.minTracksPerPlaylist;
+      if (typeof body.tracksPerPlaylist === "number") patch.tracksPerPlaylist = body.tracksPerPlaylist;
+
+      const updated = await updateAutoPlaylistConfig(patch);
+      res.json(updated);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/playlists/automatic", requireAuth, async (_req, res, next) => {
+    try {
+      const playlists = await loadAutoPlaylists();
+      res.json({
+        playlists: playlists.map((p) => ({
+          id: p.id,
+          name: p.name,
+          genre: p.genre,
+          decade: p.decade,
+          trackCount: p.trackCount,
+          generatedAt: p.generatedAt
+        }))
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/playlists/automatic/:id", requireAuth, async (req, res, next) => {
+    try {
+      const id = req.params.id;
+      if (!id) {
+        res.status(400).json({ error: "Playlist id is required" });
+        return;
+      }
+
+      const playlist = await getAutoPlaylistById(id);
+      if (!playlist) {
+        res.status(404).json({ error: "Auto playlist not found" });
+        return;
+      }
+
+      const tracks = playlist.trackIds
+        .map((trackId) => indexStore.getTrackById(trackId))
+        .filter((t) => t !== undefined);
+
+      res.json({ playlist, tracks });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/playlists/automatic/regenerate", requireAdmin, async (_req, res, next) => {
+    try {
+      const allTracks = indexStore.getSnapshot().tracks;
+      const playlists = await regenerateAutoPlaylists(allTracks);
+      log.info(`Admin triggered auto playlist regeneration: ${playlists.length} playlist(s)`);
+      res.json({ regenerated: playlists.length, playlists: playlists.map((p) => ({ id: p.id, name: p.name, trackCount: p.trackCount })) });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/backend/src/api/forYouPlaylistRoutes.ts
+++ b/backend/src/api/forYouPlaylistRoutes.ts
@@ -1,0 +1,122 @@
+import { Router } from "express";
+
+import { createLogger } from "../utils/logger";
+import { requireAuth } from "../auth/middleware";
+import type { IndexStore } from "../services/indexer/indexStore";
+import {
+  loadForYouPlaylists,
+  getForYouPlaylistById,
+  regenerateForYouPlaylists,
+  dismissForYouPlaylist,
+  getUserDismissals
+} from "../services/playlists/forYouPlaylistService";
+
+const log = createLogger("for-you-routes");
+
+export function createForYouPlaylistRouter(indexStore: IndexStore): Router {
+  const router = Router();
+
+  router.get("/playlists/for-you", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlists = await loadForYouPlaylists(userId);
+      const dismissals = await getUserDismissals(userId);
+
+      const visible = playlists.filter((p) => !dismissals.has(p.id));
+
+      res.json({
+        playlists: visible.map((p) => ({
+          id: p.id,
+          name: p.name,
+          seedArtist: p.seedArtist,
+          trackCount: p.trackCount,
+          generatedAt: p.generatedAt
+        }))
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/playlists/for-you/:id", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const id = req.params.id;
+      if (!id) {
+        res.status(400).json({ error: "Playlist id is required" });
+        return;
+      }
+
+      const playlist = await getForYouPlaylistById(userId, id);
+      if (!playlist) {
+        res.status(404).json({ error: "For-you playlist not found" });
+        return;
+      }
+
+      const tracks = playlist.trackIds
+        .map((trackId) => indexStore.getTrackById(trackId))
+        .filter((t) => t !== undefined);
+
+      res.json({ playlist, tracks });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/playlists/for-you/regenerate", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlists = await regenerateForYouPlaylists(userId, indexStore);
+      log.info(`User ${userId} triggered for-you regeneration: ${playlists.length} playlist(s)`);
+      res.json({
+        regenerated: playlists.length,
+        playlists: playlists.map((p) => ({
+          id: p.id,
+          name: p.name,
+          seedArtist: p.seedArtist,
+          trackCount: p.trackCount
+        }))
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/playlists/for-you/:id/dismiss", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlistId = req.params.id;
+      if (!playlistId) {
+        res.status(400).json({ error: "Playlist id is required" });
+        return;
+      }
+
+      await dismissForYouPlaylist(userId, playlistId);
+      res.status(204).end();
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/backend/src/api/genreRoutes.ts
+++ b/backend/src/api/genreRoutes.ts
@@ -1,0 +1,97 @@
+import { Router } from "express";
+
+import { requireAdmin, requireAuth } from "../auth/middleware";
+import type { IndexStore } from "../services/indexer/indexStore";
+import {
+  getEnrichmentStatus,
+  runBackgroundEnrichment,
+  stopEnrichment
+} from "../services/genre/genreEnrichmentService";
+import {
+  getSynonyms,
+  setSynonym,
+  removeSynonym,
+  resetSynonymsToDefaults
+} from "../services/genre/genreSynonymService";
+import { getGenreCacheStats, clearGenreCache } from "../services/genre/musicBrainzService";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("genre-routes");
+
+export function createGenreRouter(indexStore: IndexStore): Router {
+  const router = Router();
+
+  router.get("/genre/enrichment/status", requireAuth, requireAdmin, (_req, res) => {
+    res.json(getEnrichmentStatus());
+  });
+
+  router.post("/genre/enrichment/start", requireAuth, requireAdmin, (_req, res) => {
+    const status = getEnrichmentStatus();
+    if (status.running) {
+      res.json({ started: false, message: "Enrichment already running", status });
+      return;
+    }
+
+    void runBackgroundEnrichment(indexStore);
+
+    log.info("Genre enrichment started", { userId: _req.authUser?.id ?? "unknown" });
+    res.json({ started: true, message: "Genre enrichment started" });
+  });
+
+  router.post("/genre/enrichment/stop", requireAuth, requireAdmin, (_req, res) => {
+    stopEnrichment();
+    log.info("Genre enrichment stopped", { userId: _req.authUser?.id ?? "unknown" });
+    res.json({ stopped: true });
+  });
+
+  router.get("/genre/synonyms", requireAuth, requireAdmin, (_req, res) => {
+    res.json(getSynonyms());
+  });
+
+  router.put("/genre/synonyms", requireAuth, requireAdmin, (req, res) => {
+    const { from, to } = req.body as { from?: string; to?: string };
+    if (typeof from !== "string" || !from.trim() || typeof to !== "string" || !to.trim()) {
+      res.status(400).json({ error: "Both 'from' and 'to' must be non-empty strings" });
+      return;
+    }
+
+    setSynonym(from, to);
+    log.info("Genre synonym updated", { from, to, userId: req.authUser?.id ?? "unknown" });
+    res.json({ from: from.trim().toLowerCase(), to: to.trim() });
+  });
+
+  router.delete("/genre/synonyms/:key", requireAuth, requireAdmin, (req, res) => {
+    const key = req.params.key;
+    if (!key) {
+      res.status(400).json({ error: "Synonym key required" });
+      return;
+    }
+
+    const removed = removeSynonym(key);
+    if (!removed) {
+      res.status(404).json({ error: "Synonym not found" });
+      return;
+    }
+
+    log.info("Genre synonym removed", { key, userId: req.authUser?.id ?? "unknown" });
+    res.json({ removed: true });
+  });
+
+  router.post("/genre/synonyms/reset", requireAuth, requireAdmin, (_req, res) => {
+    resetSynonymsToDefaults();
+    log.info("Genre synonyms reset to defaults", { userId: _req.authUser?.id ?? "unknown" });
+    res.json({ reset: true });
+  });
+
+  router.get("/genre/cache/stats", requireAuth, requireAdmin, (_req, res) => {
+    res.json(getGenreCacheStats());
+  });
+
+  router.post("/genre/cache/clear", requireAuth, requireAdmin, (_req, res) => {
+    clearGenreCache();
+    log.info("MusicBrainz genre cache cleared", { userId: _req.authUser?.id ?? "unknown" });
+    res.json({ cleared: true });
+  });
+
+  return router;
+}

--- a/backend/src/api/libraryRoutes.ts
+++ b/backend/src/api/libraryRoutes.ts
@@ -37,6 +37,7 @@ import type { Track } from "../types/library";
 import {
   hasOwnProperty,
   parseMetadataField,
+  parseMetadataGenreField,
   parseMetadataYearField,
   readDirection,
   readFilter,
@@ -208,9 +209,10 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       const hasArtist = hasOwnProperty(req.body, "artist");
       const hasAlbum = hasOwnProperty(req.body, "album");
       const hasYear = hasOwnProperty(req.body, "year");
+      const hasGenre = hasOwnProperty(req.body, "genre");
 
-      if (!hasTitle && !hasArtist && !hasAlbum && !hasYear) {
-        res.status(400).json({ error: "At least one metadata field is required: title, artist, album, year" });
+      if (!hasTitle && !hasArtist && !hasAlbum && !hasYear && !hasGenre) {
+        res.status(400).json({ error: "At least one metadata field is required: title, artist, album, year, genre" });
         return;
       }
 
@@ -224,11 +226,13 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       const parsedArtist = hasArtist ? parseMetadataField(req.body?.artist) : undefined;
       const parsedAlbum = hasAlbum ? parseMetadataField(req.body?.album) : undefined;
       const parsedYear = hasYear ? parseMetadataYearField(req.body?.year) : undefined;
+      const parsedGenre = hasGenre ? parseMetadataGenreField(req.body?.genre) : undefined;
 
       if (parsedTitle === null) { res.status(400).json({ error: "title must be a string or null" }); return; }
       if (parsedArtist === null) { res.status(400).json({ error: "artist must be a string or null" }); return; }
       if (parsedAlbum === null) { res.status(400).json({ error: "album must be a string or null" }); return; }
       if (parsedYear === null) { res.status(400).json({ error: "year must be an integer between 1000 and 2999, or null" }); return; }
+      if (parsedGenre === null) { res.status(400).json({ error: "genre must be an array of strings or null" }); return; }
 
       const currentOverrides = await readTrackMetadataOverrides();
       const currentOverride = currentOverrides[trackId] ?? {};
@@ -238,7 +242,8 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
           title: hasTitle ? parsedTitle : currentOverride.title,
           artist: hasArtist ? parsedArtist : currentOverride.artist,
           album: hasAlbum ? parsedAlbum : currentOverride.album,
-          year: hasYear ? parsedYear : currentOverride.year
+          year: hasYear ? parsedYear : currentOverride.year,
+          genre: hasGenre ? parsedGenre : currentOverride.genre
         }
       });
 
@@ -246,7 +251,7 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
         trackId,
         title: currentTrack.tags.title ?? currentTrack.path,
         userId: req.authUser?.id ?? "unknown",
-        fields: [hasTitle && "title", hasArtist && "artist", hasAlbum && "album", hasYear && "year"].filter(Boolean).join(", ")
+        fields: [hasTitle && "title", hasArtist && "artist", hasAlbum && "album", hasYear && "year", hasGenre && "genre"].filter(Boolean).join(", ")
       });
 
       await indexStore.rebuild();
@@ -258,7 +263,7 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       }
 
       const fallbackTrack = applyMetadataPatchToTrack(currentTrack, {
-        hasTitle, title: parsedTitle, hasArtist, artist: parsedArtist, hasAlbum, album: parsedAlbum, hasYear, year: parsedYear
+        hasTitle, title: parsedTitle, hasArtist, artist: parsedArtist, hasAlbum, album: parsedAlbum, hasYear, year: parsedYear, hasGenre, genre: parsedGenre
       });
       res.json({
         track: mapTrackResponse(mapTrackOwners([fallbackTrack], ownerNamesById)[0]!),
@@ -343,9 +348,10 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       const hasArtist = hasOwnProperty(req.body, "artist");
       const hasAlbum = hasOwnProperty(req.body, "album");
       const hasYear = hasOwnProperty(req.body, "year");
+      const hasGenre = hasOwnProperty(req.body, "genre");
 
-      if (!hasTitle && !hasArtist && !hasAlbum && !hasYear) {
-        res.status(400).json({ error: "At least one metadata field is required: title, artist, album, year" });
+      if (!hasTitle && !hasArtist && !hasAlbum && !hasYear && !hasGenre) {
+        res.status(400).json({ error: "At least one metadata field is required: title, artist, album, year, genre" });
         return;
       }
 
@@ -353,14 +359,16 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       const parsedArtist = hasArtist ? parseMetadataField(req.body?.artist) : undefined;
       const parsedAlbum = hasAlbum ? parseMetadataField(req.body?.album) : undefined;
       const parsedYear = hasYear ? parseMetadataYearField(req.body?.year) : undefined;
+      const parsedGenre = hasGenre ? parseMetadataGenreField(req.body?.genre) : undefined;
 
       if (parsedTitle === null) { res.status(400).json({ error: "title must be a string or null" }); return; }
       if (parsedArtist === null) { res.status(400).json({ error: "artist must be a string or null" }); return; }
       if (parsedAlbum === null) { res.status(400).json({ error: "album must be a string or null" }); return; }
       if (parsedYear === null) { res.status(400).json({ error: "year must be an integer between 1000 and 2999, or null" }); return; }
+      if (parsedGenre === null) { res.status(400).json({ error: "genre must be an array of strings or null" }); return; }
 
       const currentOverrides = await readTrackMetadataOverrides();
-      const overridePatch: Record<string, { title?: string; artist?: string; album?: string; year?: number }> = {};
+      const overridePatch: Record<string, { title?: string; artist?: string; album?: string; year?: number; genre?: string[] }> = {};
       const updated: string[] = [];
       const notFound: string[] = [];
 
@@ -376,7 +384,8 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
           title: hasTitle ? parsedTitle : current.title,
           artist: hasArtist ? parsedArtist : current.artist,
           album: hasAlbum ? parsedAlbum : current.album,
-          year: hasYear ? parsedYear : current.year
+          year: hasYear ? parsedYear : current.year,
+          genre: hasGenre ? parsedGenre : current.genre
         };
         updated.push(trackId);
       }
@@ -389,7 +398,7 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
         userId: req.authUser?.id ?? "unknown",
         updatedCount: updated.length,
         notFoundCount: notFound.length,
-        fields: [hasTitle && "title", hasArtist && "artist", hasAlbum && "album", hasYear && "year"].filter(Boolean).join(", ")
+        fields: [hasTitle && "title", hasArtist && "artist", hasAlbum && "album", hasYear && "year", hasGenre && "genre"].filter(Boolean).join(", ")
       });
 
       await indexStore.rebuild();

--- a/backend/src/api/playCountRoutes.ts
+++ b/backend/src/api/playCountRoutes.ts
@@ -1,0 +1,56 @@
+import { Router } from "express";
+
+import { requireAuth } from "../auth/middleware";
+import type { IndexStore } from "../services/indexer/indexStore";
+import { incrementPlayCount, getUserPlayStats } from "../services/activity/playCountStore";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("play-counts");
+
+export function createPlayCountRouter(indexStore: IndexStore): Router {
+  const router = Router();
+
+  router.post("/tracks/:id/play", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const trackId = req.params.id;
+      if (!trackId) {
+        res.status(400).json({ error: "Track id is required" });
+        return;
+      }
+
+      if (!indexStore.hasTrack(trackId)) {
+        res.status(404).json({ error: "Track not found" });
+        return;
+      }
+
+      await incrementPlayCount(userId, trackId);
+      log.debug("Play recorded", { userId, trackId });
+      res.status(204).end();
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/me/play-stats", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const stats = await getUserPlayStats(userId, indexStore);
+      res.json(stats);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/backend/src/api/playlistRoutes.test.ts
+++ b/backend/src/api/playlistRoutes.test.ts
@@ -128,7 +128,12 @@ describe("playlistRoutes", () => {
     const metadataRaw = await fs.readFile(metadataPath, "utf8");
     expect(JSON.parse(metadataRaw)).toEqual({
       name: "My Playlist",
-      visibility: "private"
+      visibility: "private",
+      collaborators: [],
+      cover: null,
+      description: "",
+      hearts: [],
+      listenCount: 0
     });
 
     const updateResponse = await apiRequest(`/api/playlists/${encodeURIComponent(createdPlaylist.id)}`, {

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -95,6 +95,9 @@ function findPlaylistById(indexStore: IndexStore, playlistId: string): Playlist 
   return playlists.find((playlist) => playlist.id === playlistId);
 }
 
+const listenDebounceMap = new Map<string, number>();
+const LISTEN_DEBOUNCE_MS = 60 * 60 * 1000; // 1 hour
+
 export function createPlaylistRouter(indexStore: IndexStore): Router {
   const router = Router();
 
@@ -163,13 +166,16 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
+      const description = typeof req.body?.description === "string" ? req.body.description.trim() : undefined;
+
       const snapshot = indexStore.getSnapshot();
       const playlistId = await createFilesystemPlaylist({
         name,
         authorId: authUser.id,
         visibility: visibility ?? "private",
         trackIds: trackIds ?? [],
-        tracksById: getTracksById(snapshot.tracks)
+        tracksById: getTracksById(snapshot.tracks),
+        description
       });
 
       const rebuilt = await indexStore.refreshPlaylists();
@@ -324,6 +330,9 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
       }
 
       const description = typeof req.body?.description === "string" ? req.body.description : undefined;
+      const collaborators = Array.isArray(req.body?.collaborators)
+        ? (req.body.collaborators as unknown[]).filter((c): c is string => typeof c === "string" && c.trim() !== "").map((c) => c.trim())
+        : undefined;
 
       if (description !== undefined) {
         await updatePlaylistDescription(playlistId, description);
@@ -336,7 +345,8 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         authorId: existing.authorId,
         visibility: visibility ?? existing.visibility,
         trackIds: trackIds ?? existing.trackIds,
-        tracksById: getTracksById(snapshot.tracks)
+        tracksById: getTracksById(snapshot.tracks),
+        collaborators
       });
 
       const rebuilt = await indexStore.refreshPlaylists();
@@ -461,6 +471,16 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
+      const debounceKey = `${authUser.id}:${playlistId}`;
+      const lastListen = listenDebounceMap.get(debounceKey);
+      const now = Date.now();
+
+      if (lastListen && now - lastListen < LISTEN_DEBOUNCE_MS) {
+        res.json({ listenCount: playlist.listenCount });
+        return;
+      }
+
+      listenDebounceMap.set(debounceKey, now);
       const listenCount = await incrementPlaylistListenCount(playlistId);
       res.json({ listenCount });
     } catch (error) {

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -1,16 +1,34 @@
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+
+import multer from "multer";
 import { Router } from "express";
 
 import { requireAuth } from "../auth/middleware";
 import { IndexStore } from "../services/indexer/indexStore";
+import { ensureDir } from "../utils/fs";
 import { createLogger } from "../utils/logger";
 
 const log = createLogger("playlists");
+
+const COVER_MAX_BYTES = 5 * 1024 * 1024;
+const COVER_FILE_NAME = "cover.webp";
+
+const coverUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: COVER_MAX_BYTES, files: 1 }
+});
 import {
   canManagePlaylist,
   createFilesystemPlaylist,
   deleteFilesystemPlaylist,
   filterPlayablePlaylists,
-  updateFilesystemPlaylist
+  getPlaylistDirectory,
+  incrementPlaylistListenCount,
+  togglePlaylistHeart,
+  updateFilesystemPlaylist,
+  updatePlaylistCover,
+  updatePlaylistDescription
 } from "../services/playlists/playlistStore";
 import type { Playlist, PlaylistVisibility, Track } from "../types/library";
 
@@ -305,6 +323,12 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
+      const description = typeof req.body?.description === "string" ? req.body.description : undefined;
+
+      if (description !== undefined) {
+        await updatePlaylistDescription(playlistId, description);
+      }
+
       const snapshot = indexStore.getSnapshot();
       await updateFilesystemPlaylist({
         id: playlistId,
@@ -377,6 +401,182 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
       });
 
       res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/playlists/:id/heart", requireAuth, async (req, res, next) => {
+    try {
+      const authUser = req.authUser;
+      const playlistId = req.params.id;
+      if (!authUser || !playlistId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlist = findPlaylistById(indexStore, playlistId);
+      if (!playlist) {
+        res.status(404).json({ error: "Playlist not found" });
+        return;
+      }
+
+      if (playlist.visibility !== "public") {
+        res.status(403).json({ error: "Only public playlists can be hearted" });
+        return;
+      }
+
+      if (playlist.authorId === authUser.id) {
+        res.status(400).json({ error: "Cannot heart your own playlist" });
+        return;
+      }
+
+      const result = await togglePlaylistHeart(playlistId, authUser.id);
+      await indexStore.refreshPlaylists();
+
+      log.info("Playlist heart toggled", {
+        playlistId,
+        userId: authUser.id,
+        hearted: result.hearted
+      });
+
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/playlists/:id/listen", requireAuth, async (req, res, next) => {
+    try {
+      const authUser = req.authUser;
+      const playlistId = req.params.id;
+      if (!authUser || !playlistId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlist = findPlaylistById(indexStore, playlistId);
+      if (!playlist) {
+        res.status(404).json({ error: "Playlist not found" });
+        return;
+      }
+
+      const listenCount = await incrementPlaylistListenCount(playlistId);
+      res.json({ listenCount });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post(
+    "/playlists/:id/cover",
+    requireAuth,
+    async (req, res, next) => {
+      try {
+        await new Promise<void>((resolve, reject) => {
+          coverUpload.single("cover")(req, res, (err: unknown) => (err ? reject(err) : resolve()));
+        });
+      } catch (error) {
+        if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+          res.status(400).json({ error: `Cover image must be <= ${Math.floor(COVER_MAX_BYTES / (1024 * 1024))} MB` });
+          return;
+        }
+        next(error);
+        return;
+      }
+
+      try {
+        const authUser = req.authUser;
+        const playlistId = req.params.id;
+        if (!authUser || !playlistId) {
+          res.status(401).json({ error: "Authentication required" });
+          return;
+        }
+
+        const playlist = findPlaylistById(indexStore, playlistId);
+        if (!playlist) {
+          res.status(404).json({ error: "Playlist not found" });
+          return;
+        }
+
+        if (!canManagePlaylist(playlist, authUser)) {
+          res.status(403).json({ error: "Not allowed to modify this playlist" });
+          return;
+        }
+
+        const file = req.file;
+        if (!file) {
+          res.status(400).json({ error: "cover image file is required" });
+          return;
+        }
+
+        if (!file.mimetype.toLowerCase().startsWith("image/")) {
+          res.status(400).json({ error: "Unsupported image format" });
+          return;
+        }
+
+        const sharp = (await import("sharp")).default;
+        let convertedBuffer: Buffer;
+        try {
+          convertedBuffer = await sharp(file.buffer)
+            .rotate()
+            .resize(512, 512, { fit: "cover", position: "centre" })
+            .webp({ quality: 85 })
+            .toBuffer();
+        } catch {
+          res.status(400).json({ error: "Invalid image file" });
+          return;
+        }
+
+        const playlistDir = getPlaylistDirectory(playlistId);
+        await ensureDir(playlistDir);
+
+        const tmpPath = path.join(playlistDir, `cover-upload.${process.pid}.${Date.now()}.tmp`);
+        const targetPath = path.join(playlistDir, COVER_FILE_NAME);
+
+        await fsPromises.writeFile(tmpPath, convertedBuffer);
+        await fsPromises.rename(tmpPath, targetPath);
+
+        await updatePlaylistCover(playlistId, targetPath);
+        await indexStore.refreshPlaylists();
+
+        log.info("Playlist cover uploaded", { playlistId, userId: authUser.id });
+        res.json({ ok: true, cover: targetPath });
+      } catch (error) {
+        next(error);
+      }
+    }
+  );
+
+  router.delete("/playlists/:id/cover", requireAuth, async (req, res, next) => {
+    try {
+      const authUser = req.authUser;
+      const playlistId = req.params.id;
+      if (!authUser || !playlistId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlist = findPlaylistById(indexStore, playlistId);
+      if (!playlist) {
+        res.status(404).json({ error: "Playlist not found" });
+        return;
+      }
+
+      if (!canManagePlaylist(playlist, authUser)) {
+        res.status(403).json({ error: "Not allowed to modify this playlist" });
+        return;
+      }
+
+      const playlistDir = getPlaylistDirectory(playlistId);
+      const coverPath = path.join(playlistDir, COVER_FILE_NAME);
+      await fsPromises.unlink(coverPath).catch(() => {});
+
+      await updatePlaylistCover(playlistId, null);
+      await indexStore.refreshPlaylists();
+
+      log.info("Playlist cover removed", { playlistId, userId: authUser.id });
+      res.json({ ok: true });
     } catch (error) {
       next(error);
     }

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -548,6 +548,27 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
     }
   );
 
+  router.get("/playlists/:id/cover", requireAuth, async (req, res, next) => {
+    try {
+      const playlistId = req.params.id;
+      if (!playlistId) {
+        res.status(400).json({ error: "Playlist id is required" });
+        return;
+      }
+
+      const playlist = findPlaylistById(indexStore, playlistId);
+      if (!playlist || !playlist.cover) {
+        res.status(404).json({ error: "Cover not found" });
+        return;
+      }
+
+      res.setHeader("Cache-Control", "private, max-age=86400");
+      res.sendFile(playlist.cover);
+    } catch (error) {
+      next(error);
+    }
+  });
+
   router.delete("/playlists/:id/cover", requireAuth, async (req, res, next) => {
     try {
       const authUser = req.authUser;

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -20,6 +20,7 @@ const coverUpload = multer({
 });
 import {
   canManagePlaylist,
+  canViewPlaylist,
   createFilesystemPlaylist,
   deleteFilesystemPlaylist,
   filterPlayablePlaylists,
@@ -27,9 +28,9 @@ import {
   incrementPlaylistListenCount,
   togglePlaylistHeart,
   updateFilesystemPlaylist,
-  updatePlaylistCover,
-  updatePlaylistDescription
+  updatePlaylistCover
 } from "../services/playlists/playlistStore";
+import { listUsers } from "../auth/db";
 import type { Playlist, PlaylistVisibility, Track } from "../types/library";
 
 function normalizeVisibility(value: unknown): PlaylistVisibility | null | undefined {
@@ -97,6 +98,16 @@ function findPlaylistById(indexStore: IndexStore, playlistId: string): Playlist 
 
 const listenDebounceMap = new Map<string, number>();
 const LISTEN_DEBOUNCE_MS = 60 * 60 * 1000; // 1 hour
+
+// Sweep expired entries every hour to prevent unbounded growth
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, timestamp] of listenDebounceMap) {
+    if (now - timestamp >= LISTEN_DEBOUNCE_MS) {
+      listenDebounceMap.delete(key);
+    }
+  }
+}, LISTEN_DEBOUNCE_MS).unref();
 
 export function createPlaylistRouter(indexStore: IndexStore): Router {
   const router = Router();
@@ -329,13 +340,18 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
-      const description = typeof req.body?.description === "string" ? req.body.description : undefined;
+      const description = typeof req.body?.description === "string" ? req.body.description.trim() : undefined;
       const collaborators = Array.isArray(req.body?.collaborators)
         ? (req.body.collaborators as unknown[]).filter((c): c is string => typeof c === "string" && c.trim() !== "").map((c) => c.trim())
         : undefined;
 
-      if (description !== undefined) {
-        await updatePlaylistDescription(playlistId, description);
+      if (collaborators !== undefined && collaborators.length > 0) {
+        const validUserIds = new Set(listUsers().map((u) => u.id));
+        const invalid = collaborators.filter((id) => !validUserIds.has(id));
+        if (invalid.length > 0) {
+          res.status(400).json({ error: `Unknown collaborator user ids: ${invalid.join(", ")}` });
+          return;
+        }
       }
 
       const snapshot = indexStore.getSnapshot();
@@ -346,6 +362,7 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         visibility: visibility ?? existing.visibility,
         trackIds: trackIds ?? existing.trackIds,
         tracksById: getTracksById(snapshot.tracks),
+        description,
         collaborators
       });
 
@@ -570,15 +587,21 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
 
   router.get("/playlists/:id/cover", requireAuth, async (req, res, next) => {
     try {
+      const authUser = req.authUser;
       const playlistId = req.params.id;
-      if (!playlistId) {
-        res.status(400).json({ error: "Playlist id is required" });
+      if (!authUser || !playlistId) {
+        res.status(401).json({ error: "Authentication required" });
         return;
       }
 
       const playlist = findPlaylistById(indexStore, playlistId);
       if (!playlist || !playlist.cover) {
         res.status(404).json({ error: "Cover not found" });
+        return;
+      }
+
+      if (!canViewPlaylist(playlist, authUser)) {
+        res.status(403).json({ error: "Not allowed to access this playlist" });
         return;
       }
 

--- a/backend/src/api/queryParsers.ts
+++ b/backend/src/api/queryParsers.ts
@@ -199,3 +199,24 @@ export function parseMetadataYearField(value: unknown): number | undefined | nul
 
   return n;
 }
+
+export function parseMetadataGenreField(value: unknown): string[] | undefined | null {
+  if (value === null) {
+    return undefined;
+  }
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const genres: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") return null;
+    const trimmed = item.trim();
+    if (trimmed) genres.push(trimmed);
+  }
+
+  return genres.length > 0 ? genres : undefined;
+}

--- a/backend/src/api/router.ts
+++ b/backend/src/api/router.ts
@@ -4,6 +4,7 @@ import { IndexStore } from "../services/indexer/indexStore";
 import { createAuthRouter } from "./authRoutes";
 import { createBackupRouter } from "./backupRoutes";
 import { createCoverRouter } from "./coverRoutes";
+import { createGenreRouter } from "./genreRoutes";
 import { createIndexRouter } from "./indexRoutes";
 import { createLibraryRouter } from "./libraryRoutes";
 import { createLogRouter } from "./logRoutes";
@@ -25,6 +26,7 @@ export function createApiRouter(indexStore: IndexStore): Router {
   router.use(createStreamingRouter(indexStore));
   router.use(createCoverRouter(indexStore));
   router.use(createIndexRouter(indexStore));
+  router.use(createGenreRouter(indexStore));
   router.use(createUserRouter());
   router.use(createLogRouter());
   router.use(createServerRouter());

--- a/backend/src/api/router.ts
+++ b/backend/src/api/router.ts
@@ -8,6 +8,7 @@ import { createGenreRouter } from "./genreRoutes";
 import { createIndexRouter } from "./indexRoutes";
 import { createLibraryRouter } from "./libraryRoutes";
 import { createLogRouter } from "./logRoutes";
+import { createPlayCountRouter } from "./playCountRoutes";
 import { createPlaylistRouter } from "./playlistRoutes";
 import { createRadioRouter } from "./radioRoutes";
 import { createServerRouter } from "./serverRoutes";
@@ -24,6 +25,7 @@ export function createApiRouter(indexStore: IndexStore): Router {
   router.use(createPlaylistRouter(indexStore));
   router.use(createRadioRouter(indexStore));
   router.use(createStreamingRouter(indexStore));
+  router.use(createPlayCountRouter(indexStore));
   router.use(createCoverRouter(indexStore));
   router.use(createIndexRouter(indexStore));
   router.use(createGenreRouter(indexStore));

--- a/backend/src/api/router.ts
+++ b/backend/src/api/router.ts
@@ -3,6 +3,7 @@ import { Router } from "express";
 import { IndexStore } from "../services/indexer/indexStore";
 import { createAutoPlaylistRouter } from "./autoPlaylistRoutes";
 import { createAuthRouter } from "./authRoutes";
+import { createForYouPlaylistRouter } from "./forYouPlaylistRoutes";
 import { createBackupRouter } from "./backupRoutes";
 import { createCoverRouter } from "./coverRoutes";
 import { createGenreRouter } from "./genreRoutes";
@@ -31,6 +32,7 @@ export function createApiRouter(indexStore: IndexStore): Router {
   router.use(createIndexRouter(indexStore));
   router.use(createGenreRouter(indexStore));
   router.use(createAutoPlaylistRouter(indexStore));
+  router.use(createForYouPlaylistRouter(indexStore));
   router.use(createUserRouter());
   router.use(createLogRouter());
   router.use(createServerRouter());

--- a/backend/src/api/router.ts
+++ b/backend/src/api/router.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 import { IndexStore } from "../services/indexer/indexStore";
+import { createAutoPlaylistRouter } from "./autoPlaylistRoutes";
 import { createAuthRouter } from "./authRoutes";
 import { createBackupRouter } from "./backupRoutes";
 import { createCoverRouter } from "./coverRoutes";
@@ -29,6 +30,7 @@ export function createApiRouter(indexStore: IndexStore): Router {
   router.use(createCoverRouter(indexStore));
   router.use(createIndexRouter(indexStore));
   router.use(createGenreRouter(indexStore));
+  router.use(createAutoPlaylistRouter(indexStore));
   router.use(createUserRouter());
   router.use(createLogRouter());
   router.use(createServerRouter());

--- a/backend/src/api/trackPipeline.ts
+++ b/backend/src/api/trackPipeline.ts
@@ -103,6 +103,8 @@ export function applyMetadataPatchToTrack(
     album?: string;
     hasYear: boolean;
     year?: number;
+    hasGenre?: boolean;
+    genre?: string[];
   }
 ): Track {
   return {
@@ -112,7 +114,8 @@ export function applyMetadataPatchToTrack(
       ...(patch.hasTitle ? { title: patch.title } : {}),
       ...(patch.hasArtist ? { artist: patch.artist } : {}),
       ...(patch.hasAlbum ? { album: patch.album } : {}),
-      ...(patch.hasYear ? { year: patch.year } : {})
+      ...(patch.hasYear ? { year: patch.year } : {}),
+      ...(patch.hasGenre ? { genre: patch.genre } : {})
     }
   };
 }

--- a/backend/src/api/uploadRoutes.ts
+++ b/backend/src/api/uploadRoutes.ts
@@ -6,6 +6,7 @@ import { Router, type NextFunction, type Response } from "express";
 
 import { requireAuth } from "../auth/middleware";
 import { appendTrackActivityLogEntries, readTrackActivityLog } from "../services/activity/trackActivityStore";
+import { enrichTrackGenre } from "../services/genre/genreEnrichmentService";
 import { mergeTrackMetadataOverrides } from "../services/indexer/metadataOverrideStore";
 import { IndexStore } from "../services/indexer/indexStore";
 
@@ -83,11 +84,22 @@ export function parseUploadMetadataOverrides(value: unknown): UploadMetadataOver
         }
       }
 
+      let genre: string[] | undefined;
+      const rawGenre = (entry as { genre?: unknown }).genre;
+      if (Array.isArray(rawGenre)) {
+        const parsed = rawGenre
+          .filter((g): g is string => typeof g === "string")
+          .map((g) => g.trim())
+          .filter(Boolean);
+        if (parsed.length > 0) genre = parsed;
+      }
+
       return {
         title: normalizeOptionalString((entry as { title?: unknown }).title),
         artist: normalizeOptionalString((entry as { artist?: unknown }).artist),
         album: normalizeOptionalString((entry as { album?: unknown }).album),
-        year
+        year,
+        genre
       };
     });
   } catch {
@@ -239,6 +251,16 @@ async function ingestUploadedFiles(
 
   if (newUploadTracks.length > 0) {
     await appendTrackActivityLogEntries(newUploadTracks);
+  }
+
+  for (const track of newUploadTracks) {
+    if (!track.tags.genre || track.tags.genre.length === 0) {
+      const artist = track.tags.artist;
+      const title = track.tags.title;
+      if (artist && title) {
+        void enrichTrackGenre(track.id, artist, title).catch(() => {});
+      }
+    }
   }
 
   const deduplicated = results.filter((r) => !r.isNew).length;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -16,6 +16,8 @@ import { startBackupScheduler } from "./services/backup/backupService";
 import { startVersionCheckSchedule } from "./services/versionCheck";
 import { ensureBaseDirectories } from "./utils/fs";
 import { checkAndRegenerateOnBoot } from "./services/playlists/autoPlaylistService";
+import { checkAndRegenerateForYouOnBoot } from "./services/playlists/forYouPlaylistService";
+import { listUsers } from "./auth/db";
 
 const SESSION_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
 const SHUTDOWN_TIMEOUT_MS = 10_000;
@@ -90,6 +92,9 @@ async function bootstrap(): Promise<void> {
   startVersionCheckSchedule();
   void startBackupScheduler();
   void checkAndRegenerateOnBoot(indexStore.getSnapshot().tracks);
+  void Promise.all(
+    listUsers().map((user) => checkAndRegenerateForYouOnBoot(user.id, indexStore))
+  );
 }
 
 bootstrap().catch((error: unknown) => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -15,6 +15,7 @@ import { migratePerUserUploadsToSharedMusic } from "./services/storage/storageSe
 import { startBackupScheduler } from "./services/backup/backupService";
 import { startVersionCheckSchedule } from "./services/versionCheck";
 import { ensureBaseDirectories } from "./utils/fs";
+import { checkAndRegenerateOnBoot } from "./services/playlists/autoPlaylistService";
 
 const SESSION_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
 const SHUTDOWN_TIMEOUT_MS = 10_000;
@@ -88,6 +89,7 @@ async function bootstrap(): Promise<void> {
 
   startVersionCheckSchedule();
   void startBackupScheduler();
+  void checkAndRegenerateOnBoot(indexStore.getSnapshot().tracks);
 }
 
 bootstrap().catch((error: unknown) => {

--- a/backend/src/services/activity/playCountStore.ts
+++ b/backend/src/services/activity/playCountStore.ts
@@ -1,0 +1,128 @@
+import path from "node:path";
+
+import { readJsonFile, writeJsonAtomic, ensureDir } from "../../utils/fs";
+import { usersStorageRoot } from "../../utils/paths";
+import type { IndexStore } from "../indexer/indexStore";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("play-counts");
+
+type TrackPlayCount = {
+  count: number;
+  lastPlayedAt: string;
+};
+
+type PlayCountsFile = {
+  tracks: Record<string, TrackPlayCount>;
+};
+
+function playCountsPath(userId: string): string {
+  return path.join(usersStorageRoot, userId, "play-counts.json");
+}
+
+async function readPlayCounts(userId: string): Promise<PlayCountsFile> {
+  const filePath = playCountsPath(userId);
+  const data = await readJsonFile<PlayCountsFile>(filePath, { tracks: {} });
+  if (!data || typeof data !== "object" || !data.tracks) {
+    return { tracks: {} };
+  }
+  return data;
+}
+
+async function writePlayCounts(userId: string, data: PlayCountsFile): Promise<void> {
+  const filePath = playCountsPath(userId);
+  await ensureDir(path.dirname(filePath));
+  await writeJsonAtomic(filePath, data);
+}
+
+export async function incrementPlayCount(userId: string, trackId: string): Promise<void> {
+  const data = await readPlayCounts(userId);
+  const existing = data.tracks[trackId];
+  data.tracks[trackId] = {
+    count: (existing?.count ?? 0) + 1,
+    lastPlayedAt: new Date().toISOString()
+  };
+  await writePlayCounts(userId, data);
+}
+
+export async function getUserPlayCounts(
+  userId: string
+): Promise<Record<string, TrackPlayCount>> {
+  const data = await readPlayCounts(userId);
+  return data.tracks;
+}
+
+export type TopTrackEntry = {
+  trackId: string;
+  count: number;
+  lastPlayedAt: string;
+};
+
+export async function getUserTopTracks(
+  userId: string,
+  limit: number
+): Promise<TopTrackEntry[]> {
+  const counts = await getUserPlayCounts(userId);
+  return Object.entries(counts)
+    .map(([trackId, entry]) => ({ trackId, count: entry.count, lastPlayedAt: entry.lastPlayedAt }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit);
+}
+
+export type TopArtistEntry = {
+  artist: string;
+  playCount: number;
+};
+
+export async function getUserTopArtists(
+  userId: string,
+  limit: number,
+  indexStore: IndexStore
+): Promise<TopArtistEntry[]> {
+  const counts = await getUserPlayCounts(userId);
+  const artistPlayCounts = new Map<string, number>();
+
+  for (const [trackId, entry] of Object.entries(counts)) {
+    const track = indexStore.getTrackById(trackId);
+    if (!track) continue;
+
+    const artist = track.tags.artist ?? "Unknown";
+    artistPlayCounts.set(artist, (artistPlayCounts.get(artist) ?? 0) + entry.count);
+  }
+
+  return Array.from(artistPlayCounts.entries())
+    .map(([artist, playCount]) => ({ artist, playCount }))
+    .sort((a, b) => b.playCount - a.playCount)
+    .slice(0, limit);
+}
+
+export type PlayStatsResponse = {
+  topTracks: TopTrackEntry[];
+  topArtists: TopArtistEntry[];
+  totalPlays: number;
+  uniqueTracksPlayed: number;
+};
+
+export async function getUserPlayStats(
+  userId: string,
+  indexStore: IndexStore
+): Promise<PlayStatsResponse> {
+  const counts = await getUserPlayCounts(userId);
+  const entries = Object.entries(counts);
+
+  const totalPlays = entries.reduce((sum, [, entry]) => sum + entry.count, 0);
+
+  const topTracks = entries
+    .map(([trackId, entry]) => ({ trackId, count: entry.count, lastPlayedAt: entry.lastPlayedAt }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 20);
+
+  const topArtists = await getUserTopArtists(userId, 15, indexStore);
+
+  return {
+    topTracks,
+    topArtists,
+    totalPlays,
+    uniqueTracksPlayed: entries.length
+  };
+}

--- a/backend/src/services/genre/genreEnrichmentService.ts
+++ b/backend/src/services/genre/genreEnrichmentService.ts
@@ -1,0 +1,120 @@
+import type { IndexStore } from "../indexer/indexStore";
+import { mergeTrackMetadataOverrides } from "../indexer/metadataOverrideStore";
+import { lookupGenre } from "./musicBrainzService";
+import { normalizeGenreLabels } from "./genreSynonymService";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("genre-enrichment");
+
+export type EnrichmentStatus = {
+  running: boolean;
+  total: number;
+  processed: number;
+  enriched: number;
+  failed: number;
+  startedAt: string | null;
+};
+
+let status: EnrichmentStatus = {
+  running: false,
+  total: 0,
+  processed: 0,
+  enriched: 0,
+  failed: 0,
+  startedAt: null
+};
+
+let abortController: AbortController | null = null;
+
+export function getEnrichmentStatus(): EnrichmentStatus {
+  return { ...status };
+}
+
+export function stopEnrichment(): void {
+  if (abortController) {
+    abortController.abort();
+    abortController = null;
+  }
+}
+
+export async function enrichTrackGenre(
+  trackId: string,
+  artist: string,
+  title: string
+): Promise<string[] | null> {
+  const rawGenres = await lookupGenre(artist, title);
+  if (rawGenres.length === 0) return null;
+
+  const genres = normalizeGenreLabels(rawGenres);
+  if (genres.length === 0) return null;
+
+  await mergeTrackMetadataOverrides({ [trackId]: { genre: genres } });
+  return genres;
+}
+
+export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<void> {
+  if (status.running) {
+    log.info("Genre enrichment already running, skipping");
+    return;
+  }
+
+  const tracks = indexStore.getTracks();
+  const tracksWithoutGenre = tracks.filter(
+    (t) => !t.tags.genre || t.tags.genre.length === 0
+  );
+
+  if (tracksWithoutGenre.length === 0) {
+    log.info("All tracks have genre metadata, nothing to enrich");
+    return;
+  }
+
+  abortController = new AbortController();
+  const signal = abortController.signal;
+
+  status = {
+    running: true,
+    total: tracksWithoutGenre.length,
+    processed: 0,
+    enriched: 0,
+    failed: 0,
+    startedAt: new Date().toISOString()
+  };
+
+  log.info(`Starting genre enrichment for ${tracksWithoutGenre.length} tracks`);
+
+  for (const track of tracksWithoutGenre) {
+    if (signal.aborted) {
+      log.info("Genre enrichment aborted");
+      break;
+    }
+
+    const artist = track.tags.artist;
+    const title = track.tags.title;
+
+    if (!artist || !title) {
+      status.processed++;
+      continue;
+    }
+
+    try {
+      const genres = await enrichTrackGenre(track.id, artist, title);
+      status.processed++;
+      if (genres) {
+        status.enriched++;
+        log.debug(`Enriched genre for "${title}" by "${artist}": ${genres.join(", ")}`);
+      }
+    } catch (error) {
+      status.processed++;
+      status.failed++;
+      log.warn(`Failed to enrich genre for "${title}" by "${artist}"`, {
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  status.running = false;
+  abortController = null;
+  log.info(
+    `Genre enrichment complete: ${status.enriched} enriched, ${status.failed} failed, ${status.processed} processed out of ${status.total}`
+  );
+}

--- a/backend/src/services/genre/genreSynonymService.ts
+++ b/backend/src/services/genre/genreSynonymService.ts
@@ -1,0 +1,276 @@
+import fs from "node:fs";
+
+import { createLogger } from "../../utils/logger";
+import { configRoot } from "../../utils/paths";
+import path from "node:path";
+
+const log = createLogger("genre-synonyms");
+
+const SYNONYMS_FILE = path.join(configRoot, "genre-synonyms.json");
+
+type SynonymMap = Record<string, string>;
+
+const DEFAULT_SYNONYMS: SynonymMap = {
+  "prog rock": "Progressive Rock",
+  "prog": "Progressive Rock",
+  "synth pop": "Synthpop",
+  "synth-pop": "Synthpop",
+  "synthwave": "Synthwave",
+  "retrowave": "Synthwave",
+  "hiphop": "Hip-Hop",
+  "hip hop": "Hip-Hop",
+  "rap": "Hip-Hop",
+  "r&b": "R&B",
+  "rnb": "R&B",
+  "rhythm and blues": "R&B",
+  "electronica": "Electronic",
+  "electro": "Electronic",
+  "edm": "Electronic",
+  "techno": "Techno",
+  "house music": "House",
+  "deep house": "Deep House",
+  "drum and bass": "Drum & Bass",
+  "dnb": "Drum & Bass",
+  "d&b": "Drum & Bass",
+  "drum n bass": "Drum & Bass",
+  "alt rock": "Alternative Rock",
+  "alt-rock": "Alternative Rock",
+  "alternative": "Alternative Rock",
+  "indie": "Indie Rock",
+  "indie rock": "Indie Rock",
+  "post punk": "Post-Punk",
+  "post-punk": "Post-Punk",
+  "postpunk": "Post-Punk",
+  "shoegaze": "Shoegaze",
+  "shoe gaze": "Shoegaze",
+  "dream pop": "Dream Pop",
+  "dreampop": "Dream Pop",
+  "lo-fi": "Lo-Fi",
+  "lofi": "Lo-Fi",
+  "lo fi": "Lo-Fi",
+  "heavy metal": "Heavy Metal",
+  "metal": "Metal",
+  "thrash metal": "Thrash Metal",
+  "thrash": "Thrash Metal",
+  "death metal": "Death Metal",
+  "black metal": "Black Metal",
+  "doom metal": "Doom Metal",
+  "nu metal": "Nu Metal",
+  "nu-metal": "Nu Metal",
+  "numetal": "Nu Metal",
+  "punk rock": "Punk",
+  "punk": "Punk",
+  "pop punk": "Pop Punk",
+  "pop-punk": "Pop Punk",
+  "classic rock": "Classic Rock",
+  "hard rock": "Hard Rock",
+  "hardrock": "Hard Rock",
+  "blues rock": "Blues Rock",
+  "southern rock": "Southern Rock",
+  "psychedelic rock": "Psychedelic Rock",
+  "psych rock": "Psychedelic Rock",
+  "psychedelic": "Psychedelic Rock",
+  "grunge": "Grunge",
+  "folk": "Folk",
+  "folk rock": "Folk Rock",
+  "country": "Country",
+  "bluegrass": "Bluegrass",
+  "jazz": "Jazz",
+  "smooth jazz": "Smooth Jazz",
+  "bebop": "Bebop",
+  "bossa nova": "Bossa Nova",
+  "soul": "Soul",
+  "funk": "Funk",
+  "disco": "Disco",
+  "reggae": "Reggae",
+  "ska": "Ska",
+  "dub": "Dub",
+  "dancehall": "Dancehall",
+  "classical": "Classical",
+  "orchestral": "Orchestral",
+  "chamber music": "Chamber Music",
+  "ambient": "Ambient",
+  "new age": "New Age",
+  "newage": "New Age",
+  "world": "World Music",
+  "world music": "World Music",
+  "latin": "Latin",
+  "bossa": "Bossa Nova",
+  "flamenco": "Flamenco",
+  "afrobeat": "Afrobeat",
+  "afro beat": "Afrobeat",
+  "k-pop": "K-Pop",
+  "kpop": "K-Pop",
+  "j-pop": "J-Pop",
+  "jpop": "J-Pop",
+  "j-rock": "J-Rock",
+  "jrock": "J-Rock",
+  "trip hop": "Trip-Hop",
+  "trip-hop": "Trip-Hop",
+  "triphop": "Trip-Hop",
+  "downtempo": "Downtempo",
+  "chillout": "Chillout",
+  "chill out": "Chillout",
+  "chill": "Chillout",
+  "idm": "IDM",
+  "industrial": "Industrial",
+  "ebm": "EBM",
+  "noise": "Noise",
+  "experimental": "Experimental",
+  "avant-garde": "Avant-Garde",
+  "avantgarde": "Avant-Garde",
+  "avant garde": "Avant-Garde",
+  "gospel": "Gospel",
+  "christian": "Christian",
+  "worship": "Worship",
+  "soundtrack": "Soundtrack",
+  "ost": "Soundtrack",
+  "film score": "Soundtrack",
+  "score": "Soundtrack",
+  "game music": "Video Game Music",
+  "video game": "Video Game Music",
+  "vgm": "Video Game Music",
+  "chiptune": "Chiptune",
+  "8-bit": "Chiptune",
+  "8bit": "Chiptune",
+  "garage rock": "Garage Rock",
+  "garage": "Garage Rock",
+  "math rock": "Math Rock",
+  "mathrock": "Math Rock",
+  "emo": "Emo",
+  "screamo": "Screamo",
+  "hardcore": "Hardcore",
+  "hardcore punk": "Hardcore",
+  "metalcore": "Metalcore",
+  "deathcore": "Deathcore",
+  "post rock": "Post-Rock",
+  "post-rock": "Post-Rock",
+  "postrock": "Post-Rock",
+  "stoner rock": "Stoner Rock",
+  "stoner": "Stoner Rock",
+  "sludge": "Sludge Metal",
+  "sludge metal": "Sludge Metal",
+  "progressive metal": "Progressive Metal",
+  "prog metal": "Progressive Metal",
+  "power metal": "Power Metal",
+  "symphonic metal": "Symphonic Metal",
+  "folk metal": "Folk Metal",
+  "viking metal": "Viking Metal",
+  "glam rock": "Glam Rock",
+  "glam": "Glam Rock",
+  "new wave": "New Wave",
+  "new-wave": "New Wave",
+  "darkwave": "Darkwave",
+  "dark wave": "Darkwave",
+  "goth": "Gothic",
+  "gothic": "Gothic",
+  "gothic rock": "Gothic Rock",
+  "trance": "Trance",
+  "psytrance": "Psytrance",
+  "psy trance": "Psytrance",
+  "hardstyle": "Hardstyle",
+  "dubstep": "Dubstep",
+  "brostep": "Dubstep",
+  "trap": "Trap",
+  "future bass": "Future Bass",
+  "vaporwave": "Vaporwave",
+  "mallsoft": "Vaporwave",
+  "witch house": "Witch House",
+  "cloud rap": "Cloud Rap",
+  "boom bap": "Boom Bap",
+  "gangsta rap": "Gangsta Rap",
+  "conscious hip-hop": "Conscious Hip-Hop",
+  "conscious rap": "Conscious Hip-Hop",
+  "neo soul": "Neo Soul",
+  "neo-soul": "Neo Soul",
+  "contemporary r&b": "Contemporary R&B",
+  "mpb": "MPB",
+  "samba": "Samba",
+  "cumbia": "Cumbia",
+  "reggaeton": "Reggaeton",
+  "bachata": "Bachata",
+  "salsa": "Salsa",
+  "merengue": "Merengue",
+  "tango": "Tango"
+};
+
+let synonyms: SynonymMap | null = null;
+
+function loadSynonyms(): SynonymMap {
+  if (synonyms) return synonyms;
+
+  try {
+    if (fs.existsSync(SYNONYMS_FILE)) {
+      const raw = fs.readFileSync(SYNONYMS_FILE, "utf8");
+      synonyms = JSON.parse(raw) as SynonymMap;
+      return synonyms;
+    }
+  } catch {
+    log.warn("Failed to load genre synonyms file, using defaults");
+  }
+
+  synonyms = { ...DEFAULT_SYNONYMS };
+  saveSynonyms();
+  return synonyms;
+}
+
+function saveSynonyms(): void {
+  if (!synonyms) return;
+
+  try {
+    fs.mkdirSync(path.dirname(SYNONYMS_FILE), { recursive: true });
+    const sorted = Object.fromEntries(
+      Object.entries(synonyms).sort(([a], [b]) => a.localeCompare(b))
+    );
+    fs.writeFileSync(SYNONYMS_FILE, JSON.stringify(sorted, null, 2), "utf8");
+  } catch (error) {
+    log.warn("Failed to save genre synonyms", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+export function normalizeGenreLabel(genre: string): string {
+  const map = loadSynonyms();
+  const key = genre.trim().toLowerCase();
+  return map[key] ?? genre.trim();
+}
+
+export function normalizeGenreLabels(genres: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const genre of genres) {
+    const normalized = normalizeGenreLabel(genre);
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(normalized);
+  }
+
+  return result;
+}
+
+export function getSynonyms(): SynonymMap {
+  return { ...loadSynonyms() };
+}
+
+export function setSynonym(from: string, to: string): void {
+  const map = loadSynonyms();
+  map[from.trim().toLowerCase()] = to.trim();
+  saveSynonyms();
+}
+
+export function removeSynonym(from: string): boolean {
+  const map = loadSynonyms();
+  const key = from.trim().toLowerCase();
+  if (!(key in map)) return false;
+  delete map[key];
+  saveSynonyms();
+  return true;
+}
+
+export function resetSynonymsToDefaults(): void {
+  synonyms = { ...DEFAULT_SYNONYMS };
+  saveSynonyms();
+}

--- a/backend/src/services/genre/musicBrainzService.ts
+++ b/backend/src/services/genre/musicBrainzService.ts
@@ -1,0 +1,219 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { cacheRoot } from "../../utils/paths";
+
+const log = createLogger("musicbrainz");
+
+const MB_BASE_URL = "https://musicbrainz.org/ws/2";
+const RATE_LIMIT_MS = 1100;
+const REQUEST_TIMEOUT_MS = 15_000;
+const CACHE_FILE = path.join(cacheRoot, "musicbrainz-genre-cache.json");
+
+function readVersion(): string {
+  try {
+    const pkgPath = path.resolve(process.cwd(), "package.json");
+    const raw = fs.readFileSync(pkgPath, "utf8");
+    const pkg = JSON.parse(raw) as { version?: string };
+    return pkg.version ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+const USER_AGENT = `flaque/${readVersion()} (https://github.com/Marma92/flaque)`;
+
+type GenreCache = Record<string, string[]>;
+
+let cache: GenreCache | null = null;
+let lastRequestTime = 0;
+let queue: Array<{
+  artist: string;
+  title: string;
+  resolve: (genres: string[]) => void;
+}> = [];
+let processing = false;
+
+function cacheKey(artist: string, title: string): string {
+  return `${artist.toLowerCase().trim()}|||${title.toLowerCase().trim()}`;
+}
+
+function loadCache(): GenreCache {
+  if (cache) return cache;
+
+  try {
+    if (fs.existsSync(CACHE_FILE)) {
+      const raw = fs.readFileSync(CACHE_FILE, "utf8");
+      cache = JSON.parse(raw) as GenreCache;
+      return cache;
+    }
+  } catch {
+    log.warn("Failed to load MusicBrainz genre cache, starting fresh");
+  }
+
+  cache = {};
+  return cache;
+}
+
+function saveCache(): void {
+  if (!cache) return;
+
+  try {
+    fs.mkdirSync(path.dirname(CACHE_FILE), { recursive: true });
+    fs.writeFileSync(CACHE_FILE, JSON.stringify(cache, null, 2), "utf8");
+  } catch (error) {
+    log.warn("Failed to save MusicBrainz genre cache", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+async function waitForRateLimit(): Promise<void> {
+  const now = Date.now();
+  const elapsed = now - lastRequestTime;
+  if (elapsed < RATE_LIMIT_MS) {
+    await new Promise((resolve) => setTimeout(resolve, RATE_LIMIT_MS - elapsed));
+  }
+  lastRequestTime = Date.now();
+}
+
+type MBRecording = {
+  id?: string;
+  tags?: Array<{ name?: string; count?: number }>;
+  genres?: Array<{ name?: string; count?: number }>;
+};
+
+type MBSearchResult = {
+  recordings?: MBRecording[];
+};
+
+type MBRecordingDetail = {
+  genres?: Array<{ name?: string; count?: number }>;
+  tags?: Array<{ name?: string; count?: number }>;
+};
+
+function extractGenres(recording: MBRecording | MBRecordingDetail): string[] {
+  const genres: string[] = [];
+  const seen = new Set<string>();
+
+  const sources = [recording.genres ?? [], recording.tags ?? []];
+  for (const source of sources) {
+    for (const entry of source) {
+      if (typeof entry.name !== "string" || !entry.name.trim()) continue;
+      const normalized = entry.name.trim().toLowerCase();
+      if (seen.has(normalized)) continue;
+      seen.add(normalized);
+      const titleCased = normalized
+        .split(/[\s-]+/)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(" ");
+      genres.push(titleCased);
+    }
+  }
+
+  return genres;
+}
+
+async function fetchGenresForRecording(artist: string, title: string): Promise<string[]> {
+  await waitForRateLimit();
+
+  const query = `recording:"${title}" AND artist:"${artist}"`;
+  const searchUrl = `${MB_BASE_URL}/recording?query=${encodeURIComponent(query)}&fmt=json&limit=3`;
+
+  try {
+    const searchResponse = await fetch(searchUrl, {
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    });
+
+    if (!searchResponse.ok) {
+      log.warn(`MusicBrainz search returned ${searchResponse.status}`, {
+        artist,
+        title
+      });
+      return [];
+    }
+
+    const searchData = (await searchResponse.json()) as MBSearchResult;
+    const recordings = searchData.recordings ?? [];
+
+    if (recordings.length === 0) return [];
+
+    const firstRecording = recordings[0]!;
+    const searchGenres = extractGenres(firstRecording);
+    if (searchGenres.length > 0) return searchGenres;
+
+    if (!firstRecording.id) return [];
+
+    await waitForRateLimit();
+
+    const detailUrl = `${MB_BASE_URL}/recording/${firstRecording.id}?inc=genres+tags&fmt=json`;
+    const detailResponse = await fetch(detailUrl, {
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    });
+
+    if (!detailResponse.ok) return [];
+
+    const detailData = (await detailResponse.json()) as MBRecordingDetail;
+    return extractGenres(detailData);
+  } catch (error) {
+    log.warn("MusicBrainz lookup failed", {
+      artist,
+      title,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return [];
+  }
+}
+
+async function processQueue(): Promise<void> {
+  if (processing) return;
+  processing = true;
+
+  while (queue.length > 0) {
+    const item = queue.shift()!;
+    const key = cacheKey(item.artist, item.title);
+    const c = loadCache();
+
+    if (key in c) {
+      item.resolve(c[key] ?? []);
+      continue;
+    }
+
+    const genres = await fetchGenresForRecording(item.artist, item.title);
+    c[key] = genres;
+    saveCache();
+    item.resolve(genres);
+  }
+
+  processing = false;
+}
+
+export function lookupGenre(artist: string, title: string): Promise<string[]> {
+  if (!artist.trim() || !title.trim()) {
+    return Promise.resolve([]);
+  }
+
+  const c = loadCache();
+  const key = cacheKey(artist, title);
+  if (key in c) {
+    return Promise.resolve(c[key] ?? []);
+  }
+
+  return new Promise<string[]>((resolve) => {
+    queue.push({ artist, title, resolve });
+    void processQueue();
+  });
+}
+
+export function getGenreCacheStats(): { entries: number } {
+  const c = loadCache();
+  return { entries: Object.keys(c).length };
+}
+
+export function clearGenreCache(): void {
+  cache = {};
+  saveCache();
+}

--- a/backend/src/services/indexer/indexStore.test.ts
+++ b/backend/src/services/indexer/indexStore.test.ts
@@ -67,7 +67,13 @@ function createPlaylist(id: string, trackIds: string[]): Playlist {
     name: id,
     authorId: "owner-1",
     visibility: "private",
-    trackIds
+    trackIds,
+    description: "",
+    cover: null,
+    hearts: [],
+    heartCount: 0,
+    listenCount: 0,
+    collaborators: []
   };
 }
 

--- a/backend/src/services/indexer/metadataOverrideStore.ts
+++ b/backend/src/services/indexer/metadataOverrideStore.ts
@@ -6,6 +6,7 @@ export type TrackMetadataOverride = {
   artist?: string;
   album?: string;
   year?: number;
+  genre?: string[];
 };
 
 type TrackMetadataOverridesMap = Record<string, TrackMetadataOverride>;
@@ -26,6 +27,20 @@ function normalizeYear(value: unknown): number | undefined {
   return n;
 }
 
+function normalizeGenre(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value)) return undefined;
+
+  const genres: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const trimmed = item.trim();
+    if (trimmed) genres.push(trimmed);
+  }
+
+  return genres.length > 0 ? genres : undefined;
+}
+
 function normalizeOverride(override: unknown): TrackMetadataOverride | undefined {
   if (!override || typeof override !== "object") {
     return undefined;
@@ -36,8 +51,9 @@ function normalizeOverride(override: unknown): TrackMetadataOverride | undefined
   const album = normalizeField(record.album);
   const title = normalizeField(record.title);
   const year = normalizeYear(record.year);
+  const genre = normalizeGenre(record.genre);
 
-  if (!title && !artist && !album && year === undefined) {
+  if (!title && !artist && !album && year === undefined && !genre) {
     return undefined;
   }
 
@@ -45,7 +61,8 @@ function normalizeOverride(override: unknown): TrackMetadataOverride | undefined
     title,
     artist,
     album,
-    year
+    year,
+    genre
   };
 }
 
@@ -105,7 +122,8 @@ export async function mergeTrackMetadataOverrides(
       existing?.title === cleanOverride.title &&
       existing?.artist === cleanOverride.artist &&
       existing?.album === cleanOverride.album &&
-      existing?.year === cleanOverride.year
+      existing?.year === cleanOverride.year &&
+      JSON.stringify(existing?.genre) === JSON.stringify(cleanOverride.genre)
     ) {
       continue;
     }

--- a/backend/src/services/playlists/autoPlaylistService.ts
+++ b/backend/src/services/playlists/autoPlaylistService.ts
@@ -1,0 +1,266 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { dataRoot } from "../../utils/paths";
+import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
+import { normalizeGenreLabel } from "../genre/genreSynonymService";
+import type { Track } from "../../types/library";
+
+const log = createLogger("auto-playlists");
+
+const AUTO_PLAYLISTS_DIR = path.join(dataRoot, "auto-playlists");
+const META_FILE = path.join(AUTO_PLAYLISTS_DIR, "_meta.json");
+const CONFIG_FILE = path.join(dataRoot, "config", "auto-playlist-config.json");
+
+const REGENERATION_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000;
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export type AutoPlaylist = {
+  id: string;
+  name: string;
+  genre: string;
+  decade: number;
+  trackIds: string[];
+  trackCount: number;
+  generatedAt: string;
+};
+
+export type AutoPlaylistConfig = {
+  maxPlaylists: number;
+  minTracksPerPlaylist: number;
+  tracksPerPlaylist: number;
+};
+
+type AutoPlaylistMeta = {
+  lastGeneratedAt: string;
+};
+
+// ── Config ─────────────────────────────────────────────────────────
+
+const DEFAULT_CONFIG: AutoPlaylistConfig = {
+  maxPlaylists: 0,
+  minTracksPerPlaylist: 8,
+  tracksPerPlaylist: 30
+};
+
+export async function getAutoPlaylistConfig(): Promise<AutoPlaylistConfig> {
+  const raw = await readJsonFile<Partial<AutoPlaylistConfig>>(CONFIG_FILE, {});
+  return {
+    maxPlaylists: typeof raw.maxPlaylists === "number" && raw.maxPlaylists >= 0
+      ? raw.maxPlaylists : DEFAULT_CONFIG.maxPlaylists,
+    minTracksPerPlaylist: typeof raw.minTracksPerPlaylist === "number" && raw.minTracksPerPlaylist >= 1
+      ? raw.minTracksPerPlaylist : DEFAULT_CONFIG.minTracksPerPlaylist,
+    tracksPerPlaylist: typeof raw.tracksPerPlaylist === "number" && raw.tracksPerPlaylist >= 1
+      ? raw.tracksPerPlaylist : DEFAULT_CONFIG.tracksPerPlaylist
+  };
+}
+
+export async function updateAutoPlaylistConfig(patch: Partial<AutoPlaylistConfig>): Promise<AutoPlaylistConfig> {
+  const current = await getAutoPlaylistConfig();
+  const next: AutoPlaylistConfig = {
+    maxPlaylists: typeof patch.maxPlaylists === "number" && patch.maxPlaylists >= 0
+      ? patch.maxPlaylists : current.maxPlaylists,
+    minTracksPerPlaylist: typeof patch.minTracksPerPlaylist === "number" && patch.minTracksPerPlaylist >= 1
+      ? patch.minTracksPerPlaylist : current.minTracksPerPlaylist,
+    tracksPerPlaylist: typeof patch.tracksPerPlaylist === "number" && patch.tracksPerPlaylist >= 1
+      ? patch.tracksPerPlaylist : current.tracksPerPlaylist
+  };
+  await writeJsonAtomic(CONFIG_FILE, next);
+  return next;
+}
+
+// ── Diversity selection ────────────────────────────────────────────
+
+type ScoredTrack = {
+  track: Track;
+  artist: string;
+  album: string;
+};
+
+function selectDiverseTracks(candidates: ScoredTrack[], maxTracks: number): Track[] {
+  const pool = [...candidates].sort(() => Math.random() - 0.5);
+  const selected: ScoredTrack[] = [];
+
+  while (selected.length < maxTracks && pool.length > 0) {
+    let bestIndex = 0;
+    let bestScore = Number.NEGATIVE_INFINITY;
+
+    for (let i = 0; i < pool.length; i++) {
+      const candidate = pool[i]!;
+      let score = 100;
+
+      const prev = selected[selected.length - 1];
+      if (prev) {
+        if (prev.artist === candidate.artist) score -= 1000;
+        if (prev.album === candidate.album) score -= 500;
+      }
+
+      const recentArtists = selected.slice(-3).map((s) => s.artist);
+      if (recentArtists.includes(candidate.artist)) score -= 250;
+
+      score += Math.random() * 40;
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestIndex = i;
+      }
+    }
+
+    selected.push(pool[bestIndex]!);
+    pool.splice(bestIndex, 1);
+  }
+
+  return selected.map((s) => s.track);
+}
+
+// ── Generation ─────────────────────────────────────────────────────
+
+function toDecadeLabel(decade: number): string {
+  return `${decade % 100 === 0 ? decade : decade % 100}s`;
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export async function generateAutoPlaylists(tracks: Track[]): Promise<AutoPlaylist[]> {
+  const config = await getAutoPlaylistConfig();
+
+  const groups = new Map<string, { genre: string; decade: number; tracks: ScoredTrack[] }>();
+
+  for (const track of tracks) {
+    const genres = track.tags.genre;
+    const year = track.tags.year;
+    if (!genres || genres.length === 0 || !year) continue;
+
+    const primaryGenre = normalizeGenreLabel(genres[0]!);
+    const decade = Math.floor(year / 10) * 10;
+    const key = `${decade}:${primaryGenre.toLowerCase()}`;
+
+    let group = groups.get(key);
+    if (!group) {
+      group = { genre: primaryGenre, decade, tracks: [] };
+      groups.set(key, group);
+    }
+
+    group.tracks.push({
+      track,
+      artist: (track.tags.artist ?? "").toLowerCase(),
+      album: (track.tags.album ?? "").toLowerCase()
+    });
+  }
+
+  let qualifyingGroups = Array.from(groups.values())
+    .filter((g) => g.tracks.length >= config.minTracksPerPlaylist)
+    .sort((a, b) => b.tracks.length - a.tracks.length);
+
+  if (config.maxPlaylists > 0) {
+    qualifyingGroups = qualifyingGroups.slice(0, config.maxPlaylists);
+  }
+
+  const generatedAt = new Date().toISOString();
+  const playlists: AutoPlaylist[] = [];
+
+  for (const group of qualifyingGroups) {
+    const decadeLabel = toDecadeLabel(group.decade);
+    const name = `${decadeLabel} ${group.genre}`;
+    const id = `auto:${slugify(name)}`;
+    const selectedTracks = selectDiverseTracks(group.tracks, config.tracksPerPlaylist);
+
+    playlists.push({
+      id,
+      name,
+      genre: group.genre,
+      decade: group.decade,
+      trackIds: selectedTracks.map((t) => t.id),
+      trackCount: selectedTracks.length,
+      generatedAt
+    });
+  }
+
+  return playlists;
+}
+
+// ── Storage ────────────────────────────────────────────────────────
+
+export async function saveAutoPlaylists(playlists: AutoPlaylist[]): Promise<void> {
+  await ensureDir(AUTO_PLAYLISTS_DIR);
+
+  const existing = await fs.readdir(AUTO_PLAYLISTS_DIR).catch(() => []);
+  for (const file of existing) {
+    if (file.endsWith(".json") && file !== "_meta.json") {
+      await fs.unlink(path.join(AUTO_PLAYLISTS_DIR, file)).catch(() => {});
+    }
+  }
+
+  for (const playlist of playlists) {
+    const fileName = `${slugify(playlist.name)}.json`;
+    await writeJsonAtomic(path.join(AUTO_PLAYLISTS_DIR, fileName), playlist);
+  }
+
+  const meta: AutoPlaylistMeta = { lastGeneratedAt: new Date().toISOString() };
+  await writeJsonAtomic(META_FILE, meta);
+
+  log.info(`Saved ${playlists.length} auto playlist(s)`);
+}
+
+export async function loadAutoPlaylists(): Promise<AutoPlaylist[]> {
+  await ensureDir(AUTO_PLAYLISTS_DIR);
+
+  const files = await fs.readdir(AUTO_PLAYLISTS_DIR).catch(() => []);
+  const playlists: AutoPlaylist[] = [];
+
+  for (const file of files) {
+    if (!file.endsWith(".json") || file === "_meta.json") continue;
+    const data = await readJsonFile<AutoPlaylist>(
+      path.join(AUTO_PLAYLISTS_DIR, file),
+      null as unknown as AutoPlaylist
+    );
+    if (data && data.id && data.trackIds) {
+      playlists.push(data);
+    }
+  }
+
+  return playlists.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getAutoPlaylistById(id: string): Promise<AutoPlaylist | null> {
+  const all = await loadAutoPlaylists();
+  return all.find((p) => p.id === id) ?? null;
+}
+
+// ── Regeneration check ─────────────────────────────────────────────
+
+export async function needsRegeneration(): Promise<boolean> {
+  const meta = await readJsonFile<AutoPlaylistMeta>(META_FILE, { lastGeneratedAt: "" });
+  if (!meta.lastGeneratedAt) return true;
+
+  const lastGenerated = new Date(meta.lastGeneratedAt).getTime();
+  if (isNaN(lastGenerated)) return true;
+
+  return Date.now() - lastGenerated > REGENERATION_INTERVAL_MS;
+}
+
+export async function regenerateAutoPlaylists(tracks: Track[]): Promise<AutoPlaylist[]> {
+  log.info("Regenerating auto playlists...");
+  const playlists = await generateAutoPlaylists(tracks);
+  await saveAutoPlaylists(playlists);
+  log.info(`Generated ${playlists.length} auto playlist(s)`);
+  return playlists;
+}
+
+export async function checkAndRegenerateOnBoot(tracks: Track[]): Promise<void> {
+  const shouldRegenerate = await needsRegeneration();
+  if (!shouldRegenerate) {
+    const existing = await loadAutoPlaylists();
+    log.info(`Auto playlists up to date (${existing.length} playlist(s))`);
+    return;
+  }
+
+  await regenerateAutoPlaylists(tracks);
+}

--- a/backend/src/services/playlists/forYouPlaylistService.test.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+let tmpDir: string;
+
+vi.mock("../../utils/paths", async () => {
+  return {
+    get dataRoot() { return path.join(tmpDir, "data"); },
+    get usersStorageRoot() { return path.join(tmpDir, "data", "storage", "users"); },
+    get configRoot() { return path.join(tmpDir, "data", "config"); }
+  };
+});
+
+vi.mock("../../utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+vi.mock("../genre/genreSynonymService", () => ({
+  normalizeGenreLabel: (g: string) => g
+}));
+
+import type { Track } from "../../types/library";
+import type { IndexStore } from "../indexer/indexStore";
+
+function makeTrack(overrides: Partial<Track> & { id: string }): Track {
+  return {
+    owner: "user-1",
+    path: `/music/${overrides.id}.flac`,
+    duration: 240,
+    mimeType: "audio/flac",
+    codec: "flac",
+    tags: {},
+    ...overrides
+  };
+}
+
+function makeMockIndexStore(tracks: Track[]): IndexStore {
+  const byId = new Map(tracks.map((t) => [t.id, t]));
+  const byArtist = new Map<string, Track[]>();
+  for (const t of tracks) {
+    const artist = (t.tags.artist ?? "Unknown").toLowerCase();
+    const list = byArtist.get(artist) ?? [];
+    list.push(t);
+    byArtist.set(artist, list);
+  }
+
+  return {
+    getSnapshot: () => ({ tracks, totalTracks: tracks.length, generatedAt: "", playlists: [] }),
+    getTrackById: (id: string) => byId.get(id),
+    getTracksByArtist: (artist: string) => byArtist.get(artist.toLowerCase()) ?? [],
+    hasTrack: (id: string) => byId.has(id)
+  } as unknown as IndexStore;
+}
+
+describe("forYouPlaylistService", () => {
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "foryou-test-"));
+    await fs.mkdir(path.join(tmpDir, "data", "config"), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, "data", "storage", "users"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("skips generation when user has too few plays", async () => {
+    const { generateForYouPlaylists } = await import("./forYouPlaylistService");
+
+    const tracks = Array.from({ length: 30 }, (_, i) =>
+      makeTrack({
+        id: `track-${i}`,
+        tags: { artist: `Artist ${i % 5}`, genre: ["Rock"], year: 2000 }
+      })
+    );
+    const indexStore = makeMockIndexStore(tracks);
+
+    const result = await generateForYouPlaylists("user-1", indexStore);
+    expect(result).toEqual([]);
+  });
+
+  it("generates playlists when user meets thresholds", async () => {
+    const { generateForYouPlaylists } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    const artists = ["Pink Floyd", "Led Zeppelin", "Deep Purple", "Black Sabbath", "Jethro Tull"];
+    const tracks: Track[] = [];
+
+    for (let i = 0; i < 60; i++) {
+      const artist = artists[i % 5]!;
+      tracks.push(
+        makeTrack({
+          id: `track-${i}`,
+          tags: { artist, genre: ["Rock"], year: 1970 + (i % 10) }
+        })
+      );
+    }
+
+    const indexStore = makeMockIndexStore(tracks);
+
+    const playCountsDir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(playCountsDir);
+
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 30; i++) {
+      playCounts[`track-${i}`] = { count: 2, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    }
+    await writeJsonAtomic(path.join(playCountsDir, "play-counts.json"), { tracks: playCounts });
+
+    const result = await generateForYouPlaylists("user-1", indexStore);
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.length).toBeLessThanOrEqual(3);
+
+    for (const playlist of result) {
+      expect(playlist.id).toMatch(/^for-you:/);
+      expect(playlist.name).toMatch(/^Because you listen to /);
+      expect(playlist.trackIds.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("dismisses and stores dismissal", async () => {
+    const { dismissForYouPlaylist, getUserDismissals } = await import("./forYouPlaylistService");
+
+    await dismissForYouPlaylist("user-1", "for-you:pink-floyd");
+
+    const dismissals = await getUserDismissals("user-1");
+    expect(dismissals.has("for-you:pink-floyd")).toBe(true);
+    expect(dismissals.has("for-you:led-zeppelin")).toBe(false);
+  });
+
+  it("saves and loads for-you playlists", async () => {
+    const { saveForYouPlaylists, loadForYouPlaylists } = await import("./forYouPlaylistService");
+
+    const playlists = [
+      {
+        id: "for-you:pink-floyd",
+        name: "Because you listen to Pink Floyd",
+        seedArtist: "Pink Floyd",
+        trackIds: ["t1", "t2", "t3"],
+        trackCount: 3,
+        generatedAt: "2026-04-01T00:00:00Z"
+      }
+    ];
+
+    await saveForYouPlaylists("user-1", playlists);
+    const loaded = await loadForYouPlaylists("user-1");
+
+    expect(loaded.length).toBe(1);
+    expect(loaded[0]!.id).toBe("for-you:pink-floyd");
+    expect(loaded[0]!.trackIds).toEqual(["t1", "t2", "t3"]);
+  });
+});

--- a/backend/src/services/playlists/forYouPlaylistService.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.ts
@@ -1,0 +1,401 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { dataRoot, usersStorageRoot } from "../../utils/paths";
+import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
+import { normalizeGenreLabel } from "../genre/genreSynonymService";
+import { getUserTopArtists, getUserPlayCounts } from "../activity/playCountStore";
+import type { IndexStore } from "../indexer/indexStore";
+import type { Track } from "../../types/library";
+
+const log = createLogger("for-you-playlists");
+
+const FOR_YOU_DIR = path.join(dataRoot, "auto-playlists", "for-you");
+const REGENERATION_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000;
+
+const MIN_TOTAL_PLAYS = 20;
+const MIN_DISTINCT_ARTISTS = 3;
+const MAX_TOP_ARTISTS = 3;
+const TRACKS_PER_PLAYLIST = 25;
+const SEED_ARTIST_RATIO = 0.4;
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export type ForYouPlaylist = {
+  id: string;
+  name: string;
+  seedArtist: string;
+  trackIds: string[];
+  trackCount: number;
+  generatedAt: string;
+};
+
+type ForYouMeta = {
+  lastGeneratedAt: string;
+};
+
+type DismissedEntry = {
+  playlistId: string;
+  dismissedAt: string;
+};
+
+type DismissedFile = {
+  dismissed: DismissedEntry[];
+};
+
+// ── Paths ──────────────────────────────────────────────────────────
+
+function userForYouDir(userId: string): string {
+  return path.join(FOR_YOU_DIR, userId);
+}
+
+function userForYouMetaPath(userId: string): string {
+  return path.join(userForYouDir(userId), "_meta.json");
+}
+
+function dismissedPath(userId: string): string {
+  return path.join(usersStorageRoot, userId, "dismissed-playlists.json");
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+// ── Diversity selection (reused from auto playlist service) ───────
+
+type ScoredTrack = {
+  track: Track;
+  artist: string;
+  album: string;
+};
+
+function selectDiverseTracks(candidates: ScoredTrack[], maxTracks: number): Track[] {
+  const pool = [...candidates].sort(() => Math.random() - 0.5);
+  const selected: ScoredTrack[] = [];
+
+  while (selected.length < maxTracks && pool.length > 0) {
+    let bestIndex = 0;
+    let bestScore = Number.NEGATIVE_INFINITY;
+
+    for (let i = 0; i < pool.length; i++) {
+      const candidate = pool[i]!;
+      let score = 100;
+
+      const prev = selected[selected.length - 1];
+      if (prev) {
+        if (prev.artist === candidate.artist) score -= 1000;
+        if (prev.album === candidate.album) score -= 500;
+      }
+
+      const recentArtists = selected.slice(-3).map((s) => s.artist);
+      if (recentArtists.includes(candidate.artist)) score -= 250;
+
+      score += Math.random() * 40;
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestIndex = i;
+      }
+    }
+
+    selected.push(pool[bestIndex]!);
+    pool.splice(bestIndex, 1);
+  }
+
+  return selected.map((s) => s.track);
+}
+
+// ── Dismissal store ───────────────────────────────────────────────
+
+const DISMISSAL_EXPIRY_MS = 90 * 24 * 60 * 60 * 1000; // 3 months
+
+async function readDismissals(userId: string): Promise<DismissedEntry[]> {
+  const data = await readJsonFile<DismissedFile>(dismissedPath(userId), { dismissed: [] });
+  if (!data || !Array.isArray(data.dismissed)) return [];
+  return data.dismissed;
+}
+
+async function writeDismissals(userId: string, entries: DismissedEntry[]): Promise<void> {
+  const filePath = dismissedPath(userId);
+  await ensureDir(path.dirname(filePath));
+  await writeJsonAtomic(filePath, { dismissed: entries });
+}
+
+function getActiveDismissals(entries: DismissedEntry[]): Set<string> {
+  const now = Date.now();
+  const active = new Set<string>();
+  for (const entry of entries) {
+    const dismissedAt = new Date(entry.dismissedAt).getTime();
+    if (!isNaN(dismissedAt) && now - dismissedAt < DISMISSAL_EXPIRY_MS) {
+      active.add(entry.playlistId);
+    }
+  }
+  return active;
+}
+
+export async function dismissForYouPlaylist(userId: string, playlistId: string): Promise<void> {
+  const entries = await readDismissals(userId);
+  const existing = entries.find((e) => e.playlistId === playlistId);
+  if (existing) {
+    existing.dismissedAt = new Date().toISOString();
+  } else {
+    entries.push({ playlistId, dismissedAt: new Date().toISOString() });
+  }
+  await writeDismissals(userId, entries);
+  log.info(`User ${userId} dismissed for-you playlist ${playlistId}`);
+}
+
+export async function getUserDismissals(userId: string): Promise<Set<string>> {
+  const entries = await readDismissals(userId);
+  return getActiveDismissals(entries);
+}
+
+// ── Playlist generation ───────────────────────────────────────────
+
+function getArtistProfile(
+  artist: string,
+  indexStore: IndexStore
+): { genres: string[]; minYear: number; maxYear: number } {
+  const tracks = indexStore.getTracksByArtist(artist);
+  const genres = new Set<string>();
+  let minYear = Infinity;
+  let maxYear = -Infinity;
+
+  for (const track of tracks) {
+    if (track.tags.genre) {
+      for (const g of track.tags.genre) {
+        genres.add(normalizeGenreLabel(g).toLowerCase());
+      }
+    }
+    if (track.tags.year) {
+      if (track.tags.year < minYear) minYear = track.tags.year;
+      if (track.tags.year > maxYear) maxYear = track.tags.year;
+    }
+  }
+
+  return {
+    genres: Array.from(genres),
+    minYear: minYear === Infinity ? 1970 : minYear,
+    maxYear: maxYear === -Infinity ? 2026 : maxYear
+  };
+}
+
+function findPeerTracks(
+  seedArtist: string,
+  profile: { genres: string[]; minYear: number; maxYear: number },
+  allTracks: Track[]
+): ScoredTrack[] {
+  const yearLow = profile.minYear - 10;
+  const yearHigh = profile.maxYear + 10;
+  const genreSet = new Set(profile.genres);
+  const seedArtistLower = seedArtist.toLowerCase();
+  const peers: ScoredTrack[] = [];
+
+  for (const track of allTracks) {
+    const trackArtist = (track.tags.artist ?? "").toLowerCase();
+    if (trackArtist === seedArtistLower) continue;
+
+    const year = track.tags.year;
+    if (year && (year < yearLow || year > yearHigh)) continue;
+
+    const trackGenres = track.tags.genre;
+    if (!trackGenres || trackGenres.length === 0) continue;
+
+    const hasMatchingGenre = trackGenres.some(
+      (g) => genreSet.has(normalizeGenreLabel(g).toLowerCase())
+    );
+    if (!hasMatchingGenre) continue;
+
+    peers.push({
+      track,
+      artist: trackArtist,
+      album: (track.tags.album ?? "").toLowerCase()
+    });
+  }
+
+  return peers;
+}
+
+function buildForYouPlaylist(
+  seedArtist: string,
+  indexStore: IndexStore,
+  allTracks: Track[]
+): ForYouPlaylist | null {
+  const profile = getArtistProfile(seedArtist, indexStore);
+  if (profile.genres.length === 0) return null;
+
+  const seedTracks = indexStore.getTracksByArtist(seedArtist);
+  const seedScored: ScoredTrack[] = seedTracks.map((t) => ({
+    track: t,
+    artist: (t.tags.artist ?? "").toLowerCase(),
+    album: (t.tags.album ?? "").toLowerCase()
+  }));
+
+  const peerTracks = findPeerTracks(seedArtist, profile, allTracks);
+  if (peerTracks.length < 3) return null;
+
+  const seedCount = Math.round(TRACKS_PER_PLAYLIST * SEED_ARTIST_RATIO);
+  const peerCount = TRACKS_PER_PLAYLIST - seedCount;
+
+  const selectedSeed = selectDiverseTracks(seedScored, seedCount);
+  const selectedPeers = selectDiverseTracks(peerTracks, peerCount);
+
+  const combined: ScoredTrack[] = [
+    ...selectedSeed.map((t) => ({
+      track: t,
+      artist: (t.tags.artist ?? "").toLowerCase(),
+      album: (t.tags.album ?? "").toLowerCase()
+    })),
+    ...selectedPeers.map((t) => ({
+      track: t,
+      artist: (t.tags.artist ?? "").toLowerCase(),
+      album: (t.tags.album ?? "").toLowerCase()
+    }))
+  ];
+
+  const finalTracks = selectDiverseTracks(combined, TRACKS_PER_PLAYLIST);
+  if (finalTracks.length < 5) return null;
+
+  const id = `for-you:${slugify(seedArtist)}`;
+  return {
+    id,
+    name: `Because you listen to ${seedArtist}`,
+    seedArtist,
+    trackIds: finalTracks.map((t) => t.id),
+    trackCount: finalTracks.length,
+    generatedAt: new Date().toISOString()
+  };
+}
+
+export async function generateForYouPlaylists(
+  userId: string,
+  indexStore: IndexStore
+): Promise<ForYouPlaylist[]> {
+  const playCounts = await getUserPlayCounts(userId);
+  const entries = Object.entries(playCounts);
+  const totalPlays = entries.reduce((sum, [, e]) => sum + e.count, 0);
+
+  if (totalPlays < MIN_TOTAL_PLAYS) {
+    log.debug(`User ${userId} has only ${totalPlays} plays, skipping for-you generation`);
+    return [];
+  }
+
+  const topArtists = await getUserTopArtists(userId, MAX_TOP_ARTISTS + 5, indexStore);
+  const distinctArtists = topArtists.length;
+
+  if (distinctArtists < MIN_DISTINCT_ARTISTS) {
+    log.debug(`User ${userId} has only ${distinctArtists} distinct artists, skipping`);
+    return [];
+  }
+
+  const dismissals = await getUserDismissals(userId);
+  const allTracks = indexStore.getSnapshot().tracks;
+  const playlists: ForYouPlaylist[] = [];
+
+  for (const entry of topArtists.slice(0, MAX_TOP_ARTISTS)) {
+    const candidateId = `for-you:${slugify(entry.artist)}`;
+    if (dismissals.has(candidateId)) continue;
+
+    const playlist = buildForYouPlaylist(entry.artist, indexStore, allTracks);
+    if (playlist) {
+      playlists.push(playlist);
+    }
+  }
+
+  return playlists;
+}
+
+// ── Storage ───────────────────────────────────────────────────────
+
+export async function saveForYouPlaylists(userId: string, playlists: ForYouPlaylist[]): Promise<void> {
+  const dir = userForYouDir(userId);
+  await ensureDir(dir);
+
+  const existing = await fs.readdir(dir).catch(() => []);
+  for (const file of existing) {
+    if (file.endsWith(".json") && file !== "_meta.json") {
+      await fs.unlink(path.join(dir, file)).catch(() => {});
+    }
+  }
+
+  for (const playlist of playlists) {
+    const fileName = `${slugify(playlist.seedArtist)}.json`;
+    await writeJsonAtomic(path.join(dir, fileName), playlist);
+  }
+
+  const meta: ForYouMeta = { lastGeneratedAt: new Date().toISOString() };
+  await writeJsonAtomic(userForYouMetaPath(userId), meta);
+
+  log.info(`Saved ${playlists.length} for-you playlist(s) for user ${userId}`);
+}
+
+export async function loadForYouPlaylists(userId: string): Promise<ForYouPlaylist[]> {
+  const dir = userForYouDir(userId);
+  await ensureDir(dir);
+
+  const files = await fs.readdir(dir).catch(() => []);
+  const playlists: ForYouPlaylist[] = [];
+
+  for (const file of files) {
+    if (!file.endsWith(".json") || file === "_meta.json") continue;
+    const data = await readJsonFile<ForYouPlaylist>(
+      path.join(dir, file),
+      null as unknown as ForYouPlaylist
+    );
+    if (data && data.id && data.trackIds) {
+      playlists.push(data);
+    }
+  }
+
+  return playlists.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getForYouPlaylistById(
+  userId: string,
+  playlistId: string
+): Promise<ForYouPlaylist | null> {
+  const all = await loadForYouPlaylists(userId);
+  return all.find((p) => p.id === playlistId) ?? null;
+}
+
+// ── Regeneration ──────────────────────────────────────────────────
+
+export async function needsForYouRegeneration(userId: string): Promise<boolean> {
+  const metaPath = userForYouMetaPath(userId);
+  const meta = await readJsonFile<ForYouMeta>(metaPath, { lastGeneratedAt: "" });
+  if (!meta.lastGeneratedAt) return true;
+
+  const lastGenerated = new Date(meta.lastGeneratedAt).getTime();
+  if (isNaN(lastGenerated)) return true;
+
+  return Date.now() - lastGenerated > REGENERATION_INTERVAL_MS;
+}
+
+export async function regenerateForYouPlaylists(
+  userId: string,
+  indexStore: IndexStore
+): Promise<ForYouPlaylist[]> {
+  log.info(`Regenerating for-you playlists for user ${userId}...`);
+  const playlists = await generateForYouPlaylists(userId, indexStore);
+  await saveForYouPlaylists(userId, playlists);
+  log.info(`Generated ${playlists.length} for-you playlist(s) for user ${userId}`);
+  return playlists;
+}
+
+export async function checkAndRegenerateForYouOnBoot(
+  userId: string,
+  indexStore: IndexStore
+): Promise<void> {
+  const shouldRegenerate = await needsForYouRegeneration(userId);
+  if (!shouldRegenerate) {
+    const existing = await loadForYouPlaylists(userId);
+    log.debug(`For-you playlists up to date for user ${userId} (${existing.length} playlist(s))`);
+    return;
+  }
+
+  await regenerateForYouPlaylists(userId, indexStore);
+}

--- a/backend/src/services/playlists/playlistStore.ts
+++ b/backend/src/services/playlists/playlistStore.ts
@@ -37,6 +37,7 @@ type UpdatePlaylistInput = {
   visibility: PlaylistVisibility;
   trackIds: string[];
   tracksById: Map<string, Track>;
+  description?: string;
   collaborators?: string[];
 };
 
@@ -100,7 +101,7 @@ function getPlaylistMetadataPath(authorId: string, playlistSlug: string): string
   return path.join(getPlaylistDir(authorId, playlistSlug), PLAYLIST_METADATA_FILE);
 }
 
-function canViewPlaylist(playlist: Playlist, user: AuthUser): boolean {
+export function canViewPlaylist(playlist: Playlist, user: AuthUser): boolean {
   return playlist.visibility === "public" || playlist.authorId === user.id || user.role === "admin";
 }
 
@@ -173,10 +174,6 @@ export async function migrateLegacyPlaylists(): Promise<void> {
 
 export function canManagePlaylist(playlist: Playlist, user: AuthUser): boolean {
   return playlist.authorId === user.id || user.role === "admin";
-}
-
-export function canEditPlaylistTracks(playlist: Playlist, user: AuthUser): boolean {
-  return canManagePlaylist(playlist, user) || playlist.collaborators.includes(user.id);
 }
 
 export function filterPlayablePlaylists(playlists: Playlist[], user: AuthUser): Playlist[] {
@@ -484,7 +481,7 @@ export async function updateFilesystemPlaylist(input: UpdatePlaylistInput & { au
     visibility: input.visibility,
     trackIds: input.trackIds,
     tracksById: input.tracksById,
-    description: existingMetadata?.description,
+    description: input.description ?? existingMetadata?.description,
     cover: existingMetadata?.cover,
     hearts: existingMetadata?.hearts,
     listenCount: existingMetadata?.listenCount,
@@ -538,16 +535,6 @@ export async function incrementPlaylistListenCount(playlistId: string): Promise<
     listenCount: metadata.listenCount + 1
   }));
   return updated.listenCount;
-}
-
-export async function updatePlaylistDescription(
-  playlistId: string,
-  description: string
-): Promise<void> {
-  await patchPlaylistMetadataFile(playlistId, (metadata) => ({
-    ...metadata,
-    description
-  }));
 }
 
 export async function updatePlaylistCover(

--- a/backend/src/services/playlists/playlistStore.ts
+++ b/backend/src/services/playlists/playlistStore.ts
@@ -28,6 +28,7 @@ type CreatePlaylistInput = {
   visibility: PlaylistVisibility;
   trackIds: string[];
   tracksById: Map<string, Track>;
+  description?: string;
 };
 
 type UpdatePlaylistInput = {
@@ -36,6 +37,7 @@ type UpdatePlaylistInput = {
   visibility: PlaylistVisibility;
   trackIds: string[];
   tracksById: Map<string, Track>;
+  collaborators?: string[];
 };
 
 function normalizeVisibility(value: unknown): PlaylistVisibility | null {
@@ -436,7 +438,8 @@ export async function createFilesystemPlaylist(input: CreatePlaylistInput): Prom
     name,
     visibility: input.visibility,
     trackIds: input.trackIds,
-    tracksById: input.tracksById
+    tracksById: input.tracksById,
+    description: input.description
   });
 
   return createPlaylistId(input.authorId, playlistSlug);
@@ -485,7 +488,7 @@ export async function updateFilesystemPlaylist(input: UpdatePlaylistInput & { au
     cover: existingMetadata?.cover,
     hearts: existingMetadata?.hearts,
     listenCount: existingMetadata?.listenCount,
-    collaborators: existingMetadata?.collaborators
+    collaborators: input.collaborators ?? existingMetadata?.collaborators
   });
 }
 

--- a/backend/src/services/playlists/playlistStore.ts
+++ b/backend/src/services/playlists/playlistStore.ts
@@ -15,6 +15,11 @@ const PLAYLISTS_DIRECTORY_NAME = "playlists";
 type PlaylistMetadata = {
   name: string;
   visibility: PlaylistVisibility;
+  description: string;
+  cover: string | null;
+  hearts: string[];
+  listenCount: number;
+  collaborators: string[];
 };
 
 type CreatePlaylistInput = {
@@ -168,6 +173,10 @@ export function canManagePlaylist(playlist: Playlist, user: AuthUser): boolean {
   return playlist.authorId === user.id || user.role === "admin";
 }
 
+export function canEditPlaylistTracks(playlist: Playlist, user: AuthUser): boolean {
+  return canManagePlaylist(playlist, user) || playlist.collaborators.includes(user.id);
+}
+
 export function filterPlayablePlaylists(playlists: Playlist[], user: AuthUser): Playlist[] {
   return playlists.filter((playlist) => canViewPlaylist(playlist, user));
 }
@@ -209,13 +218,18 @@ async function listPlaylistDirectories(): Promise<string[]> {
   return directories;
 }
 
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
 async function readPlaylistMetadata(playlistId: string): Promise<PlaylistMetadata | null> {
   const { authorId, slug } = parsePlaylistIdOrThrow(playlistId);
   const filePath = getPlaylistMetadataPath(authorId, slug);
 
   try {
     const raw = await fs.readFile(filePath, "utf8");
-    const parsed = JSON.parse(raw) as Partial<PlaylistMetadata>;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
     const visibility = normalizeVisibility(parsed.visibility);
     const name = typeof parsed.name === "string" ? parsed.name.trim() : "";
     if (!name || !visibility) {
@@ -223,7 +237,14 @@ async function readPlaylistMetadata(playlistId: string): Promise<PlaylistMetadat
     }
     return {
       name,
-      visibility
+      visibility,
+      description: typeof parsed.description === "string" ? parsed.description : "",
+      cover: typeof parsed.cover === "string" && parsed.cover.trim() ? parsed.cover.trim() : null,
+      hearts: normalizeStringArray(parsed.hearts),
+      listenCount: typeof parsed.listenCount === "number" && Number.isFinite(parsed.listenCount)
+        ? Math.max(0, Math.floor(parsed.listenCount))
+        : 0,
+      collaborators: normalizeStringArray(parsed.collaborators)
     };
   } catch {
     return null;
@@ -301,7 +322,13 @@ export async function scanFilesystemPlaylists(tracks: Track[]): Promise<Playlist
       name: metadata.name,
       authorId,
       visibility: metadata.visibility,
-      trackIds
+      trackIds,
+      description: metadata.description,
+      cover: metadata.cover,
+      hearts: metadata.hearts,
+      heartCount: metadata.hearts.length,
+      listenCount: metadata.listenCount,
+      collaborators: metadata.collaborators
     });
   }
 
@@ -350,6 +377,11 @@ async function writePlaylistContents(input: {
   visibility: PlaylistVisibility;
   trackIds: string[];
   tracksById: Map<string, Track>;
+  description?: string;
+  cover?: string | null;
+  hearts?: string[];
+  listenCount?: number;
+  collaborators?: string[];
 }): Promise<void> {
   const playlistDir = getPlaylistDir(input.authorId, input.playlistSlug);
   await fs.mkdir(playlistDir, { recursive: true });
@@ -370,7 +402,12 @@ async function writePlaylistContents(input: {
 
   await writeJsonAtomic(getPlaylistMetadataPath(input.authorId, input.playlistSlug), {
     name: input.name,
-    visibility: input.visibility
+    visibility: input.visibility,
+    description: input.description ?? "",
+    cover: input.cover ?? null,
+    hearts: input.hearts ?? [],
+    listenCount: input.listenCount ?? 0,
+    collaborators: input.collaborators ?? []
   } satisfies PlaylistMetadata);
 }
 
@@ -435,13 +472,20 @@ export async function updateFilesystemPlaylist(input: UpdatePlaylistInput & { au
     await fs.rename(currentDir, nextDir);
   }
 
+  const existingMetadata = await readPlaylistMetadata(input.id);
+
   await writePlaylistContents({
     authorId: input.authorId,
     playlistSlug: nextSlug,
     name: nextName,
     visibility: input.visibility,
     trackIds: input.trackIds,
-    tracksById: input.tracksById
+    tracksById: input.tracksById,
+    description: existingMetadata?.description,
+    cover: existingMetadata?.cover,
+    hearts: existingMetadata?.hearts,
+    listenCount: existingMetadata?.listenCount,
+    collaborators: existingMetadata?.collaborators
   });
 }
 
@@ -449,4 +493,71 @@ export async function deleteFilesystemPlaylist(playlistId: string): Promise<void
   const { authorId, slug } = parsePlaylistIdOrThrow(playlistId);
   await fs.rm(getPlaylistDir(authorId, slug), { recursive: true, force: true });
   await fs.rm(getLegacyPlaylistDir(authorId, slug), { recursive: true, force: true });
+}
+
+async function patchPlaylistMetadataFile(
+  playlistId: string,
+  updater: (metadata: PlaylistMetadata) => PlaylistMetadata
+): Promise<PlaylistMetadata> {
+  const metadata = await readPlaylistMetadata(playlistId);
+  if (!metadata) {
+    throw new Error("Playlist metadata not found");
+  }
+
+  const updated = updater(metadata);
+  const { authorId, slug } = parsePlaylistIdOrThrow(playlistId);
+  await writeJsonAtomic(getPlaylistMetadataPath(authorId, slug), updated);
+  return updated;
+}
+
+export async function togglePlaylistHeart(
+  playlistId: string,
+  userId: string
+): Promise<{ hearted: boolean; heartCount: number }> {
+  const updated = await patchPlaylistMetadataFile(playlistId, (metadata) => {
+    const hearts = metadata.hearts.filter((id) => id !== userId);
+    const wasHearted = hearts.length < metadata.hearts.length;
+    if (!wasHearted) {
+      hearts.push(userId);
+    }
+    return { ...metadata, hearts };
+  });
+
+  return {
+    hearted: updated.hearts.includes(userId),
+    heartCount: updated.hearts.length
+  };
+}
+
+export async function incrementPlaylistListenCount(playlistId: string): Promise<number> {
+  const updated = await patchPlaylistMetadataFile(playlistId, (metadata) => ({
+    ...metadata,
+    listenCount: metadata.listenCount + 1
+  }));
+  return updated.listenCount;
+}
+
+export async function updatePlaylistDescription(
+  playlistId: string,
+  description: string
+): Promise<void> {
+  await patchPlaylistMetadataFile(playlistId, (metadata) => ({
+    ...metadata,
+    description
+  }));
+}
+
+export async function updatePlaylistCover(
+  playlistId: string,
+  coverPath: string | null
+): Promise<void> {
+  await patchPlaylistMetadataFile(playlistId, (metadata) => ({
+    ...metadata,
+    cover: coverPath
+  }));
+}
+
+export function getPlaylistDirectory(playlistId: string): string {
+  const { authorId, slug } = parsePlaylistIdOrThrow(playlistId);
+  return getPlaylistDir(authorId, slug);
 }

--- a/backend/src/services/upload/uploadService.ts
+++ b/backend/src/services/upload/uploadService.ts
@@ -34,13 +34,14 @@ export type UploadMetadataOverride = {
   artist?: string;
   album?: string;
   year?: number;
+  genre?: string[];
 };
 
 export type ProcessedUpload = {
   trackId: string;
   track: Track;
   isNew: boolean;
-  overrides?: { title?: string; artist?: string; album?: string; year?: number };
+  overrides?: { title?: string; artist?: string; album?: string; year?: number; genre?: string[] };
 };
 
 export function sanitizeExtension(fileName: string): string {
@@ -76,17 +77,18 @@ function resolveEffectiveOverrides(
   manualArtist: string | undefined,
   manualAlbum: string | undefined,
   manualYear: number | undefined
-): { title?: string; artist?: string; album?: string; year?: number } | undefined {
+): { title?: string; artist?: string; album?: string; year?: number; genre?: string[] } | undefined {
   const effectiveTitle = override.title;
   const effectiveArtist = override.artist ?? manualArtist;
   const effectiveAlbum = override.album ?? manualAlbum;
   const effectiveYear = override.year ?? manualYear;
+  const effectiveGenre = override.genre;
 
-  if (!effectiveTitle && !effectiveArtist && !effectiveAlbum && effectiveYear === undefined) {
+  if (!effectiveTitle && !effectiveArtist && !effectiveAlbum && effectiveYear === undefined && !effectiveGenre) {
     return undefined;
   }
 
-  return { title: effectiveTitle, artist: effectiveArtist, album: effectiveAlbum, year: effectiveYear };
+  return { title: effectiveTitle, artist: effectiveArtist, album: effectiveAlbum, year: effectiveYear, genre: effectiveGenre };
 }
 
 async function ensureArtistDirectory(artistDir: string, artistName: string): Promise<void> {
@@ -188,7 +190,8 @@ export async function processUploadedFile(
     ...(overrides?.title ? { title: overrides.title } : {}),
     ...(overrides?.artist ? { artist: overrides.artist } : {}),
     ...(overrides?.album ? { album: overrides.album } : {}),
-    ...(overrides?.year !== undefined ? { year: overrides.year } : {})
+    ...(overrides?.year !== undefined ? { year: overrides.year } : {}),
+    ...(overrides?.genre ? { genre: overrides.genre } : {})
   };
 
   const track: Track = {

--- a/backend/src/types/library.ts
+++ b/backend/src/types/library.ts
@@ -52,6 +52,12 @@ export type Playlist = {
   authorId: string;
   visibility: PlaylistVisibility;
   trackIds: string[];
+  description: string;
+  cover: string | null;
+  hearts: string[];
+  heartCount: number;
+  listenCount: number;
+  collaborators: string[];
 };
 
 export type LibraryIndex = {

--- a/docs/roadmap-playlist-remake.md
+++ b/docs/roadmap-playlist-remake.md
@@ -1,0 +1,481 @@
+# Playlist Remake Roadmap
+
+**Target version**: 0.3.0
+**Codename**: TBD
+**Status**: Planning
+
+---
+
+## Overview
+
+A ground-up rethinking of how playlists work in flaque. The goal is to go from a flat list of user-created playlists to a rich, categorized experience with three distinct playlist families: personal playlists, community-curated popular playlists, and server-generated automatic playlists powered by genre and listening habits.
+
+This roadmap is organized in 7 phases. Each phase is designed to land as a shippable increment, but later phases depend on earlier ones being complete.
+
+---
+
+## Dependency graph
+
+```
+Phase 1 (Genre)  ──────────────────────────┐
+                                            ├──> Phase 5 (Auto playlists)
+Phase 2 (Play tracking) ──┬────────────────┤
+                           │                └──> Phase 6 (Smart "For You")
+                           ├──> Phase 3 (Hearts & listen counts)
+                           │         │
+                           │         └──> Phase 4 (Playlist view overhaul)
+                           │                        │
+Phase 7 (Drag-and-drop) ───────────────────────────┘
+```
+
+Phases 1 and 2 have no dependency on each other and can be worked in parallel.
+Phase 7 (drag-and-drop) is independent and can be done at any point.
+
+---
+
+## Resolved design decisions
+
+These were discussed during planning and are final:
+
+1. **Genre synonym mapping**: Hardcoded default shipped with a solid base mapping (usable as-is). Admin override available in settings for fine-tuning by server owners.
+2. **Auto playlist configuration**: Admin-configurable via settings — both the maximum number of auto playlists generated and the minimum number of tracks per playlist.
+3. **"For You" dismissal**: Users can dismiss a "For You" playlist. A dismissal is treated as a strong signal and recorded per-user. The dismissed playlist will not be suggested again for **3 months**, after which it may reappear if the user's listening habits still warrant it.
+4. **Playlist descriptions**: Added to scope. An optional `description` field on `playlist.json`, shown on the detail page. Users can write a short description for their playlists.
+5. **Custom playlist cover**: Added to scope. Users can upload a custom cover image for their playlist, replacing the automatic mosaic patchwork when set.
+6. **Collaborative playlists**: In scope architecturally. The playlist model will include a `collaborators: string[]` field from the start. Collaborators can add/remove/reorder tracks but cannot delete the playlist or change its settings. Full collaborative playlist features are a future milestone but the data model must accommodate them now.
+
+---
+
+## Phase 1 — Genre infrastructure
+
+**Goal**: Every track in the library has genre metadata, either extracted from the file, manually set, or enriched via MusicBrainz. This is the foundation for automatic playlists.
+
+### 1a. Extend metadata overrides to support genre
+
+**What changes**:
+- Add `genre?: string[]` to `TrackMetadataOverride` in `metadataOverrideStore.ts`
+- Add `genre?: string[]` to `TrackMetadataPatch` (the frontend-facing patch type)
+- Update `uploadService.ts` to pass genre through the override pipeline
+- Update the single-track and bulk metadata edit APIs to accept genre patches
+- Update the frontend metadata edit forms (single track edit in admin, bulk edit) to show and edit genre as a comma-separated tag input
+
+**What already exists**:
+- `TrackTags.genre` is already `string[]` — the type is ready
+- `audioProbe.ts` already extracts genre from file metadata via `music-metadata`
+- The override system works for title/artist/album/year — genre follows the same pattern
+
+**Considerations**:
+- Genre values from files are freeform strings (e.g. "Progressive Rock", "Prog Rock", "prog-rock"). A lightweight normalization step (trim, title-case) during extraction would reduce fragmentation without losing user intent.
+- No genre taxonomy is enforced — users can set any value. Normalization only applies to auto-extracted and MusicBrainz-enriched values.
+
+### 1b. MusicBrainz genre lookup service
+
+**What to build**:
+- New service: `backend/src/services/genre/musicBrainzService.ts`
+- Query the [MusicBrainz API](https://musicbrainz.org/doc/MusicBrainz_API) to find genre tags for a recording, searching by artist + title
+- Lookup chain: search recordings → fetch recording details → read genre/tag data
+- Must respect MusicBrainz rate limit: **1 request per second** (mandatory). Use a serial queue with delay.
+- Set a proper `User-Agent` header as required by MusicBrainz API policy (e.g. `flaque/<version> (https://github.com/Marma92/flaque)`)
+- Return normalized genre strings or an empty array if nothing is found
+- Cache results to disk (simple JSON map `artist+title → genres`) to avoid redundant lookups
+
+**Technical notes**:
+- MusicBrainz is fully open, no API key required for moderate usage — fits a self-hosted server perfectly
+- The lookup is best-effort: if MusicBrainz doesn't have the recording, the track simply stays without genre
+- Endpoint: `https://musicbrainz.org/ws/2/recording?query=artist:{artist}+recording:{title}&fmt=json`
+
+### 1c. Genre synonym mapping
+
+**What to build**:
+- A hardcoded default synonym map shipped with the server (e.g. `"prog rock" → "progressive rock"`, `"synth pop" → "synthpop"`, `"hiphop" → "hip-hop"`). The default must be solid enough to use as-is.
+- An admin settings UI to view, add, edit, or remove synonym entries — positioned as fine-tuning for server owners, not something regular users need to touch.
+- Storage: `data/config/genre-synonyms.json`. On first boot, seeded from the hardcoded defaults. Admin edits modify this file.
+- Applied during: MusicBrainz enrichment, auto playlist grouping, and genre display normalization. **Not** applied to raw file metadata or user-set overrides (those stay as-is; normalization is at read/display time).
+
+### 1d. Auto-enrichment pipeline
+
+**What to build**:
+- **On upload**: After metadata extraction, if `tags.genre` is empty or missing, queue the track for MusicBrainz lookup. If a result is found, store it via the metadata override system.
+- **Background scan**: A one-time (or on-demand) job that scans all existing tracks with missing genre and attempts MusicBrainz enrichment. This handles the existing library backlog.
+- Enriched genres are stored as metadata overrides, meaning they can be manually corrected by the user at any time.
+
+**Considerations**:
+- The background scan can be slow due to rate limiting (1 req/sec). For a library of 1000 tracks missing genre, that's ~17 minutes. This should run as a non-blocking background task with progress logging.
+- A "genre enrichment status" indicator in the admin panel would be useful (e.g. "342/1200 tracks have genre metadata").
+
+### 1e. Genre display in the UI
+
+**What to build**:
+- Show genre tags on the track detail displays (track list rows, album track views)
+- Show genre in upload preview (already extracted, just needs rendering)
+- Genre editing in the single-track metadata edit modal and bulk edit modal
+- Genre display as small pill/badge components (similar to the lyrics "L" badge pattern already in use)
+
+---
+
+## Phase 2 — Playback tracking
+
+**Goal**: Know what each user listens to and how much. This powers popular playlist ranking and personalized automatic playlists.
+
+### 2a. Per-user play counter store
+
+**What to build**:
+- New store: `backend/src/services/activity/playCountStore.ts`
+- Storage: one JSON file per user at `data/users/{userId}/play-counts.json`
+- Schema:
+  ```json
+  {
+    "tracks": {
+      "track-id-1": { "count": 42, "lastPlayedAt": "2026-04-12T10:30:00Z" },
+      "track-id-2": { "count": 7, "lastPlayedAt": "2026-04-11T22:15:00Z" }
+    }
+  }
+  ```
+- Functions: `incrementPlayCount(userId, trackId)`, `getUserPlayCounts(userId)`, `getUserTopArtists(userId, limit)`
+- `getUserTopArtists` aggregates play counts by artist name (from the track index) and returns the top N
+
+**Why `lastPlayedAt`**: It's lightweight to store alongside the counter and enables potential "recently played" features without needing a separate system.
+
+### 2b. Play event endpoint
+
+**What to build**:
+- New endpoint: `POST /api/tracks/:id/play`
+- Called by the frontend when a track starts playing (or after a short threshold, e.g. 10 seconds, to avoid counting skips)
+- Increments the per-user play counter
+- Authenticated — userId comes from the session
+- Returns 204 (no body) — fire-and-forget from the frontend's perspective
+
+**Frontend integration**:
+- The audio player component calls this endpoint when playback begins (with a small debounce to avoid double-counting on seek/restart)
+- No UI impact — this is a background signal
+
+### 2c. Play stats API
+
+**What to build**:
+- `GET /api/me/play-stats` — returns the current user's top tracks and top artists (derived from play counts)
+- Used later by the smart playlist generator (Phase 6) and potentially by an "About you" section in the account view
+
+---
+
+## Phase 3 — Playlist model expansion
+
+**Goal**: Playlists carry engagement data, rich metadata, and a collaboration-ready structure.
+
+**Depends on**: Phase 2 (play tracking provides the listen-count signal)
+
+### 3a. Extend playlist.json schema
+
+**What changes**:
+- Expand `playlist.json` on disk with new fields:
+  ```json
+  {
+    "name": "My Metal Playlist",
+    "visibility": "public",
+    "description": "The best of thrash and prog metal from my collection.",
+    "cover": "playlists/my-metal/cover.jpg",
+    "hearts": ["user-id-1", "user-id-2"],
+    "listenCount": 47,
+    "collaborators": []
+  }
+  ```
+- `description`: optional free-text string. Displayed on the playlist detail page.
+- `cover`: optional path to a custom cover image uploaded by the playlist owner. When set, replaces the automatic mosaic patchwork.
+- `hearts`: array of user IDs. One heart per user, enforced at the API level. Since flaque servers are small-scale, storing full user IDs is fine and enables reliable toggle behavior.
+- `listenCount`: integer, incremented when a user plays the playlist.
+- `collaborators`: array of user IDs who can add/remove/reorder tracks but cannot delete the playlist or change its settings. Initially empty for all playlists — the field exists to make the model future-proof.
+- Update `PlaylistMetadata` type in `playlistStore.ts` to include these fields.
+- Update `readPlaylistMetadata` to parse them (defaulting to `""`, `null`, `[]`, `0`, `[]` for existing playlists — seamless migration).
+- Update `writePlaylistContents` to persist them.
+
+### 3b. Update the Playlist type
+
+**What changes**:
+- Add to the shared `Playlist` type in `types/library.ts`:
+  ```typescript
+  description: string;
+  cover: string | null;
+  hearts: string[];
+  heartCount: number;      // derived, for convenience
+  listenCount: number;
+  collaborators: string[];
+  ```
+- Update `scanFilesystemPlaylists` to populate these fields
+- Update `mapPlaylistResponse` in `playlistRoutes.ts` to include them in API responses
+- Update the frontend `Playlist` type to match
+- Update `canManagePlaylist` to also return true if the user is in `collaborators` (for track editing only — not for settings or deletion)
+
+### 3c. Heart/unheart API
+
+**What to build**:
+- `POST /api/playlists/:id/heart` — toggles the heart for the current user (add if absent, remove if present)
+- Only works on **user-created playlists** (not automatic playlists)
+- Updates `playlist.json` on disk, refreshes the playlist index
+- Returns the updated heart count and whether the current user has hearted it
+- Only public playlists from other users can be hearted (you can't heart your own playlist)
+
+### 3d. Playlist listen count tracking
+
+**What to build**:
+- `POST /api/playlists/:id/listen` — increments the listen count
+- Called by the frontend when a user starts playing a playlist (first track begins)
+- Debounced: at most one listen per user per playlist per hour (to avoid inflation from repeated plays)
+- Updates `playlist.json` on disk
+
+### 3e. Playlist cover upload
+
+**What to build**:
+- `POST /api/playlists/:id/cover` — upload a custom cover image (multipart/form-data)
+- Only the playlist owner (or admin) can upload a cover
+- Store the image in the playlist directory (e.g. `playlists/{slug}/cover.jpg`)
+- Resize/optimize on upload (same approach as existing profile photo upload)
+- `DELETE /api/playlists/:id/cover` — remove the custom cover, reverting to auto mosaic
+- Update the `cover` field in `playlist.json`
+- Frontend: cover upload button in the playlist edit modal / detail view
+
+### 3f. Playlist description editing
+
+**What to build**:
+- Add `description` to the PATCH `/api/playlists/:id` endpoint (already partially supports arbitrary fields)
+- Frontend: text area in the playlist edit modal
+- Display on the playlist detail page (Phase 4), below the playlist name
+
+---
+
+## Phase 4 — Playlist view overhaul
+
+**Goal**: Replace the flat playlist list with a categorized layout and a dedicated detail page.
+
+**Depends on**: Phase 3 (hearts, listen counts, descriptions, and covers must exist)
+
+### 4a. Dedicated playlist detail route
+
+**What to build**:
+- New route: `/library/playlists/:id`
+- New page component: `PlaylistDetailView.tsx`
+- Content:
+  - Playlist cover: custom cover if set, otherwise auto mosaic (large)
+  - Playlist name, description (if set), author name, visibility badge
+  - Heart button with count (if public playlist from another user)
+  - Listen count display
+  - Track count and total duration
+  - Full track list with playback controls (play track, add to queue)
+  - Play all / Shuffle buttons
+  - Edit button (if owner, collaborator, or admin) — opens the edit modal
+  - Collaborator list (if any)
+  - Back navigation to playlist section
+- Clicking a playlist card anywhere in the app navigates to this route instead of expanding inline
+
+**Routing changes**:
+- Add `"library/playlists/:id"` to the `PATH_MAP` in `appUtils.ts`
+- The route parameter needs to be parsed by `getRouteFromLocation` — this may require a small refactor to support dynamic segments (currently all routes are static)
+- Alternative: use a query param approach (`/library/playlists?id=...`) to avoid refactoring the router. Both work; the clean URL is nicer.
+
+### 4b. Three-section playlist layout
+
+**What to build**:
+- Refactor `LibraryPlaylistSection.tsx` into three distinct sections:
+
+**"My Playlists"**:
+- Shows playlists where `authorId === currentUser.id` (both private and public)
+- Includes the "Create playlist" form (moved here from the top of the current section)
+- Playlist cards link to the detail view
+
+**"Popular Playlists"**:
+- Shows public playlists where `authorId !== currentUser.id`
+- Sorted by a composite score: `heartCount * 3 + listenCount` (hearts weigh more because they're intentional; listens accumulate passively)
+- Each card shows heart count and listen count badges
+- If no public playlists from other users exist, this section is hidden
+
+**"Automatic Playlists"**:
+- Shows server-generated playlists (Phase 5)
+- Different visual treatment (e.g. gradient or subtle background pattern to distinguish from user playlists)
+- Cannot be hearted
+- Placeholder until Phase 5 is implemented: "Automatic playlists will appear here once generated"
+
+### 4c. Playlist card redesign
+
+**What to build**:
+- Redesign playlist cards to work as navigation links rather than expandable containers
+- Show: cover (custom or mosaic), name, author, track count, heart count badge, listen count badge
+- Click navigates to `/library/playlists/:id`
+- Play button on hover/focus starts playback without navigating
+- Compact grid layout (2-3 columns on desktop) instead of the current stacked list
+
+---
+
+## Phase 5 — Automatic genre/decade playlists
+
+**Goal**: The server generates thematic playlists by combining genre and decade (e.g. "70s Rock", "90s Pop", "80s Disco"). Regenerated every 2 weeks, configurable by admins.
+
+**Depends on**: Phase 1 (genre infrastructure must be in place)
+
+### 5a. Playlist generation algorithm
+
+**What to build**:
+- New service: `backend/src/services/playlists/autoPlaylistService.ts`
+- Scan all tracks in the library, group by `(genre, decade)` pairs
+  - Decade derived from `tags.year`: `Math.floor(year / 10) * 10` → "70s", "80s", etc.
+  - Genre taken from the first entry of `tags.genre[]` (primary genre), normalized via the synonym map (Phase 1c)
+  - Tracks with no genre or no year are excluded
+- For each `(genre, decade)` pair with enough tracks (minimum threshold: **admin-configurable**, default 8), generate a playlist:
+  - Name: `"{Decade} {Genre}"` (e.g. "70s Rock", "90s Pop")
+  - Select tracks up to a configurable max (default 30) using a diversity algorithm (spread across artists, avoid same-album clustering — reuse ideas from the radio's `pickBestCandidate`)
+  - Store track IDs in order
+
+**Genre normalization**:
+- Apply the synonym map from Phase 1c before grouping
+- Title-case the display name
+
+### 5b. Admin configuration
+
+**What to build**:
+- New admin settings section or entries within the existing settings:
+  - **Maximum number of auto playlists**: caps how many genre/decade playlists are generated (default: unlimited / all qualifying pairs)
+  - **Minimum tracks per playlist**: the threshold below which a genre/decade pair is skipped (default: 8)
+  - **Tracks per playlist**: max tracks selected per auto playlist (default: 30)
+- Stored in `data/config/auto-playlist-config.json`
+- Exposed via admin API: `GET/PATCH /api/config/auto-playlists`
+
+### 5c. Storage and lifecycle
+
+**What to build**:
+- Storage directory: `data/auto-playlists/`
+- Each auto-playlist stored as a JSON file:
+  ```json
+  {
+    "id": "auto:70s-rock",
+    "name": "70s Rock",
+    "genre": "rock",
+    "decade": 1970,
+    "trackIds": ["track-1", "track-2", ...],
+    "generatedAt": "2026-04-12T00:00:00Z",
+    "trackCount": 25
+  }
+  ```
+- Metadata file: `data/auto-playlists/_meta.json` storing `{ lastGeneratedAt: string }`
+- **Regeneration schedule**: Every 2 weeks. On server boot, check if `lastGeneratedAt` is older than 14 days — if so, regenerate all auto playlists.
+- Regeneration replaces all auto playlists (full rebuild). This naturally picks up new tracks added since the last generation.
+- Admin API: `POST /api/playlists/automatic/regenerate` to force regeneration on demand
+
+### 5d. Auto playlist API
+
+**What to build**:
+- `GET /api/playlists/automatic` — list all auto playlists (returns id, name, genre, decade, trackCount, generatedAt)
+- `GET /api/playlists/automatic/:id` — get a single auto playlist with full track IDs (resolved against the index for track details)
+- Auto playlists are **read-only** — no edit, no delete, no heart
+- Auto playlists are visible to all authenticated users
+
+### 5e. Frontend integration
+
+**What to build**:
+- Fetch auto playlists via the API and display in the "Automatic Playlists" section
+- Auto playlist cards use a distinct visual style (genre-colored accent or icon)
+- Clicking navigates to a detail view (reuse `PlaylistDetailView` with a read-only mode flag)
+- Show "Generated on {date}" instead of an author name
+
+---
+
+## Phase 6 — Smart "For You" playlists
+
+**Goal**: Personalized automatic playlists based on what each user listens to most. "Because you listen to {Artist}" style.
+
+**Depends on**: Phase 1 (genre data) + Phase 2 (play tracking) + Phase 5 (auto playlist infrastructure)
+
+### 6a. User listening analysis
+
+**What to build**:
+- Extend `playCountStore.ts` with a `getUserTopArtists(userId, limit)` function:
+  - Read the user's play counts
+  - Join with the track index to get artist names
+  - Aggregate by artist, return top N by total play count
+- Minimum threshold: only generate a "For You" playlist if the user has at least **20 total plays** across at least **3 distinct artists** (avoids noisy recommendations for new users)
+
+### 6b. Similar-track matching
+
+**What to build**:
+- For each of the user's top 3 artists:
+  - Look up the artist's genre(s) and typical decade range from the library
+  - Find other tracks in the library that share the same genre and are within ±10 years
+  - Exclude tracks by the seed artist (they'll be mixed back in)
+- Build a playlist of ~25 tracks:
+  - ~40% from the seed artist
+  - ~60% from genre/era peers
+  - Use the same diversity algorithm as Phase 5 to avoid clustering
+
+### 6c. "For You" playlist generation
+
+**What to build**:
+- Generate one "For You" playlist per qualifying top artist, per user
+- Naming: `"Because you listen to {Artist}"`
+- Storage: alongside auto playlists in `data/auto-playlists/for-you/{userId}/`
+- Regenerated on the same 2-week schedule as genre/decade playlists
+- Displayed in the "Automatic Playlists" section, visually distinguished (e.g. "Made for you" label)
+
+### 6d. Dismissal system
+
+**What to build**:
+- Per-user dismissal store: `data/users/{userId}/dismissed-playlists.json`
+- Schema:
+  ```json
+  {
+    "dismissed": [
+      { "playlistId": "for-you:pink-floyd", "dismissedAt": "2026-04-12T10:00:00Z" }
+    ]
+  }
+  ```
+- When the user dismisses a "For You" playlist, record the dismissal with a timestamp
+- During playlist generation and display, skip playlists that were dismissed less than **3 months** ago
+- After 3 months, the dismissal expires and the playlist may reappear if listening habits still warrant it
+- Frontend: a dismiss/hide button on "For You" playlist cards (e.g. "×" or "Not interested")
+- Dismissals only apply to "For You" playlists, not genre/decade auto playlists
+
+### 6e. (Optional) MusicBrainz artist relationships
+
+**Enhancement** (can be deferred):
+- Query MusicBrainz for artists related to the seed artist
+- Cross-reference with the local library to find matching tracks
+- This improves recommendations when the library has artists that are related but don't share exact genre tags
+
+---
+
+## Phase 7 — Drag-and-drop track reordering
+
+**Goal**: Replace the move-up/move-down buttons in the playlist edit modal with drag-and-drop.
+
+**No dependencies** — can be done at any point.
+
+### 7a. Library selection
+
+**Recommended**: [`@dnd-kit`](https://dndkit.com/)
+- Modern, accessible, well-maintained
+- Built specifically for React
+- ~12 KB gzipped (core + sortable)
+- Supports keyboard reordering (accessibility)
+- Touch-friendly for mobile
+
+Alternative: `@atlaskit/pragmatic-drag-and-drop` (Atlassian's library). Heavier but very polished.
+
+### 7b. Implementation
+
+**What to build**:
+- Replace the move-up/move-down buttons in `EditModal` (inside `LibraryPlaylistSection.tsx`) with a `@dnd-kit` `SortableContext`
+- Each track row gets a drag handle (grip icon on the left)
+- Visual feedback: dragged item has a shadow/elevation, drop target shows an insertion indicator
+- On drop: update `trackIds` array in state
+- Keep the remove button per track
+- Mobile: touch-drag works out of the box with `@dnd-kit`
+- Keyboard: arrow keys to move items when focused on the drag handle (built into `@dnd-kit`)
+
+---
+
+## Summary table
+
+| Phase | Name | Depends on | Estimated scope |
+|-------|------|-----------|----------------|
+| 1 | Genre infrastructure | — | Medium |
+| 2 | Playback tracking | — | Small |
+| 3 | Playlist model expansion | Phase 2 | Medium |
+| 4 | Playlist view overhaul | Phase 3 | Large |
+| 5 | Automatic playlists | Phase 1 | Medium–Large |
+| 6 | Smart "For You" playlists | Phases 1, 2, 5 | Medium |
+| 7 | Drag-and-drop reordering | — | Small |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,9 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "music-metadata": "^10.9.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ export default function App(): JSX.Element {
     activeView, setActiveView,
     activeLibrarySection, setActiveLibrarySection,
     activeConfigSection, setActiveConfigSection,
+    playlistDetailId, setPlaylistDetailId,
     handleLogin, notifyAuthStateChanged
   } = useSessionRoutingState();
 
@@ -37,6 +38,8 @@ export default function App(): JSX.Element {
       setActiveLibrarySection={setActiveLibrarySection}
       activeConfigSection={activeConfigSection}
       setActiveConfigSection={setActiveConfigSection}
+      playlistDetailId={playlistDetailId}
+      setPlaylistDetailId={setPlaylistDetailId}
       notifyAuthStateChanged={notifyAuthStateChanged}
     />
   );

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -20,6 +20,7 @@ import { usePlaybackCommands } from "./hooks/usePlaybackCommands";
 import { usePlaybackState } from "./hooks/usePlaybackState";
 import { useRecentlyUploaded } from "./hooks/useRecentlyUploaded";
 import { useAutoPlaylists } from "./hooks/useAutoPlaylists";
+import { useForYouPlaylists } from "./hooks/useForYouPlaylists";
 import { useRadioStation } from "./hooks/useRadioStation";
 
 type AuthenticatedAppProps = {
@@ -94,6 +95,7 @@ export function AuthenticatedApp({
   } = useInfiniteLibrary({ user, filters, pageSize: 30 });
 
   const { autoPlaylists, loading: loadingAutoPlaylists, refresh: refreshAutoPlaylists } = useAutoPlaylists();
+  const { forYouPlaylists, loading: loadingForYouPlaylists, dismiss: dismissForYouPlaylist } = useForYouPlaylists();
 
   const allTracksById = useMemo(
     () => new Map(allTracksLibrary.tracks.map((track) => [track.id, track])),
@@ -308,6 +310,9 @@ export function AuthenticatedApp({
         onReportPlaylistListen: handleReportPlaylistListen,
         autoPlaylists,
         loadingAutoPlaylists,
+        forYouPlaylists,
+        loadingForYouPlaylists,
+        onDismissForYouPlaylist: dismissForYouPlaylist,
         allTracksById,
         libraryMetadataError,
         loadingLibraryArtists,

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -19,6 +19,7 @@ import { useLibraryData } from "./hooks/useLibraryData";
 import { usePlaybackCommands } from "./hooks/usePlaybackCommands";
 import { usePlaybackState } from "./hooks/usePlaybackState";
 import { useRecentlyUploaded } from "./hooks/useRecentlyUploaded";
+import { useAutoPlaylists } from "./hooks/useAutoPlaylists";
 import { useRadioStation } from "./hooks/useRadioStation";
 
 type AuthenticatedAppProps = {
@@ -91,6 +92,8 @@ export function AuthenticatedApp({
     sentinelRef: paginatedSentinelRef,
     refresh: refreshPaginatedLibrary
   } = useInfiniteLibrary({ user, filters, pageSize: 30 });
+
+  const { autoPlaylists, loading: loadingAutoPlaylists, refresh: refreshAutoPlaylists } = useAutoPlaylists();
 
   const allTracksById = useMemo(
     () => new Map(allTracksLibrary.tracks.map((track) => [track.id, track])),
@@ -303,6 +306,8 @@ export function AuthenticatedApp({
         onDeletePlaylist: handleDeletePlaylist,
         onHeartPlaylist: handleHeartPlaylist,
         onReportPlaylistListen: handleReportPlaylistListen,
+        autoPlaylists,
+        loadingAutoPlaylists,
         allTracksById,
         libraryMetadataError,
         loadingLibraryArtists,

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -442,6 +442,7 @@ export function AuthenticatedApp({
       accountViewProps={{
         user,
         avatarUrl,
+        allTracksById,
         onUpdatePhoto: handleUpdateProfilePhoto,
         onUpdateEmail: handleUpdateEmail,
         onChangePassword: handleUpdateOwnPassword,

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -5,7 +5,7 @@ import { AppShell } from "./components/AppShell";
 import type { ConfigSection } from "./components/ConfigView";
 import type { Track, User } from "./types";
 import type { LibrarySection } from "./types/library";
-import type { ViewName } from "./utils/appUtils";
+import { navigateTo, type ViewName } from "./utils/appUtils";
 import { useAccountActions } from "./hooks/useAccountActions";
 import { useAdminBackup } from "./hooks/useAdminBackup";
 import { useAdminCommands } from "./hooks/useAdminCommands";
@@ -30,6 +30,8 @@ type AuthenticatedAppProps = {
   setActiveLibrarySection: Dispatch<SetStateAction<LibrarySection>>;
   activeConfigSection: ConfigSection;
   setActiveConfigSection: Dispatch<SetStateAction<ConfigSection>>;
+  playlistDetailId: string | null;
+  setPlaylistDetailId: Dispatch<SetStateAction<string | null>>;
   notifyAuthStateChanged: (kind: "login" | "logout" | "session-change") => void;
 };
 
@@ -42,6 +44,8 @@ export function AuthenticatedApp({
   setActiveLibrarySection,
   activeConfigSection,
   setActiveConfigSection,
+  playlistDetailId,
+  setPlaylistDetailId,
   notifyAuthStateChanged
 }: AuthenticatedAppProps): JSX.Element {
   // ── UI state ──────────────────────────────────────────────────────────
@@ -198,7 +202,8 @@ export function AuthenticatedApp({
     handleDeleteTrack, handleUpdateTrackMetadata,
     handleBulkDeleteTracks, handleBulkUpdateTrackMetadata,
     handleCreatePlaylist, handleAddTrackToPlaylist,
-    handlePatchPlaylist, handleDeletePlaylist
+    handlePatchPlaylist, handleDeletePlaylist,
+    handleHeartPlaylist, handleReportPlaylistListen
   } = useLibraryCommands({
     manageablePlaylists, refreshCurrentLibrary, refreshAllTracks,
     refreshRecentlyUploaded, refreshPaginatedLibrary,
@@ -286,10 +291,18 @@ export function AuthenticatedApp({
         onSectionChange: setActiveLibrarySection,
         availablePlaylists,
         ownerNameById,
+        user,
+        playlistDetailId,
+        onPlaylistDetailNavigate: (id: string | null) => {
+          setPlaylistDetailId(id);
+          navigateTo("library", "playlists", id);
+        },
         onCreatePlaylist: handleCreatePlaylist,
         onPlayPlaylist: handlePlayPlaylist,
         onPatchPlaylist: handlePatchPlaylist,
         onDeletePlaylist: handleDeletePlaylist,
+        onHeartPlaylist: handleHeartPlaylist,
+        onReportPlaylistListen: handleReportPlaylistListen,
         allTracksById,
         libraryMetadataError,
         loadingLibraryArtists,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,6 +3,8 @@ import type {
   ArtistEntry,
   AutoPlaylistDetail,
   AutoPlaylistSummary,
+  ForYouPlaylistDetail,
+  ForYouPlaylistSummary,
   LibraryResponse,
   Playlist,
   RadioCreateResponse,
@@ -723,6 +725,30 @@ export async function getAutoPlaylistDetail(id: string): Promise<{ playlist: Aut
 
 export async function regenerateAutoPlaylists(): Promise<{ regenerated: number }> {
   return requestJson<{ regenerated: number }>("/api/playlists/automatic/regenerate", {
+    method: "POST"
+  });
+}
+
+export async function getForYouPlaylists(): Promise<ForYouPlaylistSummary[]> {
+  const payload = await requestJson<{ playlists: ForYouPlaylistSummary[] }>("/api/playlists/for-you");
+  return payload.playlists;
+}
+
+export async function getForYouPlaylistDetail(id: string): Promise<{ playlist: ForYouPlaylistDetail; tracks: Track[] }> {
+  return requestJson<{ playlist: ForYouPlaylistDetail; tracks: Track[] }>(
+    `/api/playlists/for-you/${encodeURIComponent(id)}`
+  );
+}
+
+export async function dismissForYouPlaylist(playlistId: string): Promise<void> {
+  await requestJson<void>(
+    `/api/playlists/for-you/${encodeURIComponent(playlistId)}/dismiss`,
+    { method: "POST", skipJson: true }
+  );
+}
+
+export async function regenerateForYouPlaylists(): Promise<{ regenerated: number }> {
+  return requestJson<{ regenerated: number }>("/api/playlists/for-you/regenerate", {
     method: "POST"
   });
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,8 @@
 import type {
   AlbumEntry,
   ArtistEntry,
+  AutoPlaylistDetail,
+  AutoPlaylistSummary,
   LibraryResponse,
   Playlist,
   RadioCreateResponse,
@@ -706,6 +708,23 @@ export async function reportPlaylistListen(playlistId: string): Promise<void> {
 
 export function playlistCoverUrl(playlistId: string): string {
   return withApiBase(`/api/playlists/${encodeURIComponent(playlistId)}/cover`);
+}
+
+export async function getAutoPlaylists(): Promise<AutoPlaylistSummary[]> {
+  const payload = await requestJson<{ playlists: AutoPlaylistSummary[] }>("/api/playlists/automatic");
+  return payload.playlists;
+}
+
+export async function getAutoPlaylistDetail(id: string): Promise<{ playlist: AutoPlaylistDetail; tracks: Track[] }> {
+  return requestJson<{ playlist: AutoPlaylistDetail; tracks: Track[] }>(
+    `/api/playlists/automatic/${encodeURIComponent(id)}`
+  );
+}
+
+export async function regenerateAutoPlaylists(): Promise<{ regenerated: number }> {
+  return requestJson<{ regenerated: number }>("/api/playlists/automatic/regenerate", {
+    method: "POST"
+  });
 }
 
 export async function getUsers(): Promise<User[]> {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -886,6 +886,24 @@ export function coverUrl(trackId: string, coverPath?: string): string {
   return withApiBase(`/api/covers/${trackId}`);
 }
 
+export async function reportTrackPlay(trackId: string): Promise<void> {
+  await fetch(withApiBase(`/api/tracks/${encodeURIComponent(trackId)}/play`), {
+    method: "POST",
+    credentials: "include"
+  });
+}
+
+export type PlayStatsResponse = {
+  topTracks: Array<{ trackId: string; count: number; lastPlayedAt: string }>;
+  topArtists: Array<{ artist: string; playCount: number }>;
+  totalPlays: number;
+  uniqueTracksPlayed: number;
+};
+
+export async function getMyPlayStats(): Promise<PlayStatsResponse> {
+  return requestJson<PlayStatsResponse>("/api/me/play-stats");
+}
+
 // ── Admin: Server Logs ────────────────────────────────────────────────
 
 export type LogFile = {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -311,6 +311,7 @@ export type UploadTracksInput = {
     artist?: string;
     album?: string;
     year?: number;
+    genre?: string[];
   } | null>;
   onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
 };
@@ -349,6 +350,7 @@ type UploadSingleTrackInput = {
     artist?: string;
     album?: string;
     year?: number;
+    genre?: string[];
   } | null;
   onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
 };

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -691,6 +691,23 @@ export async function deletePlaylist(playlistId: string): Promise<void> {
   });
 }
 
+export async function heartPlaylist(playlistId: string): Promise<{ hearted: boolean; heartCount: number }> {
+  return requestJson<{ hearted: boolean; heartCount: number }>(
+    `/api/playlists/${encodeURIComponent(playlistId)}/heart`,
+    { method: "POST" }
+  );
+}
+
+export async function reportPlaylistListen(playlistId: string): Promise<void> {
+  await requestJson(`/api/playlists/${encodeURIComponent(playlistId)}/listen`, {
+    method: "POST"
+  }).catch(() => {});
+}
+
+export function playlistCoverUrl(playlistId: string): string {
+  return withApiBase(`/api/playlists/${encodeURIComponent(playlistId)}/cover`);
+}
+
 export async function getUsers(): Promise<User[]> {
   const payload = await requestJson<{ users: User[] }>("/api/users");
   return payload.users;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -725,9 +725,8 @@ export async function uploadPlaylistCover(playlistId: string, file: File): Promi
 }
 
 export async function deletePlaylistCover(playlistId: string): Promise<void> {
-  await requestJson<void>(`/api/playlists/${encodeURIComponent(playlistId)}/cover`, {
-    method: "DELETE",
-    skipJson: true
+  await requestJson<{ ok: boolean }>(`/api/playlists/${encodeURIComponent(playlistId)}/cover`, {
+    method: "DELETE"
   });
 }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -657,6 +657,7 @@ export async function rebuildIndex(): Promise<{ generatedAt: string; totalTracks
 export async function createPlaylist(input: {
   name: string;
   visibility: PlaylistVisibility;
+  description?: string;
 }): Promise<Playlist> {
   const payload = await requestJson<{ playlist: Playlist }>("/api/playlists", {
     method: "POST",
@@ -675,6 +676,8 @@ export async function patchPlaylist(
     name?: string;
     visibility?: PlaylistVisibility;
     trackIds?: string[];
+    description?: string;
+    collaborators?: string[];
   }
 ): Promise<Playlist> {
   const payload = await requestJson<{ playlist: Playlist }>(`/api/playlists/${encodeURIComponent(playlistId)}`, {
@@ -710,6 +713,22 @@ export async function reportPlaylistListen(playlistId: string): Promise<void> {
 
 export function playlistCoverUrl(playlistId: string): string {
   return withApiBase(`/api/playlists/${encodeURIComponent(playlistId)}/cover`);
+}
+
+export async function uploadPlaylistCover(playlistId: string, file: File): Promise<void> {
+  const formData = new FormData();
+  formData.append("cover", file);
+  await requestJson<{ ok: boolean }>(`/api/playlists/${encodeURIComponent(playlistId)}/cover`, {
+    method: "POST",
+    body: formData
+  });
+}
+
+export async function deletePlaylistCover(playlistId: string): Promise<void> {
+  await requestJson<void>(`/api/playlists/${encodeURIComponent(playlistId)}/cover`, {
+    method: "DELETE",
+    skipJson: true
+  });
 }
 
 export async function getAutoPlaylists(): Promise<AutoPlaylistSummary[]> {
@@ -964,6 +983,86 @@ export type PlayStatsResponse = {
 
 export async function getMyPlayStats(): Promise<PlayStatsResponse> {
   return requestJson<PlayStatsResponse>("/api/me/play-stats");
+}
+
+// ── Admin: Genre Management ───────────────────────────────────────────
+
+export type GenreSynonyms = Record<string, string>;
+
+export async function getGenreSynonyms(): Promise<GenreSynonyms> {
+  const payload = await requestJson<{ synonyms: GenreSynonyms }>("/api/genre/synonyms");
+  return payload.synonyms;
+}
+
+export async function putGenreSynonym(key: string, value: string): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/synonyms", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, value })
+  });
+}
+
+export async function deleteGenreSynonym(key: string): Promise<void> {
+  await requestJson<void>(`/api/genre/synonyms/${encodeURIComponent(key)}`, {
+    method: "DELETE",
+    skipJson: true
+  });
+}
+
+export async function resetGenreSynonyms(): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/synonyms/reset", { method: "POST" });
+}
+
+export type EnrichmentStatus = {
+  running: boolean;
+  processed?: number;
+  total?: number;
+  startedAt?: string;
+};
+
+export async function getEnrichmentStatus(): Promise<EnrichmentStatus> {
+  return requestJson<EnrichmentStatus>("/api/genre/enrichment/status");
+}
+
+export async function startEnrichment(): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/enrichment/start", { method: "POST" });
+}
+
+export async function stopEnrichment(): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/enrichment/stop", { method: "POST" });
+}
+
+export type GenreCacheStats = {
+  entries: number;
+  sizeBytes: number;
+};
+
+export async function getGenreCacheStats(): Promise<GenreCacheStats> {
+  return requestJson<GenreCacheStats>("/api/genre/cache/stats");
+}
+
+export async function clearGenreCache(): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/cache/clear", { method: "POST" });
+}
+
+// ── Admin: Auto-Playlist Config ──────────────────────────────────────
+
+export type AutoPlaylistConfig = {
+  maxPlaylists: number;
+  minTracksPerPlaylist: number;
+  tracksPerPlaylist: number;
+};
+
+export async function getAutoPlaylistConfig(): Promise<AutoPlaylistConfig> {
+  return requestJson<AutoPlaylistConfig>("/api/config/auto-playlists");
+}
+
+export async function patchAutoPlaylistConfig(patch: Partial<AutoPlaylistConfig>): Promise<AutoPlaylistConfig> {
+  return requestJson<AutoPlaylistConfig>("/api/config/auto-playlists", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch)
+  });
 }
 
 // ── Admin: Server Logs ────────────────────────────────────────────────

--- a/frontend/src/components/AccountView.test.tsx
+++ b/frontend/src/components/AccountView.test.tsx
@@ -55,6 +55,7 @@ describe("AccountView", () => {
       <AccountView
         user={createUser()}
         avatarUrl="/api/users/me/photo"
+        allTracksById={new Map()}
         onUpdatePhoto={vi.fn().mockResolvedValue(undefined)}
         onUpdateEmail={vi.fn().mockResolvedValue(undefined)}
         onChangePassword={vi.fn().mockResolvedValue(undefined)}
@@ -93,6 +94,7 @@ describe("AccountView", () => {
       <AccountView
         user={createUser()}
         avatarUrl="/api/users/me/photo"
+        allTracksById={new Map()}
         onUpdatePhoto={vi.fn().mockResolvedValue(undefined)}
         onUpdateEmail={vi.fn().mockResolvedValue(undefined)}
         onChangePassword={vi.fn().mockResolvedValue(undefined)}
@@ -127,6 +129,7 @@ describe("AccountView", () => {
       <AccountView
         user={createUser()}
         avatarUrl="/api/users/me/photo"
+        allTracksById={new Map()}
         onUpdatePhoto={vi.fn().mockResolvedValue(undefined)}
         onUpdateEmail={vi.fn().mockResolvedValue(undefined)}
         onChangePassword={vi.fn().mockResolvedValue(undefined)}

--- a/frontend/src/components/AccountView.tsx
+++ b/frontend/src/components/AccountView.tsx
@@ -1,10 +1,12 @@
 import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { User, UserSession } from "../types";
+import { coverUrl, getMyPlayStats, type PlayStatsResponse } from "../api";
+import type { Track, User, UserSession } from "../types";
 
 type AccountViewProps = {
   user: User;
   avatarUrl: string;
+  allTracksById: Map<string, Track>;
   onUpdatePhoto: (file: File) => Promise<void>;
   onUpdateEmail: (email: string) => Promise<void>;
   onChangePassword: (input: { currentPassword: string; newPassword: string }) => Promise<void>;
@@ -50,6 +52,7 @@ function getSessionTitle(session: UserSession): string {
 export function AccountView({
   user,
   avatarUrl,
+  allTracksById,
   onUpdatePhoto,
   onUpdateEmail,
   onChangePassword,
@@ -80,6 +83,17 @@ export function AccountView({
   const [sessionsMessage, setSessionsMessage] = useState<string | null>(null);
   const [revokingSessionId, setRevokingSessionId] = useState<string | null>(null);
   const [loggingOutOtherSessions, setLoggingOutOtherSessions] = useState(false);
+
+  const [playStats, setPlayStats] = useState<PlayStatsResponse | null>(null);
+  const [loadingStats, setLoadingStats] = useState(true);
+
+  useEffect(() => {
+    setLoadingStats(true);
+    void getMyPlayStats()
+      .then(setPlayStats)
+      .catch(() => {})
+      .finally(() => setLoadingStats(false));
+  }, []);
 
   const initial = useMemo(() => getUserInitial(user), [user]);
   const displayedAvatarUrl = selectedPhotoPreviewUrl ?? avatarUrl;
@@ -458,6 +472,74 @@ export function AccountView({
             {passwordMessage.text}
           </p>
         ) : null}
+      </section>
+
+      <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <h3 className="font-display text-xl text-flaque-ink">Listening Stats</h3>
+
+        {loadingStats ? (
+          <p className="mt-3 text-sm text-flaque-steel">Loading stats...</p>
+        ) : !playStats || playStats.totalPlays === 0 ? (
+          <p className="mt-3 text-sm text-flaque-steel">No listening history yet. Start playing some music!</p>
+        ) : (
+          <div className="mt-3 space-y-4">
+            <div className="flex flex-wrap gap-4">
+              <div className="rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-4 py-3">
+                <p className="font-display text-2xl text-flaque-ink">{playStats.totalPlays}</p>
+                <p className="text-xs text-flaque-steel">Total plays</p>
+              </div>
+              <div className="rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-4 py-3">
+                <p className="font-display text-2xl text-flaque-ink">{playStats.uniqueTracksPlayed}</p>
+                <p className="text-xs text-flaque-steel">Unique tracks</p>
+              </div>
+              <div className="rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-4 py-3">
+                <p className="font-display text-2xl text-flaque-ink">{playStats.topArtists.length}</p>
+                <p className="text-xs text-flaque-steel">Artists</p>
+              </div>
+            </div>
+
+            {playStats.topArtists.length > 0 ? (
+              <div>
+                <h4 className="text-sm font-medium text-flaque-ink">Top Artists</h4>
+                <div className="mt-2 space-y-1">
+                  {playStats.topArtists.slice(0, 10).map((entry, i) => (
+                    <div key={entry.artist} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-3 py-1.5">
+                      <span className="w-5 shrink-0 text-right text-xs text-flaque-steel/60">{i + 1}</span>
+                      <span className="min-w-0 flex-1 truncate text-sm text-flaque-ink">{entry.artist}</span>
+                      <span className="shrink-0 text-xs text-flaque-steel">{entry.playCount} play{entry.playCount !== 1 ? "s" : ""}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {playStats.topTracks.length > 0 ? (
+              <div>
+                <h4 className="text-sm font-medium text-flaque-ink">Top Tracks</h4>
+                <div className="mt-2 space-y-1">
+                  {playStats.topTracks.slice(0, 10).map((entry, i) => {
+                    const track = allTracksById.get(entry.trackId);
+                    return (
+                      <div key={entry.trackId} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-2 py-1.5">
+                        <span className="w-5 shrink-0 text-right text-xs text-flaque-steel/60">{i + 1}</span>
+                        {track ? (
+                          <img src={coverUrl(track.id)} alt="" className="h-8 w-8 shrink-0 rounded-md object-cover" loading="lazy" />
+                        ) : (
+                          <div className="h-8 w-8 shrink-0 rounded-md bg-flaque-clay/30" />
+                        )}
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm text-flaque-ink">{track?.tags.title ?? entry.trackId}</p>
+                          <p className="truncate text-xs text-flaque-steel">{track?.tags.artist ?? "Unknown"}</p>
+                        </div>
+                        <span className="shrink-0 text-xs text-flaque-steel">{entry.count}x</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        )}
       </section>
 
       <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">

--- a/frontend/src/components/AdminLibraryView.tsx
+++ b/frontend/src/components/AdminLibraryView.tsx
@@ -1,0 +1,380 @@
+import { FormEvent, useEffect, useState } from "react";
+
+import {
+  clearGenreCache,
+  deleteGenreSynonym,
+  getAutoPlaylistConfig,
+  getEnrichmentStatus,
+  getGenreCacheStats,
+  getGenreSynonyms,
+  patchAutoPlaylistConfig,
+  putGenreSynonym,
+  regenerateAutoPlaylists,
+  resetGenreSynonyms,
+  startEnrichment,
+  stopEnrichment,
+  type AutoPlaylistConfig,
+  type EnrichmentStatus,
+  type GenreCacheStats,
+  type GenreSynonyms
+} from "../api";
+
+export function AdminLibraryView(): JSX.Element {
+  // ── Genre synonyms ─────────────────────────────────────────────
+  const [synonyms, setSynonyms] = useState<GenreSynonyms>({});
+  const [loadingSynonyms, setLoadingSynonyms] = useState(true);
+  const [synonymKey, setSynonymKey] = useState("");
+  const [synonymValue, setSynonymValue] = useState("");
+  const [synonymMessage, setSynonymMessage] = useState<string | null>(null);
+
+  // ── Enrichment ─────────────────────────────────────────────────
+  const [enrichStatus, setEnrichStatus] = useState<EnrichmentStatus | null>(null);
+  const [enrichLoading, setEnrichLoading] = useState(false);
+
+  // ── Cache ──────────────────────────────────────────────────────
+  const [cacheStats, setCacheStats] = useState<GenreCacheStats | null>(null);
+
+  // ── Auto-playlist config ───────────────────────────────────────
+  const [config, setConfig] = useState<AutoPlaylistConfig | null>(null);
+  const [loadingConfig, setLoadingConfig] = useState(true);
+  const [configMax, setConfigMax] = useState("");
+  const [configMin, setConfigMin] = useState("");
+  const [configTracks, setConfigTracks] = useState("");
+  const [configMessage, setConfigMessage] = useState<string | null>(null);
+  const [savingConfig, setSavingConfig] = useState(false);
+  const [regenerating, setRegenerating] = useState(false);
+  const [regenMessage, setRegenMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    void loadSynonyms();
+    void loadEnrichStatus();
+    void loadCacheStats();
+    void loadConfig();
+  }, []);
+
+  async function loadSynonyms(): Promise<void> {
+    setLoadingSynonyms(true);
+    try {
+      const data = await getGenreSynonyms();
+      setSynonyms(data);
+    } catch {
+      setSynonymMessage("Failed to load synonyms.");
+    } finally {
+      setLoadingSynonyms(false);
+    }
+  }
+
+  async function loadEnrichStatus(): Promise<void> {
+    try {
+      const status = await getEnrichmentStatus();
+      setEnrichStatus(status);
+    } catch {}
+  }
+
+  async function loadCacheStats(): Promise<void> {
+    try {
+      const stats = await getGenreCacheStats();
+      setCacheStats(stats);
+    } catch {}
+  }
+
+  async function loadConfig(): Promise<void> {
+    setLoadingConfig(true);
+    try {
+      const cfg = await getAutoPlaylistConfig();
+      setConfig(cfg);
+      setConfigMax(String(cfg.maxPlaylists));
+      setConfigMin(String(cfg.minTracksPerPlaylist));
+      setConfigTracks(String(cfg.tracksPerPlaylist));
+    } catch {} finally {
+      setLoadingConfig(false);
+    }
+  }
+
+  async function handleAddSynonym(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    const k = synonymKey.trim().toLowerCase();
+    const v = synonymValue.trim();
+    if (!k || !v) return;
+    try {
+      await putGenreSynonym(k, v);
+      setSynonymKey("");
+      setSynonymValue("");
+      await loadSynonyms();
+    } catch (err) {
+      setSynonymMessage(err instanceof Error ? err.message : "Failed to save synonym.");
+    }
+  }
+
+  async function handleDeleteSynonym(key: string): Promise<void> {
+    try {
+      await deleteGenreSynonym(key);
+      await loadSynonyms();
+    } catch {}
+  }
+
+  async function handleResetSynonyms(): Promise<void> {
+    try {
+      await resetGenreSynonyms();
+      await loadSynonyms();
+      setSynonymMessage("Synonyms reset to defaults.");
+    } catch {}
+  }
+
+  async function handleToggleEnrichment(): Promise<void> {
+    setEnrichLoading(true);
+    try {
+      if (enrichStatus?.running) {
+        await stopEnrichment();
+      } else {
+        await startEnrichment();
+      }
+      await loadEnrichStatus();
+    } catch {} finally {
+      setEnrichLoading(false);
+    }
+  }
+
+  async function handleClearCache(): Promise<void> {
+    try {
+      await clearGenreCache();
+      await loadCacheStats();
+    } catch {}
+  }
+
+  async function handleSaveConfig(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    setSavingConfig(true);
+    setConfigMessage(null);
+    try {
+      const patch: Partial<AutoPlaylistConfig> = {};
+      const maxVal = parseInt(configMax);
+      const minVal = parseInt(configMin);
+      const tracksVal = parseInt(configTracks);
+      if (!isNaN(maxVal)) patch.maxPlaylists = maxVal;
+      if (!isNaN(minVal)) patch.minTracksPerPlaylist = minVal;
+      if (!isNaN(tracksVal)) patch.tracksPerPlaylist = tracksVal;
+      const updated = await patchAutoPlaylistConfig(patch);
+      setConfig(updated);
+      setConfigMessage("Configuration saved.");
+    } catch (err) {
+      setConfigMessage(err instanceof Error ? err.message : "Failed to save config.");
+    } finally {
+      setSavingConfig(false);
+    }
+  }
+
+  async function handleRegenerate(): Promise<void> {
+    setRegenerating(true);
+    setRegenMessage(null);
+    try {
+      const result = await regenerateAutoPlaylists();
+      setRegenMessage(`Regenerated ${result.regenerated} playlist${result.regenerated !== 1 ? "s" : ""}.`);
+    } catch (err) {
+      setRegenMessage(err instanceof Error ? err.message : "Failed to regenerate.");
+    } finally {
+      setRegenerating(false);
+    }
+  }
+
+  const synonymEntries = Object.entries(synonyms).sort(([a], [b]) => a.localeCompare(b));
+
+  return (
+    <div className="m-4 space-y-4">
+      {/* ── Genre Synonyms ──────────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="font-display text-xl text-flaque-ink">Genre Synonyms</h3>
+          <button
+            type="button"
+            className="rounded-xl border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+            onClick={() => { void handleResetSynonyms(); }}
+          >
+            Reset to defaults
+          </button>
+        </div>
+
+        <form className="mt-3 flex flex-wrap items-end gap-2" onSubmit={(e) => { void handleAddSynonym(e); }}>
+          <label className="text-sm text-flaque-ink">
+            From
+            <input
+              className="mt-1 block w-40 rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              value={synonymKey}
+              onChange={(e) => setSynonymKey(e.target.value)}
+              placeholder="e.g. hiphop"
+            />
+          </label>
+          <label className="text-sm text-flaque-ink">
+            To
+            <input
+              className="mt-1 block w-40 rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              value={synonymValue}
+              onChange={(e) => setSynonymValue(e.target.value)}
+              placeholder="e.g. hip-hop"
+            />
+          </label>
+          <button
+            type="submit"
+            className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:opacity-60"
+            disabled={!synonymKey.trim() || !synonymValue.trim()}
+          >
+            Add
+          </button>
+        </form>
+
+        {synonymMessage ? <p className="mt-2 text-xs text-flaque-steel">{synonymMessage}</p> : null}
+
+        {loadingSynonyms ? (
+          <p className="mt-3 text-sm text-flaque-steel">Loading...</p>
+        ) : synonymEntries.length === 0 ? (
+          <p className="mt-3 text-sm text-flaque-steel">No synonyms configured.</p>
+        ) : (
+          <div className="mt-3 max-h-60 overflow-y-auto rounded-xl border border-flaque-clay/40">
+            <table className="w-full text-left text-sm">
+              <thead className="sticky top-0 bg-flaque-cream/95 text-flaque-ink">
+                <tr>
+                  <th className="px-3 py-2 font-medium">From</th>
+                  <th className="px-3 py-2 font-medium">To</th>
+                  <th className="w-16 px-3 py-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {synonymEntries.map(([key, value]) => (
+                  <tr key={key} className="border-t border-flaque-clay/30">
+                    <td className="px-3 py-1.5 text-flaque-ink">{key}</td>
+                    <td className="px-3 py-1.5 text-flaque-steel">{value}</td>
+                    <td className="px-3 py-1.5">
+                      <button
+                        type="button"
+                        className="text-xs text-red-500 hover:text-red-700"
+                        onClick={() => { void handleDeleteSynonym(key); }}
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* ── Genre Enrichment ────────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <h3 className="font-display text-xl text-flaque-ink">MusicBrainz Enrichment</h3>
+        <p className="mt-1 text-sm text-flaque-steel">
+          Enrich tracks missing genre data by looking them up on MusicBrainz.
+        </p>
+
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            className={`rounded-xl px-4 py-2 text-sm font-medium transition ${
+              enrichStatus?.running
+                ? "border border-red-300 bg-red-50 text-red-700 hover:bg-red-100"
+                : "bg-flaque-ink text-flaque-cream hover:bg-black"
+            }`}
+            onClick={() => { void handleToggleEnrichment(); }}
+            disabled={enrichLoading}
+          >
+            {enrichLoading
+              ? "..."
+              : enrichStatus?.running
+                ? "Stop enrichment"
+                : "Start enrichment"}
+          </button>
+
+          {enrichStatus?.running && enrichStatus.processed !== undefined ? (
+            <span className="text-sm text-flaque-steel">
+              {enrichStatus.processed}{enrichStatus.total !== undefined ? ` / ${enrichStatus.total}` : ""} tracks processed
+            </span>
+          ) : null}
+        </div>
+
+        {cacheStats ? (
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <span className="text-sm text-flaque-steel">
+              Cache: {cacheStats.entries} entries ({(cacheStats.sizeBytes / 1024).toFixed(1)} KB)
+            </span>
+            <button
+              type="button"
+              className="rounded-lg border border-flaque-clay px-3 py-1 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+              onClick={() => { void handleClearCache(); }}
+            >
+              Clear cache
+            </button>
+          </div>
+        ) : null}
+      </section>
+
+      {/* ── Auto-Playlist Config ────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <h3 className="font-display text-xl text-flaque-ink">Automatic Playlists</h3>
+        <p className="mt-1 text-sm text-flaque-steel">
+          Configure how genre/decade playlists are generated.
+        </p>
+
+        {loadingConfig ? (
+          <p className="mt-3 text-sm text-flaque-steel">Loading...</p>
+        ) : (
+          <form className="mt-3 space-y-3" onSubmit={(e) => { void handleSaveConfig(e); }}>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <label className="text-sm text-flaque-ink">
+                Max playlists
+                <input
+                  className="mt-1 block w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                  type="number"
+                  min={0}
+                  value={configMax}
+                  onChange={(e) => setConfigMax(e.target.value)}
+                />
+              </label>
+              <label className="text-sm text-flaque-ink">
+                Min tracks per playlist
+                <input
+                  className="mt-1 block w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                  type="number"
+                  min={1}
+                  value={configMin}
+                  onChange={(e) => setConfigMin(e.target.value)}
+                />
+              </label>
+              <label className="text-sm text-flaque-ink">
+                Tracks per playlist
+                <input
+                  className="mt-1 block w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                  type="number"
+                  min={1}
+                  value={configTracks}
+                  onChange={(e) => setConfigTracks(e.target.value)}
+                />
+              </label>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="submit"
+                className="rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-flaque-cream transition hover:bg-black disabled:opacity-60"
+                disabled={savingConfig}
+              >
+                {savingConfig ? "Saving..." : "Save configuration"}
+              </button>
+              <button
+                type="button"
+                className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:opacity-60"
+                onClick={() => { void handleRegenerate(); }}
+                disabled={regenerating}
+              >
+                {regenerating ? "Regenerating..." : "Regenerate now"}
+              </button>
+            </div>
+
+            {configMessage ? <p className="text-sm text-flaque-steel">{configMessage}</p> : null}
+            {regenMessage ? <p className="text-sm text-flaque-steel">{regenMessage}</p> : null}
+          </form>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -2,6 +2,7 @@ import type { User } from "../types";
 import { navigateTo, type ViewName } from "../utils/appUtils";
 import { AccountView } from "./AccountView";
 import { AdminBackupView } from "./AdminBackupView";
+import { AdminLibraryView } from "./AdminLibraryView";
 import { AdminServerView } from "./AdminServerView";
 import { AdminUsersView } from "./AdminUsersView";
 import { AudioPlayer } from "./AudioPlayer";
@@ -75,7 +76,7 @@ export function AppShell({
     }`;
 
   const configSections: Array<[ConfigSection, string]> = [
-    ["index", "Index"], ["files", "Files"], ["users", "Users"], ["server", "Server"], ["backup", "Backup"]
+    ["index", "Index"], ["files", "Files"], ["users", "Users"], ["library", "Library"], ["server", "Server"], ["backup", "Backup"]
   ];
 
   const sectionSwitcher = activeView === "config" && user.role === "admin" ? (
@@ -145,6 +146,10 @@ export function AppShell({
 
             {configViewProps.activeSection === "backup" ? (
               <AdminBackupView {...backupViewProps} />
+            ) : null}
+
+            {configViewProps.activeSection === "library" ? (
+              <AdminLibraryView />
             ) : null}
           </div>
         ) : null}

--- a/frontend/src/components/AutoPlaylistDetailView.tsx
+++ b/frontend/src/components/AutoPlaylistDetailView.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { coverUrl, getAutoPlaylistDetail } from "../api";
+import type { AutoPlaylistDetail, Playlist, Track } from "../types";
+import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+
+type AutoPlaylistDetailViewProps = {
+  playlistId: string;
+  allTracksById: Map<string, Track>;
+  onBack: () => void;
+  onPlayTrack: (playlist: Playlist) => void;
+};
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+export function AutoPlaylistDetailView({
+  playlistId,
+  allTracksById,
+  onBack,
+  onPlayTrack
+}: AutoPlaylistDetailViewProps): JSX.Element {
+  const [detail, setDetail] = useState<AutoPlaylistDetail | null>(null);
+  const [detailTracks, setDetailTracks] = useState<Track[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    getAutoPlaylistDetail(playlistId)
+      .then((result) => {
+        setDetail(result.playlist);
+        setDetailTracks(result.tracks);
+      })
+      .catch(() => {
+        setDetail(null);
+        setDetailTracks([]);
+      })
+      .finally(() => setLoading(false));
+  }, [playlistId]);
+
+  const tracks = useMemo(() => {
+    if (!detail) return detailTracks;
+    return detail.trackIds
+      .map((id) => detailTracks.find((t) => t.id === id) ?? allTracksById.get(id))
+      .filter((t): t is Track => t !== undefined);
+  }, [detail, detailTracks, allTracksById]);
+
+  const totalDuration = useMemo(() => tracks.reduce((sum, t) => sum + t.duration, 0), [tracks]);
+
+  function handlePlayAll(): void {
+    if (!detail || tracks.length === 0) return;
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: tracks.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
+  function handleShufflePlay(): void {
+    if (!detail || tracks.length === 0) return;
+    const shuffled = [...tracks].sort(() => Math.random() - 0.5);
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: shuffled.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
+  if (loading) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <button
+          type="button"
+          className="mb-4 flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+          onClick={onBack}
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to playlists
+        </button>
+        <p className="text-sm text-flaque-steel">Loading...</p>
+      </section>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <button
+          type="button"
+          className="mb-4 flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+          onClick={onBack}
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to playlists
+        </button>
+        <p className="text-sm text-flaque-steel">Auto playlist not found.</p>
+      </section>
+    );
+  }
+
+  const decadeLabel = detail.decade % 100 === 0 ? `${detail.decade}` : `${detail.decade % 100}s`;
+
+  return (
+    <section className="m-4 space-y-4">
+      {/* Back button */}
+      <button
+        type="button"
+        className="flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+        onClick={onBack}
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        Back to playlists
+      </button>
+
+      {/* Header card */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-white/85 to-flaque-cream/40 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-col gap-5 sm:flex-row">
+          {/* Genre/decade visual */}
+          <div className="flex h-48 w-48 shrink-0 items-center justify-center self-center overflow-hidden rounded-2xl bg-gradient-to-br from-flaque-sand/50 to-flaque-clay/30 sm:self-start">
+            <div className="text-center">
+              <p className="font-display text-5xl font-bold text-flaque-ink/60">{decadeLabel}</p>
+              <p className="mt-1 text-sm font-medium text-flaque-steel">{detail.genre}</p>
+            </div>
+          </div>
+
+          {/* Info */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <h2 className="font-display text-2xl text-flaque-ink">{detail.name}</h2>
+
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-flaque-steel">
+              <span className="rounded-full bg-flaque-sand/50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-flaque-ink/70">
+                Auto-generated
+              </span>
+              <span>{detail.trackCount} track{detail.trackCount !== 1 ? "s" : ""}</span>
+              {totalDuration > 0 ? <span>{formatDuration(totalDuration)}</span> : null}
+              <span>Generated {new Date(detail.generatedAt).toLocaleDateString()}</span>
+            </div>
+
+            {/* Action buttons */}
+            <div className="mt-auto flex flex-wrap items-center gap-2 pt-4">
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black"
+                onClick={handlePlayAll}
+              >
+                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+                Play all
+              </button>
+
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
+                onClick={handleShufflePlay}
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4" />
+                </svg>
+                Shuffle
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Track list */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
+        {tracks.length === 0 ? (
+          <p className="px-5 py-4 text-sm text-flaque-steel">No playable tracks.</p>
+        ) : (
+          <ul>
+            {tracks.map((track, index) => (
+              <li
+                key={track.id}
+                className="flex items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+              >
+                <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
+                <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
+                  <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
+                    {track.tags.extra?.lyrics ? (
+                      <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
+                        L
+                      </span>
+                    ) : null}
+                    <span className="truncate">{getTrackDisplayTitle(track)}</span>
+                  </p>
+                  <p className="truncate text-xs text-flaque-steel">
+                    {getTrackDisplayArtist(track) ?? "Unknown artist"}
+                    {track.tags.album ? ` \u00b7 ${track.tags.album}` : ""}
+                  </p>
+                </div>
+                <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
+                  {formatDuration(track.duration)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/ConfigView.tsx
+++ b/frontend/src/components/ConfigView.tsx
@@ -39,10 +39,12 @@ type BulkEditState = {
   artist: string;
   album: string;
   year: string;
+  genre: string;
   commonTitle: string | undefined;
   commonArtist: string | undefined;
   commonAlbum: string | undefined;
   commonYear: string | undefined;
+  commonGenre: string | undefined;
 };
 
 function computeCommonField(tracks: Track[], getter: (t: Track) => string | undefined): string | undefined {
@@ -156,7 +158,8 @@ export function ConfigView({
       title: track.tags.title ?? "",
       artist: track.tags.artist ?? "",
       album: track.tags.album ?? "",
-      year: track.tags.year != null ? String(track.tags.year) : ""
+      year: track.tags.year != null ? String(track.tags.year) : "",
+      genre: track.tags.genre?.join(", ") ?? ""
     });
   }
 
@@ -179,11 +182,17 @@ export function ConfigView({
       const yearValue = editState.year.trim();
       const parsedYear = yearValue ? Number(yearValue) : null;
 
+      const genreValue = editState.genre.trim();
+      const parsedGenre: string[] | null = genreValue
+        ? genreValue.split(",").map((g) => g.trim()).filter(Boolean)
+        : null;
+
       await onUpdateTrackMetadata(editState.track.id, {
         title: editState.title.trim() || null,
         artist: editState.artist.trim() || null,
         album: editState.album.trim() || null,
-        year: Number.isInteger(parsedYear) ? parsedYear : parsedYear === null ? null : undefined
+        year: Number.isInteger(parsedYear) ? parsedYear : parsedYear === null ? null : undefined,
+        genre: parsedGenre && parsedGenre.length > 0 ? parsedGenre : parsedGenre === null ? null : undefined
       });
       setEditState(null);
     } catch (error) {
@@ -237,6 +246,7 @@ export function ConfigView({
     const commonArtist = computeCommonField(selected, (t) => t.tags.artist);
     const commonAlbum = computeCommonField(selected, (t) => t.tags.album);
     const commonYear = computeCommonField(selected, (t) => t.tags.year != null ? String(t.tags.year) : undefined);
+    const commonGenre = computeCommonField(selected, (t) => t.tags.genre?.join(", "));
 
     setBulkEditState({
       trackIds: selected.map((t) => t.id),
@@ -244,10 +254,12 @@ export function ConfigView({
       artist: commonArtist ?? "",
       album: commonAlbum ?? "",
       year: commonYear ?? "",
+      genre: commonGenre ?? "",
       commonTitle,
       commonArtist,
       commonAlbum,
-      commonYear
+      commonYear,
+      commonGenre
     });
   }
 
@@ -270,8 +282,14 @@ export function ConfigView({
       const parsedYear = yearValue ? Number(yearValue) : null;
       patch.year = Number.isInteger(parsedYear) ? parsedYear : parsedYear === null ? null : undefined;
     }
+    if (bulkEditState.genre !== (bulkEditState.commonGenre ?? "")) {
+      const genreValue = bulkEditState.genre.trim();
+      patch.genre = genreValue
+        ? genreValue.split(",").map((g) => g.trim()).filter(Boolean)
+        : null;
+    }
 
-    const hasChanges = "title" in patch || "artist" in patch || "album" in patch || "year" in patch;
+    const hasChanges = "title" in patch || "artist" in patch || "album" in patch || "year" in patch || "genre" in patch;
     if (!hasChanges) {
       setBulkEditState(null);
       return;
@@ -684,6 +702,18 @@ export function ConfigView({
                 placeholder={bulkEditState.commonYear === undefined ? "Mixed values" : "e.g. 1979"}
                 onChange={(e) => setBulkEditState((s) => s ? { ...s, year: e.target.value } : s)}
               />
+            </label>
+
+            <label className="mt-3 block text-sm text-flaque-ink">
+              Genre
+              <input
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                type="text"
+                value={bulkEditState.genre}
+                placeholder={bulkEditState.commonGenre === undefined ? "Mixed values" : "e.g. Rock, Progressive Rock"}
+                onChange={(e) => setBulkEditState((s) => s ? { ...s, genre: e.target.value } : s)}
+              />
+              <span className="mt-0.5 block text-xs text-flaque-steel">Comma-separated</span>
             </label>
 
             <p className="mt-3 text-xs text-flaque-steel">

--- a/frontend/src/components/ConfigView.tsx
+++ b/frontend/src/components/ConfigView.tsx
@@ -27,7 +27,7 @@ export type ConfigViewProps = {
   onSectionChange: (section: ConfigSection) => void;
 };
 
-export type ConfigSection = "index" | "files" | "users" | "server" | "backup";
+export type ConfigSection = "index" | "files" | "users" | "server" | "backup" | "library";
 
 function normalizeSearch(value: string): string {
   return value.trim().toLowerCase();

--- a/frontend/src/components/ForYouPlaylistDetailView.tsx
+++ b/frontend/src/components/ForYouPlaylistDetailView.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { coverUrl, getForYouPlaylistDetail } from "../api";
+import type { ForYouPlaylistDetail, Playlist, Track } from "../types";
+import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+
+type ForYouPlaylistDetailViewProps = {
+  playlistId: string;
+  allTracksById: Map<string, Track>;
+  onBack: () => void;
+  onPlayTrack: (playlist: Playlist) => void;
+  onDismiss: (playlistId: string) => Promise<void>;
+};
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+export function ForYouPlaylistDetailView({
+  playlistId,
+  allTracksById,
+  onBack,
+  onPlayTrack,
+  onDismiss
+}: ForYouPlaylistDetailViewProps): JSX.Element {
+  const [detail, setDetail] = useState<ForYouPlaylistDetail | null>(null);
+  const [detailTracks, setDetailTracks] = useState<Track[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dismissing, setDismissing] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    getForYouPlaylistDetail(playlistId)
+      .then((result) => {
+        setDetail(result.playlist);
+        setDetailTracks(result.tracks);
+      })
+      .catch(() => {
+        setDetail(null);
+        setDetailTracks([]);
+      })
+      .finally(() => setLoading(false));
+  }, [playlistId]);
+
+  const tracks = useMemo(() => {
+    if (!detail) return detailTracks;
+    return detail.trackIds
+      .map((id) => detailTracks.find((t) => t.id === id) ?? allTracksById.get(id))
+      .filter((t): t is Track => t !== undefined);
+  }, [detail, detailTracks, allTracksById]);
+
+  const totalDuration = useMemo(() => tracks.reduce((sum, t) => sum + t.duration, 0), [tracks]);
+
+  function handlePlayAll(): void {
+    if (!detail || tracks.length === 0) return;
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: tracks.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
+  function handleShufflePlay(): void {
+    if (!detail || tracks.length === 0) return;
+    const shuffled = [...tracks].sort(() => Math.random() - 0.5);
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: shuffled.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
+  async function handleDismiss(): Promise<void> {
+    if (!detail || dismissing) return;
+    setDismissing(true);
+    try {
+      await onDismiss(detail.id);
+      onBack();
+    } finally {
+      setDismissing(false);
+    }
+  }
+
+  const backButton = (
+    <button
+      type="button"
+      className="flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+      onClick={onBack}
+    >
+      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+      </svg>
+      Back to playlists
+    </button>
+  );
+
+  if (loading) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        {backButton}
+        <p className="mt-4 text-sm text-flaque-steel">Loading...</p>
+      </section>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        {backButton}
+        <p className="mt-4 text-sm text-flaque-steel">For-you playlist not found.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="m-4 space-y-4">
+      {backButton}
+
+      {/* Header card */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/80 to-purple-50/60 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-col gap-5 sm:flex-row">
+          {/* Seed artist visual */}
+          <div className="flex h-48 w-48 shrink-0 items-center justify-center self-center overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-100/80 to-purple-100/60 sm:self-start">
+            <div className="text-center px-3">
+              <svg className="mx-auto h-8 w-8 text-indigo-400/70" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                  d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+              </svg>
+              <p className="mt-2 font-display text-lg font-bold text-flaque-ink/70 leading-tight">{detail.seedArtist}</p>
+            </div>
+          </div>
+
+          {/* Info */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <h2 className="font-display text-2xl text-flaque-ink">{detail.name}</h2>
+
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-flaque-steel">
+              <span className="rounded-full bg-indigo-100/70 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-indigo-600/80">
+                Made for you
+              </span>
+              <span>{detail.trackCount} track{detail.trackCount !== 1 ? "s" : ""}</span>
+              {totalDuration > 0 ? <span>{formatDuration(totalDuration)}</span> : null}
+              <span>Generated {new Date(detail.generatedAt).toLocaleDateString()}</span>
+            </div>
+
+            {/* Action buttons */}
+            <div className="mt-auto flex flex-wrap items-center gap-2 pt-4">
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black"
+                onClick={handlePlayAll}
+              >
+                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+                Play all
+              </button>
+
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
+                onClick={handleShufflePlay}
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4" />
+                </svg>
+                Shuffle
+              </button>
+
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl border border-red-200 px-4 py-2 text-sm text-red-500 transition hover:bg-red-50"
+                onClick={() => { void handleDismiss(); }}
+                disabled={dismissing}
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                {dismissing ? "Hiding..." : "Not interested"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Track list */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
+        {tracks.length === 0 ? (
+          <p className="px-5 py-4 text-sm text-flaque-steel">No playable tracks.</p>
+        ) : (
+          <ul>
+            {tracks.map((track, index) => (
+              <li
+                key={track.id}
+                className="flex items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+              >
+                <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
+                <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
+                  <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
+                    {track.tags.extra?.lyrics ? (
+                      <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
+                        L
+                      </span>
+                    ) : null}
+                    <span className="truncate">{getTrackDisplayTitle(track)}</span>
+                  </p>
+                  <p className="truncate text-xs text-flaque-steel">
+                    {getTrackDisplayArtist(track) ?? "Unknown artist"}
+                    {track.tags.album ? ` \u00b7 ${track.tags.album}` : ""}
+                  </p>
+                </div>
+                <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
+                  {formatDuration(track.duration)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/LibraryAlbumsSection.test.tsx
+++ b/frontend/src/components/LibraryAlbumsSection.test.tsx
@@ -174,7 +174,13 @@ describe("LibraryAlbumsSection", () => {
       name: "Workout",
       authorId: "user-1",
       visibility: "private" as const,
-      trackIds: []
+      trackIds: [],
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
     };
     const onTrackSelect = vi.fn();
     const onAddTrackToPlaylist = vi.fn().mockResolvedValue(undefined);

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -35,7 +35,9 @@ const defaultProps = {
   onPatchPlaylist: vi.fn().mockResolvedValue(undefined),
   onDeletePlaylist: vi.fn().mockResolvedValue(undefined),
   onNavigateToPlaylist: vi.fn(),
-  onReportPlaylistListen: vi.fn().mockResolvedValue(undefined)
+  onReportPlaylistListen: vi.fn().mockResolvedValue(undefined),
+  autoPlaylists: [],
+  loadingAutoPlaylists: false
 };
 
 describe("LibraryPlaylistSection", () => {

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -31,8 +31,11 @@ function createPlaylist(input: {
 const defaultProps = {
   manageablePlaylists: [] as Playlist[],
   allTracksById: new Map(),
+  user: { id: "user-1", username: "Alice", email: "alice@test.local", role: "user" as const },
   onPatchPlaylist: vi.fn().mockResolvedValue(undefined),
-  onDeletePlaylist: vi.fn().mockResolvedValue(undefined)
+  onDeletePlaylist: vi.fn().mockResolvedValue(undefined),
+  onNavigateToPlaylist: vi.fn(),
+  onReportPlaylistListen: vi.fn().mockResolvedValue(undefined)
 };
 
 describe("LibraryPlaylistSection", () => {

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -18,7 +18,13 @@ function createPlaylist(input: {
     name: input.name,
     authorId: input.authorId,
     visibility: input.visibility ?? "private",
-    trackIds: input.trackIds ?? []
+    trackIds: input.trackIds ?? [],
+    description: "",
+    cover: null,
+    hearts: [],
+    heartCount: 0,
+    listenCount: 0,
+    collaborators: []
   };
 }
 

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -37,7 +37,10 @@ const defaultProps = {
   onNavigateToPlaylist: vi.fn(),
   onReportPlaylistListen: vi.fn().mockResolvedValue(undefined),
   autoPlaylists: [],
-  loadingAutoPlaylists: false
+  loadingAutoPlaylists: false,
+  forYouPlaylists: [],
+  loadingForYouPlaylists: false,
+  onDismissForYouPlaylist: vi.fn().mockResolvedValue(undefined)
 };
 
 describe("LibraryPlaylistSection", () => {

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -40,7 +40,8 @@ const defaultProps = {
   loadingAutoPlaylists: false,
   forYouPlaylists: [],
   loadingForYouPlaylists: false,
-  onDismissForYouPlaylist: vi.fn().mockResolvedValue(undefined)
+  onDismissForYouPlaylist: vi.fn().mockResolvedValue(undefined),
+  onHeartPlaylist: vi.fn().mockResolvedValue(undefined)
 };
 
 describe("LibraryPlaylistSection", () => {

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useState } from "react";
 
 import { coverUrl, playlistCoverUrl } from "../api";
-import type { Playlist, PlaylistVisibility, Track, User } from "../types";
+import type { AutoPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
 
 type LibraryPlaylistSectionProps = {
   availablePlaylists: Playlist[];
@@ -15,6 +15,8 @@ type LibraryPlaylistSectionProps = {
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onNavigateToPlaylist: (playlistId: string) => void;
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
+  autoPlaylists: AutoPlaylistSummary[];
+  loadingAutoPlaylists: boolean;
 };
 
 // ── Mosaic cover (compact) ─────────────────────────────────────────
@@ -168,7 +170,9 @@ export function LibraryPlaylistSection({
   onPatchPlaylist: _onPatchPlaylist,
   onDeletePlaylist: _onDeletePlaylist,
   onNavigateToPlaylist,
-  onReportPlaylistListen
+  onReportPlaylistListen,
+  autoPlaylists,
+  loadingAutoPlaylists
 }: LibraryPlaylistSectionProps): JSX.Element {
   const [playlistName, setPlaylistName] = useState("");
   const [playlistVisibility, setPlaylistVisibility] = useState<PlaylistVisibility>("private");
@@ -275,12 +279,43 @@ export function LibraryPlaylistSection({
         </section>
       ) : null}
 
-      {/* ── Automatic Playlists (placeholder) ─────────────────────── */}
-      <section className="rounded-xl border border-dashed border-flaque-clay/60 bg-white/60 p-5 backdrop-blur-sm">
+      {/* ── Automatic Playlists ────────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-gradient-to-br from-white/85 to-flaque-cream/40 p-5 shadow-panel backdrop-blur-sm">
         <SectionHeader title="Automatic Playlists" />
-        <p className="mt-2 text-sm text-flaque-steel">
-          Automatic playlists will appear here once generated.
-        </p>
+        {loadingAutoPlaylists ? (
+          <p className="mt-2 text-sm text-flaque-steel">Loading...</p>
+        ) : autoPlaylists.length === 0 ? (
+          <p className="mt-2 text-sm text-flaque-steel">
+            Automatic playlists will appear here once generated.
+          </p>
+        ) : (
+          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            {autoPlaylists.map((ap) => (
+              <div
+                key={ap.id}
+                className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-flaque-ink/5 to-flaque-sand/30 shadow-sm transition hover:shadow-md"
+                onClick={() => onNavigateToPlaylist(ap.id)}
+                role="link"
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === "Enter") onNavigateToPlaylist(ap.id); }}
+              >
+                <div className="flex aspect-square w-full items-center justify-center bg-gradient-to-br from-flaque-sand/40 to-flaque-clay/20">
+                  <div className="text-center">
+                    <p className="font-display text-2xl font-bold text-flaque-ink/70">{ap.decade % 100 === 0 ? ap.decade : `${ap.decade % 100}s`}</p>
+                    <p className="mt-0.5 text-xs font-medium text-flaque-steel">{ap.genre}</p>
+                  </div>
+                </div>
+                <div className="p-3">
+                  <p className="truncate text-sm font-semibold text-flaque-ink">{ap.name}</p>
+                  <p className="mt-0.5 text-xs text-flaque-steel">
+                    {ap.trackCount} track{ap.trackCount !== 1 ? "s" : ""}
+                    {" \u00b7 "}Generated {new Date(ap.generatedAt).toLocaleDateString()}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </section>
     </div>
   );

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -1,26 +1,27 @@
-import { FormEvent, useEffect, useRef, useState } from "react";
+import { FormEvent, useState } from "react";
 
-import { coverUrl } from "../api";
-import type { Playlist, PlaylistVisibility, Track } from "../types";
-import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+import { coverUrl, playlistCoverUrl } from "../api";
+import type { Playlist, PlaylistVisibility, Track, User } from "../types";
 
 type LibraryPlaylistSectionProps = {
   availablePlaylists: Playlist[];
   manageablePlaylists: Playlist[];
   ownerNameById: Record<string, string>;
   allTracksById: Map<string, Track>;
+  user: User;
   onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
   onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
+  onNavigateToPlaylist: (playlistId: string) => void;
+  onReportPlaylistListen: (playlistId: string) => Promise<void>;
 };
 
-// ── Mosaic cover ────────────────────────────────────────────────────
+// ── Mosaic cover (compact) ─────────────────────────────────────────
 
 function getPlaylistMosaicTracks(trackIds: string[], allTracksById: Map<string, Track>): Track[] {
   const seen = new Set<string>();
   const result: Track[] = [];
-
   for (const id of trackIds) {
     if (result.length >= 4) break;
     const track = allTracksById.get(id);
@@ -31,7 +32,6 @@ function getPlaylistMosaicTracks(trackIds: string[], allTracksById: Map<string, 
       result.push(track);
     }
   }
-
   return result;
 }
 
@@ -50,14 +50,8 @@ function PlaylistMosaic({ tracks }: { tracks: Track[] }): JSX.Element {
   }
 
   if (tracks.length === 1) {
-    const track = tracks[0]!;
     return (
-      <img
-        src={coverUrl(track.id)}
-        alt=""
-        className="h-full w-full object-cover"
-        loading="lazy"
-      />
+      <img src={coverUrl(tracks[0]!.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
     );
   }
 
@@ -65,13 +59,7 @@ function PlaylistMosaic({ tracks }: { tracks: Track[] }): JSX.Element {
     <div className="grid h-full w-full grid-cols-2 grid-rows-2">
       {slots.map((track, i) =>
         track ? (
-          <img
-            key={i}
-            src={coverUrl(track.id)}
-            alt=""
-            className="h-full w-full object-cover"
-            loading="lazy"
-          />
+          <img key={i} src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
         ) : (
           <div key={i} className="bg-flaque-clay/20" />
         )
@@ -80,444 +68,117 @@ function PlaylistMosaic({ tracks }: { tracks: Track[] }): JSX.Element {
   );
 }
 
-// ── Dropdown menu ───────────────────────────────────────────────────
-
-type PlaylistMenuProps = {
-  canManage: boolean;
-  onEdit: () => void;
-  onDownload: () => void;
-  onDelete: () => void;
-};
-
-function PlaylistMenu({ canManage, onEdit, onDownload, onDelete }: PlaylistMenuProps): JSX.Element {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent): void {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
-
-  return (
-    <div ref={ref} className="relative">
-      <button
-        type="button"
-        className="flex h-7 w-7 items-center justify-center rounded-lg text-flaque-steel transition hover:bg-flaque-clay/30 hover:text-flaque-ink"
-        onClick={(e) => { e.stopPropagation(); setOpen((v) => !v); }}
-        aria-label="Playlist options"
-      >
-        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
-          <circle cx="10" cy="4" r="1.5" />
-          <circle cx="10" cy="10" r="1.5" />
-          <circle cx="10" cy="16" r="1.5" />
-        </svg>
-      </button>
-
-      {open ? (
-        <div className="absolute bottom-full right-0 z-20 mb-1 min-w-[160px] overflow-hidden rounded-xl border border-flaque-clay/60 bg-white shadow-lg">
-          {canManage ? (
-            <button
-              type="button"
-              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-flaque-ink transition hover:bg-flaque-cream"
-              onClick={(e) => { e.stopPropagation(); setOpen(false); onEdit(); }}
-            >
-              <svg className="h-4 w-4 shrink-0 text-flaque-steel" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-              Edit playlist
-            </button>
-          ) : null}
-          <button
-            type="button"
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-flaque-ink transition hover:bg-flaque-cream"
-            onClick={(e) => { e.stopPropagation(); setOpen(false); onDownload(); }}
-          >
-            <svg className="h-4 w-4 shrink-0 text-flaque-steel" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-            </svg>
-            Download playlist
-          </button>
-          {canManage ? (
-            <button
-              type="button"
-              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-red-600 transition hover:bg-red-50"
-              onClick={(e) => { e.stopPropagation(); setOpen(false); onDelete(); }}
-            >
-              <svg className="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-              Delete playlist
-            </button>
-          ) : null}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-// ── Edit modal ──────────────────────────────────────────────────────
-
-type EditModalProps = {
-  playlist: Playlist;
-  allTracksById: Map<string, Track>;
-  saving: boolean;
-  onSave: (patch: { name?: string; trackIds?: string[] }) => Promise<void>;
-  onClose: () => void;
-};
-
-function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditModalProps): JSX.Element {
-  const [name, setName] = useState(playlist.name);
-  const [trackIds, setTrackIds] = useState<string[]>([...playlist.trackIds]);
-
-  function removeTrack(id: string): void {
-    setTrackIds((prev) => prev.filter((t) => t !== id));
-  }
-
-  function moveTrack(index: number, direction: -1 | 1): void {
-    const next = [...trackIds];
-    const target = index + direction;
-    if (target < 0 || target >= next.length) return;
-    [next[index], next[target]] = [next[target]!, next[index]!];
-    setTrackIds(next);
-  }
-
-  async function handleSubmit(e: FormEvent): Promise<void> {
-    e.preventDefault();
-    await onSave({ name: name.trim() || playlist.name, trackIds });
-  }
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      <div className="flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-flaque-clay/60 bg-white shadow-xl">
-        <div className="flex items-center justify-between border-b border-flaque-clay/30 px-5 py-4">
-          <h3 className="font-display text-lg text-flaque-ink">Edit playlist</h3>
-          <button
-            type="button"
-            className="rounded-lg p-1 text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-
-        <form className="flex flex-1 flex-col overflow-hidden" onSubmit={(e) => { void handleSubmit(e); }}>
-          <div className="px-5 pt-4">
-            <label className="block text-sm font-medium text-flaque-ink">Name</label>
-            <input
-              className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              disabled={saving}
-            />
-          </div>
-
-          <div className="mt-4 flex-1 overflow-y-auto px-5">
-            <p className="text-sm font-medium text-flaque-ink">
-              Tracks <span className="text-flaque-steel">({trackIds.length})</span>
-            </p>
-            {trackIds.length === 0 ? (
-              <p className="mt-2 text-sm text-flaque-steel">No tracks in this playlist.</p>
-            ) : (
-              <ul className="mt-2 space-y-1">
-                {trackIds.map((id, index) => {
-                  const track = allTracksById.get(id);
-                  return (
-                    <li key={id} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-2 py-1.5">
-                      <div className="h-8 w-8 shrink-0 overflow-hidden rounded-md">
-                        {track ? (
-                          <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-                        ) : (
-                          <div className="h-full w-full bg-flaque-clay/30" />
-                        )}
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-xs font-medium text-flaque-ink">
-                          {track ? getTrackDisplayTitle(track) : id}
-                        </p>
-                        {track ? (
-                          <p className="truncate text-[10px] text-flaque-steel">
-                            {getTrackDisplayArtist(track) ?? "Unknown artist"}
-                          </p>
-                        ) : null}
-                      </div>
-                      <div className="flex shrink-0 items-center gap-1">
-                        <button
-                          type="button"
-                          className="rounded p-0.5 text-flaque-steel transition hover:text-flaque-ink disabled:opacity-30"
-                          onClick={() => moveTrack(index, -1)}
-                          disabled={index === 0 || saving}
-                          aria-label="Move up"
-                        >
-                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 15l7-7 7 7" />
-                          </svg>
-                        </button>
-                        <button
-                          type="button"
-                          className="rounded p-0.5 text-flaque-steel transition hover:text-flaque-ink disabled:opacity-30"
-                          onClick={() => moveTrack(index, 1)}
-                          disabled={index === trackIds.length - 1 || saving}
-                          aria-label="Move down"
-                        >
-                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" />
-                          </svg>
-                        </button>
-                        <button
-                          type="button"
-                          className="rounded p-0.5 text-red-400 transition hover:text-red-600 disabled:opacity-30"
-                          onClick={() => removeTrack(id)}
-                          disabled={saving}
-                          aria-label="Remove track"
-                        >
-                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
-                          </svg>
-                        </button>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </div>
-
-          <div className="flex justify-end gap-2 border-t border-flaque-clay/30 px-5 py-4">
-            <button
-              type="button"
-              className="rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-steel transition hover:bg-flaque-cream"
-              onClick={onClose}
-              disabled={saving}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              className="rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-flaque-cream transition hover:bg-black disabled:opacity-60"
-              disabled={saving}
-            >
-              {saving ? "Saving…" : "Save"}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
-
-// ── Playlist card ───────────────────────────────────────────────────
+// ── Playlist card (grid) ───────────────────────────────────────────
 
 type PlaylistCardProps = {
   playlist: Playlist;
-  canManage: boolean;
   allTracksById: Map<string, Track>;
   ownerNameById: Record<string, string>;
+  onNavigate: () => void;
   onPlay: () => void;
-  onPatch: (patch: { name?: string; trackIds?: string[] }) => Promise<void>;
-  onDelete: () => void;
+  showBadges?: boolean;
 };
 
-function formatDuration(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = Math.floor(seconds % 60);
-  if (h > 0) return `${h}h ${m}m`;
-  if (m > 0) return `${m}m ${s}s`;
-  return `${s}s`;
-}
-
-function PlaylistCard({
-  playlist,
-  canManage,
-  allTracksById,
-  ownerNameById,
-  onPlay,
-  onPatch,
-  onDelete
-}: PlaylistCardProps): JSX.Element {
-  const [expanded, setExpanded] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [saving, setSaving] = useState(false);
-
-  const tracks = playlist.trackIds.map((id) => allTracksById.get(id)).filter((t): t is Track => t !== undefined);
+function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPlay, showBadges }: PlaylistCardProps): JSX.Element {
   const mosaicTracks = getPlaylistMosaicTracks(playlist.trackIds, allTracksById);
-  const totalDuration = tracks.reduce((sum, t) => sum + t.duration, 0);
   const owner = ownerNameById[playlist.authorId] ?? playlist.authorId;
 
-  function downloadPlaylist(): void {
-    const data = {
-      id: playlist.id,
-      name: playlist.name,
-      visibility: playlist.visibility,
-      tracks: tracks.map((t) => ({
-        id: t.id,
-        title: getTrackDisplayTitle(t),
-        artist: getTrackDisplayArtist(t),
-        album: t.tags.album,
-        duration: t.duration
-      }))
-    };
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${playlist.name}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
-  }
-
-  async function handleSave(patch: { name?: string; trackIds?: string[] }): Promise<void> {
-    setSaving(true);
-    try {
-      await onPatch(patch);
-      setEditOpen(false);
-    } finally {
-      setSaving(false);
-    }
-  }
-
   return (
-    <>
-      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-sm">
-        {/* Header row — cover + info + buttons */}
-        <div
-          className="flex cursor-pointer items-center gap-3 p-3 transition hover:bg-flaque-cream/50"
-          onClick={() => setExpanded((v) => !v)}
-          role="button"
-          tabIndex={0}
-          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setExpanded((v) => !v); }}
-          aria-expanded={expanded}
+    <div
+      className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-sm transition hover:shadow-md"
+      onClick={onNavigate}
+      role="link"
+      tabIndex={0}
+      onKeyDown={(e) => { if (e.key === "Enter") onNavigate(); }}
+    >
+      {/* Cover */}
+      <div className="relative aspect-square w-full overflow-hidden">
+        {playlist.cover ? (
+          <img src={playlistCoverUrl(playlist.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+        ) : (
+          <PlaylistMosaic tracks={mosaicTracks} />
+        )}
+
+        {/* Play button overlay */}
+        <button
+          type="button"
+          className="absolute bottom-2 right-2 flex h-10 w-10 items-center justify-center rounded-full bg-flaque-ink text-white opacity-0 shadow-lg transition group-hover:opacity-100"
+          onClick={(e) => { e.stopPropagation(); onPlay(); }}
+          aria-label={`Play ${playlist.name}`}
         >
-          {/* Mosaic */}
-          <div className="h-14 w-14 shrink-0 overflow-hidden rounded-xl">
-            <PlaylistMosaic tracks={mosaicTracks} />
-          </div>
+          <svg className="h-5 w-5 translate-x-px" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        </button>
+      </div>
 
-          {/* Info */}
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-semibold text-flaque-ink">{playlist.name}</p>
-            <p className="truncate text-xs text-flaque-steel">
-              {playlist.trackIds.length} track{playlist.trackIds.length !== 1 ? "s" : ""}
-              {totalDuration > 0 ? ` · ${formatDuration(totalDuration)}` : ""}
-              {" · "}{owner}
-            </p>
-          </div>
+      {/* Info */}
+      <div className="flex flex-1 flex-col p-3">
+        <p className="truncate text-sm font-semibold text-flaque-ink">{playlist.name}</p>
+        {playlist.description ? (
+          <p className="mt-0.5 line-clamp-1 text-xs text-flaque-steel">{playlist.description}</p>
+        ) : null}
+        <p className="mt-1 truncate text-xs text-flaque-steel">
+          {owner} &middot; {playlist.trackIds.length} track{playlist.trackIds.length !== 1 ? "s" : ""}
+        </p>
 
-          {/* Actions */}
-          <div className="flex shrink-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
-            <button
-              type="button"
-              className="flex h-8 w-8 items-center justify-center rounded-xl bg-flaque-ink text-white transition hover:bg-black"
-              onClick={onPlay}
-              aria-label={`Play ${playlist.name}`}
-            >
-              <svg className="h-4 w-4 translate-x-px" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M8 5v14l11-7z" />
-              </svg>
-            </button>
-
-            <PlaylistMenu
-              canManage={canManage}
-              onEdit={() => setEditOpen(true)}
-              onDownload={downloadPlaylist}
-              onDelete={onDelete}
-            />
-
-            {/* Chevron */}
-            <svg
-              className={`h-4 w-4 shrink-0 text-flaque-steel/60 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
-              fill="none" viewBox="0 0 24 24" stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg>
-          </div>
-        </div>
-
-        {/* Expanded track list */}
-        {expanded ? (
-          <div className="overflow-hidden rounded-b-2xl border-t border-flaque-clay/30">
-            {tracks.length === 0 ? (
-              <p className="px-4 py-3 text-sm text-flaque-steel">No playable tracks.</p>
-            ) : (
-              <ul>
-                {tracks.map((track, index) => (
-                  <li
-                    key={track.id}
-                    className="flex items-center gap-3 border-b border-flaque-clay/20 px-3 py-2 last:border-b-0"
-                  >
-                    <span className="w-5 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
-                    <div className="h-8 w-8 shrink-0 overflow-hidden rounded-md">
-                      <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <p className="flex items-center gap-1 truncate text-xs font-medium text-flaque-ink">
-                        {track.tags.extra?.lyrics ? (
-                          <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
-                            L
-                          </span>
-                        ) : null}
-                        <span className="truncate">{getTrackDisplayTitle(track)}</span>
-                      </p>
-                      <p className="truncate text-[10px] text-flaque-steel">
-                        {getTrackDisplayArtist(track) ?? "Unknown artist"}
-                        {track.tags.album ? ` · ${track.tags.album}` : ""}
-                      </p>
-                    </div>
-                    <span className="shrink-0 font-mono text-[10px] text-flaque-steel/60">
-                      {formatDuration(track.duration)}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            )}
+        {/* Badges */}
+        {showBadges ? (
+          <div className="mt-1.5 flex items-center gap-2">
+            {playlist.heartCount > 0 ? (
+              <span className="flex items-center gap-0.5 text-[10px] text-red-400">
+                <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                </svg>
+                {playlist.heartCount}
+              </span>
+            ) : null}
+            {playlist.listenCount > 0 ? (
+              <span className="flex items-center gap-0.5 text-[10px] text-flaque-steel">
+                <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                {playlist.listenCount}
+              </span>
+            ) : null}
           </div>
         ) : null}
       </div>
-
-      {editOpen ? (
-        <EditModal
-          playlist={playlist}
-          allTracksById={allTracksById}
-          saving={saving}
-          onSave={handleSave}
-          onClose={() => setEditOpen(false)}
-        />
-      ) : null}
-    </>
+    </div>
   );
 }
 
-// ── Main section ────────────────────────────────────────────────────
+// ── Section header ─────────────────────────────────────────────────
+
+function SectionHeader({ title }: { title: string }): JSX.Element {
+  return <h3 className="font-display text-lg text-flaque-ink">{title}</h3>;
+}
+
+// ── Main section ───────────────────────────────────────────────────
 
 export function LibraryPlaylistSection({
   availablePlaylists,
   manageablePlaylists,
   ownerNameById,
   allTracksById,
+  user,
   onCreatePlaylist,
   onPlayPlaylist,
-  onPatchPlaylist,
-  onDeletePlaylist
+  onPatchPlaylist: _onPatchPlaylist,
+  onDeletePlaylist: _onDeletePlaylist,
+  onNavigateToPlaylist,
+  onReportPlaylistListen
 }: LibraryPlaylistSectionProps): JSX.Element {
   const [playlistName, setPlaylistName] = useState("");
   const [playlistVisibility, setPlaylistVisibility] = useState<PlaylistVisibility>("private");
   const [submitting, setSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
-  const manageableIds = new Set(manageablePlaylists.map((p) => p.id));
+  const myPlaylists = availablePlaylists.filter((p) => p.authorId === user.id);
+  const popularPlaylists = availablePlaylists
+    .filter((p) => p.visibility === "public" && p.authorId !== user.id)
+    .sort((a, b) => (b.heartCount * 3 + b.listenCount) - (a.heartCount * 3 + a.listenCount));
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
@@ -535,58 +196,92 @@ export function LibraryPlaylistSection({
     }
   }
 
+  function handlePlay(playlist: Playlist): void {
+    void onReportPlaylistListen(playlist.id);
+    onPlayPlaylist(playlist);
+  }
+
   return (
-    <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
-      <h2 className="font-display text-xl text-flaque-ink">Playlists</h2>
+    <div className="m-4 space-y-6">
+      {/* ── My Playlists ──────────────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <SectionHeader title="My Playlists" />
 
-      <form
-        className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]"
-        onSubmit={(event) => { void handleSubmit(event); }}
-      >
-        <input
-          className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-          type="text"
-          placeholder="New playlist name"
-          value={playlistName}
-          onChange={(event) => setPlaylistName(event.target.value)}
-        />
-        <select
-          className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-          value={playlistVisibility}
-          onChange={(event) => setPlaylistVisibility(event.target.value as PlaylistVisibility)}
+        <form
+          className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]"
+          onSubmit={(event) => { void handleSubmit(event); }}
         >
-          <option value="private">Private</option>
-          <option value="public">Public</option>
-        </select>
-        <button
-          className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
-          type="submit"
-          disabled={submitting || !playlistName.trim()}
-        >
-          {submitting ? "Creating…" : "Create"}
-        </button>
-      </form>
+          <input
+            className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+            type="text"
+            placeholder="New playlist name"
+            value={playlistName}
+            onChange={(event) => setPlaylistName(event.target.value)}
+          />
+          <select
+            className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+            value={playlistVisibility}
+            onChange={(event) => setPlaylistVisibility(event.target.value as PlaylistVisibility)}
+          >
+            <option value="private">Private</option>
+            <option value="public">Public</option>
+          </select>
+          <button
+            className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+            type="submit"
+            disabled={submitting || !playlistName.trim()}
+          >
+            {submitting ? "Creating..." : "Create"}
+          </button>
+        </form>
 
-      {statusMessage ? <p className="mt-2 text-sm text-flaque-steel">{statusMessage}</p> : null}
+        {statusMessage ? <p className="mt-2 text-sm text-flaque-steel">{statusMessage}</p> : null}
 
-      <div className="mt-4">
-        {availablePlaylists.length === 0 ? (
-          <p className="text-sm text-flaque-steel">No playlists yet.</p>
+        {myPlaylists.length === 0 ? (
+          <p className="mt-4 text-sm text-flaque-steel">No playlists yet.</p>
         ) : (
-          availablePlaylists.map((playlist) => (
-            <PlaylistCard
-              key={playlist.id}
-              playlist={playlist}
-              canManage={manageableIds.has(playlist.id)}
-              allTracksById={allTracksById}
-              ownerNameById={ownerNameById}
-              onPlay={() => onPlayPlaylist(playlist)}
-              onPatch={(patch) => onPatchPlaylist(playlist.id, patch)}
-              onDelete={() => { void onDeletePlaylist(playlist.id); }}
-            />
-          ))
+          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            {myPlaylists.map((playlist) => (
+              <PlaylistCard
+                key={playlist.id}
+                playlist={playlist}
+                allTracksById={allTracksById}
+                ownerNameById={ownerNameById}
+                onNavigate={() => onNavigateToPlaylist(playlist.id)}
+                onPlay={() => handlePlay(playlist)}
+              />
+            ))}
+          </div>
         )}
-      </div>
-    </section>
+      </section>
+
+      {/* ── Popular Playlists ─────────────────────────────────────── */}
+      {popularPlaylists.length > 0 ? (
+        <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+          <SectionHeader title="Popular Playlists" />
+          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            {popularPlaylists.map((playlist) => (
+              <PlaylistCard
+                key={playlist.id}
+                playlist={playlist}
+                allTracksById={allTracksById}
+                ownerNameById={ownerNameById}
+                onNavigate={() => onNavigateToPlaylist(playlist.id)}
+                onPlay={() => handlePlay(playlist)}
+                showBadges
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {/* ── Automatic Playlists (placeholder) ─────────────────────── */}
+      <section className="rounded-xl border border-dashed border-flaque-clay/60 bg-white/60 p-5 backdrop-blur-sm">
+        <SectionHeader title="Automatic Playlists" />
+        <p className="mt-2 text-sm text-flaque-steel">
+          Automatic playlists will appear here once generated.
+        </p>
+      </section>
+    </div>
   );
 }

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useState } from "react";
 
 import { coverUrl, playlistCoverUrl } from "../api";
-import type { AutoPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
+import type { AutoPlaylistSummary, ForYouPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
 
 type LibraryPlaylistSectionProps = {
   availablePlaylists: Playlist[];
@@ -17,6 +17,9 @@ type LibraryPlaylistSectionProps = {
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
   autoPlaylists: AutoPlaylistSummary[];
   loadingAutoPlaylists: boolean;
+  forYouPlaylists: ForYouPlaylistSummary[];
+  loadingForYouPlaylists: boolean;
+  onDismissForYouPlaylist: (playlistId: string) => Promise<void>;
 };
 
 // ── Mosaic cover (compact) ─────────────────────────────────────────
@@ -172,7 +175,10 @@ export function LibraryPlaylistSection({
   onNavigateToPlaylist,
   onReportPlaylistListen,
   autoPlaylists,
-  loadingAutoPlaylists
+  loadingAutoPlaylists,
+  forYouPlaylists,
+  loadingForYouPlaylists,
+  onDismissForYouPlaylist
 }: LibraryPlaylistSectionProps): JSX.Element {
   const [playlistName, setPlaylistName] = useState("");
   const [playlistVisibility, setPlaylistVisibility] = useState<PlaylistVisibility>("private");
@@ -258,6 +264,56 @@ export function LibraryPlaylistSection({
           </div>
         )}
       </section>
+
+      {/* ── Made For You ────────────────────────────────────────── */}
+      {!loadingForYouPlaylists && forYouPlaylists.length > 0 ? (
+        <section className="rounded-xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/60 to-purple-50/40 p-5 shadow-panel backdrop-blur-sm">
+          <SectionHeader title="Made for you" />
+          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            {forYouPlaylists.map((fy) => (
+              <div
+                key={fy.id}
+                className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/80 to-purple-50/60 shadow-sm transition hover:shadow-md"
+                onClick={() => onNavigateToPlaylist(fy.id)}
+                role="link"
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === "Enter") onNavigateToPlaylist(fy.id); }}
+              >
+                <div className="flex aspect-square w-full items-center justify-center bg-gradient-to-br from-indigo-100/60 to-purple-100/40">
+                  <div className="text-center px-3">
+                    <svg className="mx-auto h-8 w-8 text-indigo-400/60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                        d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                    </svg>
+                    <p className="mt-1 font-display text-sm font-bold text-flaque-ink/70 leading-tight">{fy.seedArtist}</p>
+                  </div>
+                </div>
+                <div className="p-3">
+                  <p className="truncate text-sm font-semibold text-flaque-ink">{fy.name}</p>
+                  <p className="mt-0.5 text-xs text-flaque-steel">
+                    {fy.trackCount} track{fy.trackCount !== 1 ? "s" : ""}
+                  </p>
+                </div>
+
+                {/* Dismiss button */}
+                <button
+                  type="button"
+                  className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-flaque-steel opacity-0 shadow-sm transition hover:bg-white hover:text-red-500 group-hover:opacity-100"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void onDismissForYouPlaylist(fy.id);
+                  }}
+                  aria-label={`Hide ${fy.name}`}
+                >
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       {/* ── Popular Playlists ─────────────────────────────────────── */}
       {popularPlaylists.length > 0 ? (

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -9,11 +9,12 @@ type LibraryPlaylistSectionProps = {
   ownerNameById: Record<string, string>;
   allTracksById: Map<string, Track>;
   user: User;
-  onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility }) => Promise<void>;
+  onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
-  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
+  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onNavigateToPlaylist: (playlistId: string) => void;
+  onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
   autoPlaylists: AutoPlaylistSummary[];
   loadingAutoPlaylists: boolean;
@@ -82,9 +83,11 @@ type PlaylistCardProps = {
   onNavigate: () => void;
   onPlay: () => void;
   showBadges?: boolean;
+  onHeart?: () => void;
+  hasHearted?: boolean;
 };
 
-function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPlay, showBadges }: PlaylistCardProps): JSX.Element {
+function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPlay, showBadges, onHeart, hasHearted }: PlaylistCardProps): JSX.Element {
   const mosaicTracks = getPlaylistMosaicTracks(playlist.trackIds, allTracksById);
   const owner = ownerNameById[playlist.authorId] ?? playlist.authorId;
 
@@ -130,7 +133,21 @@ function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPl
         {/* Badges */}
         {showBadges ? (
           <div className="mt-1.5 flex items-center gap-2">
-            {playlist.heartCount > 0 ? (
+            {onHeart ? (
+              <button
+                type="button"
+                className={`flex items-center gap-0.5 text-[10px] transition ${
+                  hasHearted ? "text-red-500 hover:text-red-600" : "text-flaque-steel hover:text-red-400"
+                }`}
+                onClick={(e) => { e.stopPropagation(); onHeart(); }}
+                aria-label={hasHearted ? "Remove heart" : "Heart playlist"}
+              >
+                <svg className="h-3 w-3" fill={hasHearted ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                </svg>
+                {playlist.heartCount > 0 ? playlist.heartCount : ""}
+              </button>
+            ) : playlist.heartCount > 0 ? (
               <span className="flex items-center gap-0.5 text-[10px] text-red-400">
                 <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
@@ -173,6 +190,7 @@ export function LibraryPlaylistSection({
   onPatchPlaylist: _onPatchPlaylist,
   onDeletePlaylist: _onDeletePlaylist,
   onNavigateToPlaylist,
+  onHeartPlaylist,
   onReportPlaylistListen,
   autoPlaylists,
   loadingAutoPlaylists,
@@ -181,6 +199,7 @@ export function LibraryPlaylistSection({
   onDismissForYouPlaylist
 }: LibraryPlaylistSectionProps): JSX.Element {
   const [playlistName, setPlaylistName] = useState("");
+  const [playlistDescription, setPlaylistDescription] = useState("");
   const [playlistVisibility, setPlaylistVisibility] = useState<PlaylistVisibility>("private");
   const [submitting, setSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -196,8 +215,13 @@ export function LibraryPlaylistSection({
     setSubmitting(true);
     setStatusMessage(null);
     try {
-      await onCreatePlaylist({ name: playlistName, visibility: playlistVisibility });
+      await onCreatePlaylist({
+        name: playlistName,
+        visibility: playlistVisibility,
+        description: playlistDescription.trim() || undefined
+      });
       setPlaylistName("");
+      setPlaylistDescription("");
       setStatusMessage("Playlist created.");
     } catch (error) {
       setStatusMessage(error instanceof Error ? error.message : "Unable to create playlist");
@@ -218,31 +242,42 @@ export function LibraryPlaylistSection({
         <SectionHeader title="My Playlists" />
 
         <form
-          className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]"
+          className="mt-4 space-y-3"
           onSubmit={(event) => { void handleSubmit(event); }}
         >
-          <input
-            className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-            type="text"
-            placeholder="New playlist name"
-            value={playlistName}
-            onChange={(event) => setPlaylistName(event.target.value)}
-          />
-          <select
-            className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-            value={playlistVisibility}
-            onChange={(event) => setPlaylistVisibility(event.target.value as PlaylistVisibility)}
-          >
-            <option value="private">Private</option>
-            <option value="public">Public</option>
-          </select>
-          <button
-            className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
-            type="submit"
-            disabled={submitting || !playlistName.trim()}
-          >
-            {submitting ? "Creating..." : "Create"}
-          </button>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]">
+            <input
+              className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              type="text"
+              placeholder="New playlist name"
+              value={playlistName}
+              onChange={(event) => setPlaylistName(event.target.value)}
+            />
+            <select
+              className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              value={playlistVisibility}
+              onChange={(event) => setPlaylistVisibility(event.target.value as PlaylistVisibility)}
+            >
+              <option value="private">Private</option>
+              <option value="public">Public</option>
+            </select>
+            <button
+              className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+              type="submit"
+              disabled={submitting || !playlistName.trim()}
+            >
+              {submitting ? "Creating..." : "Create"}
+            </button>
+          </div>
+          {playlistName.trim() ? (
+            <textarea
+              className="w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              rows={2}
+              placeholder="Description (optional)"
+              value={playlistDescription}
+              onChange={(event) => setPlaylistDescription(event.target.value)}
+            />
+          ) : null}
         </form>
 
         {statusMessage ? <p className="mt-2 text-sm text-flaque-steel">{statusMessage}</p> : null}
@@ -329,6 +364,8 @@ export function LibraryPlaylistSection({
                 onNavigate={() => onNavigateToPlaylist(playlist.id)}
                 onPlay={() => handlePlay(playlist)}
                 showBadges
+                onHeart={() => { void onHeartPlaylist(playlist.id); }}
+                hasHearted={playlist.hearts.includes(user.id)}
               />
             ))}
           </div>

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -3,9 +3,10 @@ import { LibraryAlbumsSection } from "./LibraryAlbumsSection";
 import { LibraryArtistsSection } from "./LibraryArtistsSection";
 import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
 import { AutoPlaylistDetailView } from "./AutoPlaylistDetailView";
+import { ForYouPlaylistDetailView } from "./ForYouPlaylistDetailView";
 import { PlaylistDetailView } from "./PlaylistDetailView";
 import { PaginatedLibrary } from "./PaginatedLibrary";
-import type { AlbumEntry, ArtistEntry, AutoPlaylistSummary, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
+import type { AlbumEntry, ArtistEntry, AutoPlaylistSummary, ForYouPlaylistSummary, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
 import type { LibraryFilters, LibrarySection } from "../types/library";
 import { navigateTo } from "../utils/appUtils";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
@@ -26,6 +27,9 @@ type LibraryWorkspaceProps = {
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
   autoPlaylists: AutoPlaylistSummary[];
   loadingAutoPlaylists: boolean;
+  forYouPlaylists: ForYouPlaylistSummary[];
+  loadingForYouPlaylists: boolean;
+  onDismissForYouPlaylist: (playlistId: string) => Promise<void>;
   allTracksById: Map<string, Track>;
   libraryMetadataError: string | null;
   loadingLibraryArtists: boolean;
@@ -99,6 +103,9 @@ export function LibraryWorkspace({
   onReportPlaylistListen,
   autoPlaylists,
   loadingAutoPlaylists,
+  forYouPlaylists,
+  loadingForYouPlaylists,
+  onDismissForYouPlaylist,
   allTracksById,
   libraryMetadataError,
   loadingLibraryArtists,
@@ -153,7 +160,15 @@ export function LibraryWorkspace({
   return (
     <div className="h-full min-h-0 space-y-4 overflow-y-auto">
       {activeLibrarySection === "playlists" ? (
-        playlistDetailId && playlistDetailId.startsWith("auto:") ? (
+        playlistDetailId && playlistDetailId.startsWith("for-you:") ? (
+          <ForYouPlaylistDetailView
+            playlistId={playlistDetailId}
+            allTracksById={allTracksById}
+            onBack={() => onPlaylistDetailNavigate(null)}
+            onPlayTrack={onPlayPlaylist}
+            onDismiss={onDismissForYouPlaylist}
+          />
+        ) : playlistDetailId && playlistDetailId.startsWith("auto:") ? (
           <AutoPlaylistDetailView
             playlistId={playlistDetailId}
             allTracksById={allTracksById}
@@ -190,6 +205,9 @@ export function LibraryWorkspace({
             onReportPlaylistListen={onReportPlaylistListen}
             autoPlaylists={autoPlaylists}
             loadingAutoPlaylists={loadingAutoPlaylists}
+            forYouPlaylists={forYouPlaylists}
+            loadingForYouPlaylists={loadingForYouPlaylists}
+            onDismissForYouPlaylist={onDismissForYouPlaylist}
           />
         )
       ) : null}

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -2,8 +2,9 @@ import { HomePanels } from "./HomePanels";
 import { LibraryAlbumsSection } from "./LibraryAlbumsSection";
 import { LibraryArtistsSection } from "./LibraryArtistsSection";
 import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
+import { PlaylistDetailView } from "./PlaylistDetailView";
 import { PaginatedLibrary } from "./PaginatedLibrary";
-import type { AlbumEntry, ArtistEntry, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track } from "../types";
+import type { AlbumEntry, ArtistEntry, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
 import type { LibraryFilters, LibrarySection } from "../types/library";
 import { navigateTo } from "../utils/appUtils";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
@@ -13,10 +14,15 @@ type LibraryWorkspaceProps = {
   onSectionChange: (section: LibrarySection) => void;
   availablePlaylists: Playlist[];
   ownerNameById: Record<string, string>;
+  user: User;
+  playlistDetailId: string | null;
+  onPlaylistDetailNavigate: (id: string | null) => void;
   onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
   onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
+  onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
+  onReportPlaylistListen: (playlistId: string) => Promise<void>;
   allTracksById: Map<string, Track>;
   libraryMetadataError: string | null;
   loadingLibraryArtists: boolean;
@@ -79,10 +85,15 @@ export function LibraryWorkspace({
   onSectionChange,
   availablePlaylists,
   ownerNameById,
+  user,
+  playlistDetailId,
+  onPlaylistDetailNavigate,
   onCreatePlaylist,
   onPlayPlaylist,
   onPatchPlaylist,
   onDeletePlaylist,
+  onHeartPlaylist,
+  onReportPlaylistListen,
   allTracksById,
   libraryMetadataError,
   loadingLibraryArtists,
@@ -137,16 +148,36 @@ export function LibraryWorkspace({
   return (
     <div className="h-full min-h-0 space-y-4 overflow-y-auto">
       {activeLibrarySection === "playlists" ? (
-        <LibraryPlaylistSection
-          availablePlaylists={availablePlaylists}
-          manageablePlaylists={manageablePlaylists}
-          ownerNameById={ownerNameById}
-          allTracksById={allTracksById}
-          onCreatePlaylist={onCreatePlaylist}
-          onPlayPlaylist={onPlayPlaylist}
-          onPatchPlaylist={onPatchPlaylist}
-          onDeletePlaylist={onDeletePlaylist}
-        />
+        playlistDetailId ? (
+          <PlaylistDetailView
+            playlistId={playlistDetailId}
+            availablePlaylists={availablePlaylists}
+            manageablePlaylists={manageablePlaylists}
+            allTracksById={allTracksById}
+            ownerNameById={ownerNameById}
+            user={user}
+            onBack={() => onPlaylistDetailNavigate(null)}
+            onPlay={onPlayPlaylist}
+            onPatch={onPatchPlaylist}
+            onDelete={onDeletePlaylist}
+            onHeart={onHeartPlaylist}
+            onReportListen={onReportPlaylistListen}
+          />
+        ) : (
+          <LibraryPlaylistSection
+            availablePlaylists={availablePlaylists}
+            manageablePlaylists={manageablePlaylists}
+            ownerNameById={ownerNameById}
+            allTracksById={allTracksById}
+            user={user}
+            onCreatePlaylist={onCreatePlaylist}
+            onPlayPlaylist={onPlayPlaylist}
+            onPatchPlaylist={onPatchPlaylist}
+            onDeletePlaylist={onDeletePlaylist}
+            onNavigateToPlaylist={onPlaylistDetailNavigate}
+            onReportPlaylistListen={onReportPlaylistListen}
+          />
+        )
       ) : null}
 
       {activeLibrarySection === "artists" ? (

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -19,9 +19,9 @@ type LibraryWorkspaceProps = {
   user: User;
   playlistDetailId: string | null;
   onPlaylistDetailNavigate: (id: string | null) => void;
-  onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility }) => Promise<void>;
+  onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
-  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
+  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
@@ -202,6 +202,7 @@ export function LibraryWorkspace({
             onPatchPlaylist={onPatchPlaylist}
             onDeletePlaylist={onDeletePlaylist}
             onNavigateToPlaylist={onPlaylistDetailNavigate}
+            onHeartPlaylist={onHeartPlaylist}
             onReportPlaylistListen={onReportPlaylistListen}
             autoPlaylists={autoPlaylists}
             loadingAutoPlaylists={loadingAutoPlaylists}

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -2,9 +2,10 @@ import { HomePanels } from "./HomePanels";
 import { LibraryAlbumsSection } from "./LibraryAlbumsSection";
 import { LibraryArtistsSection } from "./LibraryArtistsSection";
 import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
+import { AutoPlaylistDetailView } from "./AutoPlaylistDetailView";
 import { PlaylistDetailView } from "./PlaylistDetailView";
 import { PaginatedLibrary } from "./PaginatedLibrary";
-import type { AlbumEntry, ArtistEntry, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
+import type { AlbumEntry, ArtistEntry, AutoPlaylistSummary, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
 import type { LibraryFilters, LibrarySection } from "../types/library";
 import { navigateTo } from "../utils/appUtils";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
@@ -23,6 +24,8 @@ type LibraryWorkspaceProps = {
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
+  autoPlaylists: AutoPlaylistSummary[];
+  loadingAutoPlaylists: boolean;
   allTracksById: Map<string, Track>;
   libraryMetadataError: string | null;
   loadingLibraryArtists: boolean;
@@ -94,6 +97,8 @@ export function LibraryWorkspace({
   onDeletePlaylist,
   onHeartPlaylist,
   onReportPlaylistListen,
+  autoPlaylists,
+  loadingAutoPlaylists,
   allTracksById,
   libraryMetadataError,
   loadingLibraryArtists,
@@ -148,7 +153,14 @@ export function LibraryWorkspace({
   return (
     <div className="h-full min-h-0 space-y-4 overflow-y-auto">
       {activeLibrarySection === "playlists" ? (
-        playlistDetailId ? (
+        playlistDetailId && playlistDetailId.startsWith("auto:") ? (
+          <AutoPlaylistDetailView
+            playlistId={playlistDetailId}
+            allTracksById={allTracksById}
+            onBack={() => onPlaylistDetailNavigate(null)}
+            onPlayTrack={onPlayPlaylist}
+          />
+        ) : playlistDetailId ? (
           <PlaylistDetailView
             playlistId={playlistDetailId}
             availablePlaylists={availablePlaylists}
@@ -176,6 +188,8 @@ export function LibraryWorkspace({
             onDeletePlaylist={onDeletePlaylist}
             onNavigateToPlaylist={onPlaylistDetailNavigate}
             onReportPlaylistListen={onReportPlaylistListen}
+            autoPlaylists={autoPlaylists}
+            loadingAutoPlaylists={loadingAutoPlaylists}
           />
         )
       ) : null}

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -268,14 +268,18 @@ function EditModal({ playlist, allTracksById, isOwner, saving, onSave, onClose }
 
   async function handleSubmit(e: FormEvent): Promise<void> {
     e.preventDefault();
-    setCoverUploading(true);
-    try {
-      if (coverFile) {
-        await uploadPlaylistCover(playlist.id, coverFile);
-      } else if (coverRemoved && playlist.cover) {
-        await deletePlaylistCover(playlist.id);
+    if (coverFile || (coverRemoved && playlist.cover)) {
+      setCoverUploading(true);
+      try {
+        if (coverFile) {
+          await uploadPlaylistCover(playlist.id, coverFile);
+        } else {
+          await deletePlaylistCover(playlist.id);
+        }
+      } catch {
+        setCoverUploading(false);
+        return;
       }
-    } finally {
       setCoverUploading(false);
     }
     await onSave({

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { type ChangeEvent, FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -17,7 +17,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
-import { coverUrl, playlistCoverUrl } from "../api";
+import { coverUrl, deletePlaylistCover, getUsers, playlistCoverUrl, uploadPlaylistCover } from "../api";
 import type { Playlist, PlaylistVisibility, Track, User } from "../types";
 import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
 
@@ -30,7 +30,7 @@ type PlaylistDetailViewProps = {
   user: User;
   onBack: () => void;
   onPlay: (playlist: Playlist) => void;
-  onPatch: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string }) => Promise<void>;
+  onPatch: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   onDelete: (playlistId: string) => Promise<void>;
   onHeart: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportListen: (playlistId: string) => Promise<void>;
@@ -117,8 +117,9 @@ function PlaylistCover({ playlist, mosaicTracks }: { playlist: Playlist; mosaicT
 type EditModalProps = {
   playlist: Playlist;
   allTracksById: Map<string, Track>;
+  isOwner: boolean;
   saving: boolean;
-  onSave: (patch: { name?: string; trackIds?: string[]; description?: string }) => Promise<void>;
+  onSave: (patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   onClose: () => void;
 };
 
@@ -204,15 +205,51 @@ function SortableTrackItem({
   );
 }
 
-function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditModalProps): JSX.Element {
+function EditModal({ playlist, allTracksById, isOwner, saving, onSave, onClose }: EditModalProps): JSX.Element {
   const [name, setName] = useState(playlist.name);
   const [description, setDescription] = useState(playlist.description);
+  const [visibility, setVisibility] = useState<PlaylistVisibility>(playlist.visibility);
   const [trackIds, setTrackIds] = useState<string[]>([...playlist.trackIds]);
+  const [collaboratorIds, setCollaboratorIds] = useState<string[]>([...playlist.collaborators]);
+  const [allUsers, setAllUsers] = useState<User[]>([]);
+  const [coverPreview, setCoverPreview] = useState<string | null>(null);
+  const [coverFile, setCoverFile] = useState<File | null>(null);
+  const [coverRemoved, setCoverRemoved] = useState(false);
+  const [coverUploading, setCoverUploading] = useState(false);
+  const coverInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOwner) {
+      void getUsers().then(setAllUsers).catch(() => {});
+    }
+  }, [isOwner]);
+
+  const availableCollaborators = useMemo(() =>
+    allUsers.filter((u) => u.id !== playlist.authorId && !collaboratorIds.includes(u.id)),
+    [allUsers, playlist.authorId, collaboratorIds]
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
+
+  function handleCoverSelect(e: ChangeEvent<HTMLInputElement>): void {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setCoverFile(file);
+    setCoverRemoved(false);
+    const url = URL.createObjectURL(file);
+    setCoverPreview(url);
+  }
+
+  function handleCoverRemove(): void {
+    setCoverFile(null);
+    if (coverPreview) URL.revokeObjectURL(coverPreview);
+    setCoverPreview(null);
+    setCoverRemoved(true);
+    if (coverInputRef.current) coverInputRef.current.value = "";
+  }
 
   function removeTrack(id: string): void {
     setTrackIds((prev) => prev.filter((t) => t !== id));
@@ -231,10 +268,22 @@ function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditMod
 
   async function handleSubmit(e: FormEvent): Promise<void> {
     e.preventDefault();
+    setCoverUploading(true);
+    try {
+      if (coverFile) {
+        await uploadPlaylistCover(playlist.id, coverFile);
+      } else if (coverRemoved && playlist.cover) {
+        await deletePlaylistCover(playlist.id);
+      }
+    } finally {
+      setCoverUploading(false);
+    }
     await onSave({
       name: name.trim() || playlist.name,
+      visibility,
       description: description.trim(),
-      trackIds
+      trackIds,
+      collaborators: isOwner ? collaboratorIds : undefined
     });
   }
 
@@ -280,6 +329,110 @@ function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditMod
                 placeholder="Add a description..."
               />
             </div>
+            <div>
+              <label className="block text-sm font-medium text-flaque-ink">Visibility</label>
+              <select
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                value={visibility}
+                onChange={(e) => setVisibility(e.target.value as PlaylistVisibility)}
+                disabled={saving}
+              >
+                <option value="private">Private</option>
+                <option value="public">Public</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-flaque-ink">Cover image</label>
+              <div className="mt-1 flex items-center gap-3">
+                {(coverPreview ?? (!coverRemoved && playlist.cover)) ? (
+                  <img
+                    src={coverPreview ?? playlistCoverUrl(playlist.id)}
+                    alt="Cover preview"
+                    className="h-14 w-14 shrink-0 rounded-lg object-cover"
+                  />
+                ) : (
+                  <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-lg bg-flaque-clay/20">
+                    <svg className="h-6 w-6 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                  </div>
+                )}
+                <div className="flex flex-col gap-1">
+                  <input
+                    ref={coverInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleCoverSelect}
+                    disabled={saving || coverUploading}
+                  />
+                  <button
+                    type="button"
+                    className="rounded-lg border border-flaque-clay px-3 py-1 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+                    onClick={() => coverInputRef.current?.click()}
+                    disabled={saving || coverUploading}
+                  >
+                    {coverFile ? "Change" : "Upload"}
+                  </button>
+                  {(coverPreview ?? (!coverRemoved && playlist.cover)) ? (
+                    <button
+                      type="button"
+                      className="rounded-lg px-3 py-1 text-xs text-red-500 transition hover:text-red-700"
+                      onClick={handleCoverRemove}
+                      disabled={saving || coverUploading}
+                    >
+                      Remove
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+            {isOwner ? (
+              <div>
+                <label className="block text-sm font-medium text-flaque-ink">Collaborators</label>
+                {collaboratorIds.length > 0 ? (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {collaboratorIds.map((collab) => {
+                      const u = allUsers.find((usr) => usr.id === collab);
+                      return (
+                        <span key={collab} className="inline-flex items-center gap-1 rounded-full bg-flaque-cream px-2 py-0.5 text-xs text-flaque-ink">
+                          {u?.username ?? collab}
+                          <button
+                            type="button"
+                            className="text-flaque-steel hover:text-red-500"
+                            onClick={() => setCollaboratorIds((prev) => prev.filter((c) => c !== collab))}
+                            aria-label={`Remove ${u?.username ?? collab}`}
+                          >
+                            <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                          </button>
+                        </span>
+                      );
+                    })}
+                  </div>
+                ) : null}
+                {availableCollaborators.length > 0 ? (
+                  <select
+                    className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                    value=""
+                    onChange={(e) => {
+                      if (e.target.value) setCollaboratorIds((prev) => [...prev, e.target.value]);
+                    }}
+                    disabled={saving}
+                  >
+                    <option value="">Add a collaborator...</option>
+                    {availableCollaborators.map((u) => (
+                      <option key={u.id} value={u.id}>{u.username}</option>
+                    ))}
+                  </select>
+                ) : (
+                  <p className="mt-1 text-xs text-flaque-steel">
+                    {collaboratorIds.length > 0 ? "All users added." : "No other users available."}
+                  </p>
+                )}
+              </div>
+            ) : null}
           </div>
 
           <div className="mt-4 flex-1 overflow-y-auto px-5">
@@ -323,9 +476,9 @@ function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditMod
             <button
               type="submit"
               className="rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-flaque-cream transition hover:bg-black disabled:opacity-60"
-              disabled={saving}
+              disabled={saving || coverUploading}
             >
-              {saving ? "Saving..." : "Save"}
+              {coverUploading ? "Uploading cover..." : saving ? "Saving..." : "Save"}
             </button>
           </div>
         </form>
@@ -443,7 +596,7 @@ export function PlaylistDetailView({
     }
   }
 
-  async function handleSave(patch: { name?: string; trackIds?: string[]; description?: string }): Promise<void> {
+  async function handleSave(patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }): Promise<void> {
     setSaving(true);
     try {
       await onPatch(playlist!.id, patch);
@@ -645,6 +798,7 @@ export function PlaylistDetailView({
         <EditModal
           playlist={playlist}
           allTracksById={allTracksById}
+          isOwner={playlist.authorId === user.id}
           saving={saving}
           onSave={handleSave}
           onClose={() => setEditOpen(false)}

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -1,0 +1,590 @@
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+
+import { coverUrl, playlistCoverUrl } from "../api";
+import type { Playlist, PlaylistVisibility, Track, User } from "../types";
+import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+
+type PlaylistDetailViewProps = {
+  playlistId: string;
+  availablePlaylists: Playlist[];
+  manageablePlaylists: Playlist[];
+  allTracksById: Map<string, Track>;
+  ownerNameById: Record<string, string>;
+  user: User;
+  onBack: () => void;
+  onPlay: (playlist: Playlist) => void;
+  onPatch: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string }) => Promise<void>;
+  onDelete: (playlistId: string) => Promise<void>;
+  onHeart: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
+  onReportListen: (playlistId: string) => Promise<void>;
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+function getPlaylistMosaicTracks(trackIds: string[], allTracksById: Map<string, Track>): Track[] {
+  const seen = new Set<string>();
+  const result: Track[] = [];
+  for (const id of trackIds) {
+    if (result.length >= 4) break;
+    const track = allTracksById.get(id);
+    if (!track) continue;
+    const albumKey = track.tags.album ?? track.id;
+    if (!seen.has(albumKey)) {
+      seen.add(albumKey);
+      result.push(track);
+    }
+  }
+  return result;
+}
+
+// ── Large cover display ────────────────────────────────────────────
+
+function PlaylistCover({ playlist, mosaicTracks }: { playlist: Playlist; mosaicTracks: Track[] }): JSX.Element {
+  if (playlist.cover) {
+    return (
+      <img
+        src={playlistCoverUrl(playlist.id)}
+        alt={playlist.name}
+        className="h-full w-full rounded-2xl object-cover"
+      />
+    );
+  }
+
+  const slots = Array.from({ length: 4 }, (_, i) => mosaicTracks[i] ?? null);
+
+  if (mosaicTracks.length === 0) {
+    return (
+      <div className="flex h-full w-full items-center justify-center rounded-2xl bg-flaque-clay/20">
+        <svg className="h-16 w-16 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+            d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+        </svg>
+      </div>
+    );
+  }
+
+  if (mosaicTracks.length === 1) {
+    return (
+      <img
+        src={coverUrl(mosaicTracks[0]!.id)}
+        alt=""
+        className="h-full w-full rounded-2xl object-cover"
+      />
+    );
+  }
+
+  return (
+    <div className="grid h-full w-full grid-cols-2 grid-rows-2 overflow-hidden rounded-2xl">
+      {slots.map((track, i) =>
+        track ? (
+          <img key={i} src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+        ) : (
+          <div key={i} className="bg-flaque-clay/20" />
+        )
+      )}
+    </div>
+  );
+}
+
+// ── Edit modal ─────────────────────────────────────────────────────
+
+type EditModalProps = {
+  playlist: Playlist;
+  allTracksById: Map<string, Track>;
+  saving: boolean;
+  onSave: (patch: { name?: string; trackIds?: string[]; description?: string }) => Promise<void>;
+  onClose: () => void;
+};
+
+function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditModalProps): JSX.Element {
+  const [name, setName] = useState(playlist.name);
+  const [description, setDescription] = useState(playlist.description);
+  const [trackIds, setTrackIds] = useState<string[]>([...playlist.trackIds]);
+
+  function removeTrack(id: string): void {
+    setTrackIds((prev) => prev.filter((t) => t !== id));
+  }
+
+  function moveTrack(index: number, direction: -1 | 1): void {
+    const next = [...trackIds];
+    const target = index + direction;
+    if (target < 0 || target >= next.length) return;
+    [next[index], next[target]] = [next[target]!, next[index]!];
+    setTrackIds(next);
+  }
+
+  async function handleSubmit(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    await onSave({
+      name: name.trim() || playlist.name,
+      description: description.trim(),
+      trackIds
+    });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-flaque-clay/60 bg-white shadow-xl">
+        <div className="flex items-center justify-between border-b border-flaque-clay/30 px-5 py-4">
+          <h3 className="font-display text-lg text-flaque-ink">Edit playlist</h3>
+          <button
+            type="button"
+            className="rounded-lg p-1 text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <form className="flex flex-1 flex-col overflow-hidden" onSubmit={(e) => { void handleSubmit(e); }}>
+          <div className="space-y-3 px-5 pt-4">
+            <div>
+              <label className="block text-sm font-medium text-flaque-ink">Name</label>
+              <input
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                disabled={saving}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-flaque-ink">Description</label>
+              <textarea
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                rows={3}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                disabled={saving}
+                placeholder="Add a description..."
+              />
+            </div>
+          </div>
+
+          <div className="mt-4 flex-1 overflow-y-auto px-5">
+            <p className="text-sm font-medium text-flaque-ink">
+              Tracks <span className="text-flaque-steel">({trackIds.length})</span>
+            </p>
+            {trackIds.length === 0 ? (
+              <p className="mt-2 text-sm text-flaque-steel">No tracks in this playlist.</p>
+            ) : (
+              <ul className="mt-2 space-y-1">
+                {trackIds.map((id, index) => {
+                  const track = allTracksById.get(id);
+                  return (
+                    <li key={id} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-2 py-1.5">
+                      <div className="h-8 w-8 shrink-0 overflow-hidden rounded-md">
+                        {track ? (
+                          <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+                        ) : (
+                          <div className="h-full w-full bg-flaque-clay/30" />
+                        )}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-xs font-medium text-flaque-ink">
+                          {track ? getTrackDisplayTitle(track) : id}
+                        </p>
+                        {track ? (
+                          <p className="truncate text-[10px] text-flaque-steel">
+                            {getTrackDisplayArtist(track) ?? "Unknown artist"}
+                          </p>
+                        ) : null}
+                      </div>
+                      <div className="flex shrink-0 items-center gap-1">
+                        <button
+                          type="button"
+                          className="rounded p-0.5 text-flaque-steel transition hover:text-flaque-ink disabled:opacity-30"
+                          onClick={() => moveTrack(index, -1)}
+                          disabled={index === 0 || saving}
+                          aria-label="Move up"
+                        >
+                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 15l7-7 7 7" />
+                          </svg>
+                        </button>
+                        <button
+                          type="button"
+                          className="rounded p-0.5 text-flaque-steel transition hover:text-flaque-ink disabled:opacity-30"
+                          onClick={() => moveTrack(index, 1)}
+                          disabled={index === trackIds.length - 1 || saving}
+                          aria-label="Move down"
+                        >
+                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" />
+                          </svg>
+                        </button>
+                        <button
+                          type="button"
+                          className="rounded p-0.5 text-red-400 transition hover:text-red-600 disabled:opacity-30"
+                          onClick={() => removeTrack(id)}
+                          disabled={saving}
+                          aria-label="Remove track"
+                        >
+                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                          </svg>
+                        </button>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 border-t border-flaque-clay/30 px-5 py-4">
+            <button
+              type="button"
+              className="rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-steel transition hover:bg-flaque-cream"
+              onClick={onClose}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-flaque-cream transition hover:bg-black disabled:opacity-60"
+              disabled={saving}
+            >
+              {saving ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────
+
+export function PlaylistDetailView({
+  playlistId,
+  availablePlaylists,
+  manageablePlaylists,
+  allTracksById,
+  ownerNameById,
+  user,
+  onBack,
+  onPlay,
+  onPatch,
+  onDelete,
+  onHeart,
+  onReportListen
+}: PlaylistDetailViewProps): JSX.Element {
+  const playlist = availablePlaylists.find((p) => p.id === playlistId);
+  const [editOpen, setEditOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [hearting, setHearting] = useState(false);
+  const listenReportedRef = useRef(false);
+
+  const canManage = useMemo(() => {
+    if (!playlist) return false;
+    return manageablePlaylists.some((p) => p.id === playlist.id);
+  }, [playlist, manageablePlaylists]);
+
+  const canEdit = useMemo(() => {
+    if (!playlist) return false;
+    return canManage || playlist.collaborators.includes(user.id);
+  }, [playlist, canManage, user.id]);
+
+  const canHeart = useMemo(() => {
+    if (!playlist) return false;
+    return playlist.visibility === "public" && playlist.authorId !== user.id;
+  }, [playlist, user.id]);
+
+  const hasHearted = useMemo(() => {
+    if (!playlist) return false;
+    return playlist.hearts.includes(user.id);
+  }, [playlist, user.id]);
+
+  const tracks = useMemo(() => {
+    if (!playlist) return [];
+    return playlist.trackIds
+      .map((id) => allTracksById.get(id))
+      .filter((t): t is Track => t !== undefined);
+  }, [playlist, allTracksById]);
+
+  const mosaicTracks = useMemo(() => {
+    if (!playlist) return [];
+    return getPlaylistMosaicTracks(playlist.trackIds, allTracksById);
+  }, [playlist, allTracksById]);
+
+  const totalDuration = useMemo(() => tracks.reduce((sum, t) => sum + t.duration, 0), [tracks]);
+  const owner = playlist ? (ownerNameById[playlist.authorId] ?? playlist.authorId) : "";
+
+  useEffect(() => {
+    listenReportedRef.current = false;
+  }, [playlistId]);
+
+  if (!playlist) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <button
+          type="button"
+          className="mb-4 flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+          onClick={onBack}
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to playlists
+        </button>
+        <p className="text-sm text-flaque-steel">Playlist not found.</p>
+      </section>
+    );
+  }
+
+  function handlePlayAll(): void {
+    if (!playlist) return;
+    if (!listenReportedRef.current) {
+      listenReportedRef.current = true;
+      void onReportListen(playlist.id);
+    }
+    onPlay(playlist);
+  }
+
+  function handleShufflePlay(): void {
+    if (!playlist || tracks.length === 0) return;
+    if (!listenReportedRef.current) {
+      listenReportedRef.current = true;
+      void onReportListen(playlist.id);
+    }
+    const shuffled = [...tracks].sort(() => Math.random() - 0.5);
+    const shuffledPlaylist: Playlist = { ...playlist, trackIds: shuffled.map((t) => t.id) };
+    onPlay(shuffledPlaylist);
+  }
+
+  async function handleHeart(): Promise<void> {
+    if (hearting) return;
+    setHearting(true);
+    try {
+      await onHeart(playlist!.id);
+    } finally {
+      setHearting(false);
+    }
+  }
+
+  async function handleSave(patch: { name?: string; trackIds?: string[]; description?: string }): Promise<void> {
+    setSaving(true);
+    try {
+      await onPatch(playlist!.id, patch);
+      setEditOpen(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(): Promise<void> {
+    await onDelete(playlist!.id);
+    onBack();
+  }
+
+  return (
+    <section className="m-4 space-y-4">
+      {/* Back button */}
+      <button
+        type="button"
+        className="flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+        onClick={onBack}
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        Back to playlists
+      </button>
+
+      {/* Header card */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-col gap-5 sm:flex-row">
+          {/* Cover */}
+          <div className="h-48 w-48 shrink-0 self-center overflow-hidden sm:self-start">
+            <PlaylistCover playlist={playlist} mosaicTracks={mosaicTracks} />
+          </div>
+
+          {/* Info */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <div className="flex items-start gap-2">
+              <h2 className="font-display text-2xl text-flaque-ink">{playlist.name}</h2>
+              <span className={`mt-1 shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+                playlist.visibility === "public"
+                  ? "bg-green-100 text-green-700"
+                  : "bg-flaque-clay/30 text-flaque-steel"
+              }`}>
+                {playlist.visibility}
+              </span>
+            </div>
+
+            {playlist.description ? (
+              <p className="mt-1 text-sm text-flaque-steel">{playlist.description}</p>
+            ) : null}
+
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-flaque-steel">
+              <span>by {owner}</span>
+              <span>{playlist.trackIds.length} track{playlist.trackIds.length !== 1 ? "s" : ""}</span>
+              {totalDuration > 0 ? <span>{formatDuration(totalDuration)}</span> : null}
+              {playlist.listenCount > 0 ? (
+                <span className="flex items-center gap-0.5">
+                  <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  {playlist.listenCount}
+                </span>
+              ) : null}
+            </div>
+
+            {playlist.collaborators.length > 0 ? (
+              <div className="mt-2 flex flex-wrap gap-1">
+                <span className="text-xs text-flaque-steel">Collaborators:</span>
+                {playlist.collaborators.map((collab) => (
+                  <span key={collab} className="rounded-full bg-flaque-cream px-2 py-0.5 text-[10px] font-medium text-flaque-ink">
+                    {ownerNameById[collab] ?? collab}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+
+            {/* Action buttons */}
+            <div className="mt-auto flex flex-wrap items-center gap-2 pt-4">
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black"
+                onClick={handlePlayAll}
+              >
+                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+                Play all
+              </button>
+
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
+                onClick={handleShufflePlay}
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4" />
+                </svg>
+                Shuffle
+              </button>
+
+              {canHeart ? (
+                <button
+                  type="button"
+                  className={`flex items-center gap-1 rounded-xl border px-3 py-2 text-sm transition ${
+                    hasHearted
+                      ? "border-red-200 bg-red-50 text-red-600 hover:bg-red-100"
+                      : "border-flaque-clay text-flaque-steel hover:bg-flaque-cream hover:text-flaque-ink"
+                  }`}
+                  onClick={() => { void handleHeart(); }}
+                  disabled={hearting}
+                >
+                  <svg className="h-4 w-4" fill={hasHearted ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                  </svg>
+                  {playlist.heartCount > 0 ? playlist.heartCount : ""}
+                </button>
+              ) : playlist.heartCount > 0 ? (
+                <span className="flex items-center gap-1 text-xs text-flaque-steel">
+                  <svg className="h-3.5 w-3.5 text-red-400" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                  </svg>
+                  {playlist.heartCount}
+                </span>
+              ) : null}
+
+              {canEdit ? (
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-3 py-2 text-sm text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
+                  onClick={() => setEditOpen(true)}
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                  Edit
+                </button>
+              ) : null}
+
+              {canManage ? (
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 rounded-xl border border-red-200 px-3 py-2 text-sm text-red-500 transition hover:bg-red-50 hover:text-red-600"
+                  onClick={() => { void handleDelete(); }}
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                  Delete
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Track list */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
+        {tracks.length === 0 ? (
+          <p className="px-5 py-4 text-sm text-flaque-steel">No playable tracks.</p>
+        ) : (
+          <ul>
+            {tracks.map((track, index) => (
+              <li
+                key={track.id}
+                className="flex items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+              >
+                <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
+                <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
+                  <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
+                    {track.tags.extra?.lyrics ? (
+                      <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
+                        L
+                      </span>
+                    ) : null}
+                    <span className="truncate">{getTrackDisplayTitle(track)}</span>
+                  </p>
+                  <p className="truncate text-xs text-flaque-steel">
+                    {getTrackDisplayArtist(track) ?? "Unknown artist"}
+                    {track.tags.album ? ` \u00b7 ${track.tags.album}` : ""}
+                  </p>
+                </div>
+                <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
+                  {formatDuration(track.duration)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Edit modal */}
+      {editOpen ? (
+        <EditModal
+          playlist={playlist}
+          allTracksById={allTracksById}
+          saving={saving}
+          onSave={handleSave}
+          onClose={() => setEditOpen(false)}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -1,4 +1,21 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 import { coverUrl, playlistCoverUrl } from "../api";
 import type { Playlist, PlaylistVisibility, Track, User } from "../types";
@@ -105,21 +122,111 @@ type EditModalProps = {
   onClose: () => void;
 };
 
+function SortableTrackItem({
+  id,
+  track,
+  saving,
+  onRemove
+}: {
+  id: string;
+  track: Track | undefined;
+  saving: boolean;
+  onRemove: (id: string) => void;
+}): JSX.Element {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : undefined,
+    position: isDragging ? "relative" as const : undefined
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-2 py-1.5 ${
+        isDragging ? "shadow-lg ring-2 ring-flaque-sand/60" : ""
+      }`}
+    >
+      {/* Drag handle */}
+      <button
+        type="button"
+        className="shrink-0 cursor-grab touch-none rounded p-0.5 text-flaque-steel/50 transition hover:text-flaque-ink active:cursor-grabbing"
+        aria-label="Drag to reorder"
+        {...attributes}
+        {...listeners}
+      >
+        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+          <circle cx="9" cy="6" r="1.5" /><circle cx="15" cy="6" r="1.5" />
+          <circle cx="9" cy="12" r="1.5" /><circle cx="15" cy="12" r="1.5" />
+          <circle cx="9" cy="18" r="1.5" /><circle cx="15" cy="18" r="1.5" />
+        </svg>
+      </button>
+
+      <div className="h-8 w-8 shrink-0 overflow-hidden rounded-md">
+        {track ? (
+          <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+        ) : (
+          <div className="h-full w-full bg-flaque-clay/30" />
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-medium text-flaque-ink">
+          {track ? getTrackDisplayTitle(track) : id}
+        </p>
+        {track ? (
+          <p className="truncate text-[10px] text-flaque-steel">
+            {getTrackDisplayArtist(track) ?? "Unknown artist"}
+          </p>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        className="shrink-0 rounded p-0.5 text-red-400 transition hover:text-red-600 disabled:opacity-30"
+        onClick={() => onRemove(id)}
+        disabled={saving}
+        aria-label="Remove track"
+      >
+        <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </li>
+  );
+}
+
 function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditModalProps): JSX.Element {
   const [name, setName] = useState(playlist.name);
   const [description, setDescription] = useState(playlist.description);
   const [trackIds, setTrackIds] = useState<string[]>([...playlist.trackIds]);
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
   function removeTrack(id: string): void {
     setTrackIds((prev) => prev.filter((t) => t !== id));
   }
 
-  function moveTrack(index: number, direction: -1 | 1): void {
-    const next = [...trackIds];
-    const target = index + direction;
-    if (target < 0 || target >= next.length) return;
-    [next[index], next[target]] = [next[target]!, next[index]!];
-    setTrackIds(next);
+  function handleDragEnd(event: DragEndEvent): void {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      setTrackIds((prev) => {
+        const oldIndex = prev.indexOf(active.id as string);
+        const newIndex = prev.indexOf(over.id as string);
+        return arrayMove(prev, oldIndex, newIndex);
+      });
+    }
   }
 
   async function handleSubmit(e: FormEvent): Promise<void> {
@@ -182,67 +289,25 @@ function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditMod
             {trackIds.length === 0 ? (
               <p className="mt-2 text-sm text-flaque-steel">No tracks in this playlist.</p>
             ) : (
-              <ul className="mt-2 space-y-1">
-                {trackIds.map((id, index) => {
-                  const track = allTracksById.get(id);
-                  return (
-                    <li key={id} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-2 py-1.5">
-                      <div className="h-8 w-8 shrink-0 overflow-hidden rounded-md">
-                        {track ? (
-                          <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-                        ) : (
-                          <div className="h-full w-full bg-flaque-clay/30" />
-                        )}
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-xs font-medium text-flaque-ink">
-                          {track ? getTrackDisplayTitle(track) : id}
-                        </p>
-                        {track ? (
-                          <p className="truncate text-[10px] text-flaque-steel">
-                            {getTrackDisplayArtist(track) ?? "Unknown artist"}
-                          </p>
-                        ) : null}
-                      </div>
-                      <div className="flex shrink-0 items-center gap-1">
-                        <button
-                          type="button"
-                          className="rounded p-0.5 text-flaque-steel transition hover:text-flaque-ink disabled:opacity-30"
-                          onClick={() => moveTrack(index, -1)}
-                          disabled={index === 0 || saving}
-                          aria-label="Move up"
-                        >
-                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 15l7-7 7 7" />
-                          </svg>
-                        </button>
-                        <button
-                          type="button"
-                          className="rounded p-0.5 text-flaque-steel transition hover:text-flaque-ink disabled:opacity-30"
-                          onClick={() => moveTrack(index, 1)}
-                          disabled={index === trackIds.length - 1 || saving}
-                          aria-label="Move down"
-                        >
-                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" />
-                          </svg>
-                        </button>
-                        <button
-                          type="button"
-                          className="rounded p-0.5 text-red-400 transition hover:text-red-600 disabled:opacity-30"
-                          onClick={() => removeTrack(id)}
-                          disabled={saving}
-                          aria-label="Remove track"
-                        >
-                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
-                          </svg>
-                        </button>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext items={trackIds} strategy={verticalListSortingStrategy}>
+                  <ul className="mt-2 space-y-1">
+                    {trackIds.map((id) => (
+                      <SortableTrackItem
+                        key={id}
+                        id={id}
+                        track={allTracksById.get(id)}
+                        saving={saving}
+                        onRemove={removeTrack}
+                      />
+                    ))}
+                  </ul>
+                </SortableContext>
+              </DndContext>
             )}
           </div>
 

--- a/frontend/src/components/TrackEditModal.tsx
+++ b/frontend/src/components/TrackEditModal.tsx
@@ -9,6 +9,7 @@ export type EditTrackState = {
   artist: string;
   album: string;
   year: string;
+  genre: string;
 };
 
 type TrackEditModalProps = {
@@ -111,6 +112,27 @@ export function TrackEditModal({
               )
             }
           />
+        </label>
+
+        <label className="mt-3 block text-sm text-flaque-ink">
+          Genre
+          <input
+            className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+            type="text"
+            value={editState.genre}
+            placeholder="e.g. Rock, Progressive Rock"
+            onChange={(event) =>
+              onStateChange((current) =>
+                current
+                  ? {
+                      ...current,
+                      genre: event.target.value
+                    }
+                  : current
+              )
+            }
+          />
+          <span className="mt-0.5 block text-xs text-flaque-steel">Comma-separated</span>
         </label>
 
         <p className="mt-3 text-xs text-flaque-steel">

--- a/frontend/src/components/TrackList.tsx
+++ b/frontend/src/components/TrackList.tsx
@@ -64,6 +64,14 @@ export function TrackList({
     }`;
   }
 
+  function getGenrePillClassName(selected: boolean): string {
+    return `inline-block max-w-[7rem] truncate rounded-full px-1.5 py-px text-[10px] leading-tight ${
+      selected
+        ? "bg-flaque-cream/20 text-flaque-cream/90"
+        : "bg-flaque-ink/8 text-flaque-steel"
+    }`;
+  }
+
   return (
     <>
       <div className="space-y-3 p-4 md:hidden">
@@ -117,6 +125,16 @@ export function TrackList({
                   <p className={`truncate text-xs ${selected ? "text-flaque-cream/75" : "text-flaque-steel/80"}`}>
                     {trackAlbum}
                   </p>
+
+                  {track.tags.genre && track.tags.genre.length > 0 ? (
+                    <span className="mt-1 flex flex-wrap gap-1">
+                      {track.tags.genre.slice(0, 3).map((genre) => (
+                        <span key={genre} className={getGenrePillClassName(selected)} title={genre}>
+                          {genre}
+                        </span>
+                      ))}
+                    </span>
+                  ) : null}
 
                   <span
                     className={`mt-2 flex items-center justify-between text-[11px] uppercase tracking-[0.12em] ${
@@ -216,6 +234,15 @@ export function TrackList({
                         <span className="min-w-0 truncate" title={trackTitle}>
                           {trackTitle}
                         </span>
+                        {track.tags.genre && track.tags.genre.length > 0 ? (
+                          <>
+                            {track.tags.genre.slice(0, 2).map((genre) => (
+                              <span key={genre} className={getGenrePillClassName(selected)} title={genre}>
+                                {genre}
+                              </span>
+                            ))}
+                          </>
+                        ) : null}
                       </span>
                     </td>
                     <td className="px-4 py-3 text-flaque-steel">{trackArtist}</td>

--- a/frontend/src/components/UploadView.tsx
+++ b/frontend/src/components/UploadView.tsx
@@ -15,6 +15,7 @@ type UploadViewProps = {
       artist?: string;
       album?: string;
       year?: number;
+      genre?: string[];
     } | null>;
     onProgress?: (input: { loaded: number; total: number; percent: number }) => void;
   }) => Promise<UploadTracksResult>;
@@ -79,7 +80,7 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
   const [previewByFileKey, setPreviewByFileKey] = useState<Record<string, PreviewState>>({});
   const [editableMetadataByFileKey, setEditableMetadataByFileKey] = useState<
-    Record<string, { title: string; artist: string; album: string; year: string }>
+    Record<string, { title: string; artist: string; album: string; year: string; genre: string }>
   >({});
   const [uploadArtist, setUploadArtist] = useState("");
   const [uploadAlbum, setUploadAlbum] = useState("");
@@ -204,7 +205,11 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
       const yearStr = editedMetadata.year.trim();
       const yearNum = yearStr ? Number(yearStr) : undefined;
       const year = yearNum && Number.isInteger(yearNum) && yearNum >= 1000 && yearNum <= 2999 ? yearNum : undefined;
-      if (!title && !artist && !album && year === undefined) {
+      const genreStr = editedMetadata.genre.trim();
+      const genre = genreStr
+        ? genreStr.split(",").map((g) => g.trim()).filter(Boolean)
+        : undefined;
+      if (!title && !artist && !album && year === undefined && !genre) {
         return null;
       }
 
@@ -212,7 +217,8 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
         title: title || undefined,
         artist: artist || undefined,
         album: album || undefined,
-        year
+        year,
+        genre: genre && genre.length > 0 ? genre : undefined
       };
     });
 
@@ -420,11 +426,13 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
               const year = extractYearFromTags(preview?.tags);
               const albumBase = preview?.tags.album?.trim() || "Unknown album";
               const album = year ? `${albumBase} (${year})` : albumBase;
+              const genreFromTags = preview?.tags.genre?.join(", ") ?? "";
               const editableMetadata = editableMetadataByFileKey[fileKey];
               const editableTitle = editableMetadata?.title ?? title;
               const editableArtist = editableMetadata?.artist ?? artist;
               const editableAlbum = editableMetadata?.album ?? albumBase;
               const editableYear = editableMetadata?.year ?? (year ?? "");
+              const editableGenre = editableMetadata?.genre ?? genreFromTags;
               const trackPosition =
                 typeof preview?.tags.trackNumber === "number"
                   ? `${preview.tags.trackNumber}${
@@ -467,7 +475,8 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
                                     title: nextTitle,
                                     artist: current[fileKey]?.artist ?? editableArtist,
                                     album: current[fileKey]?.album ?? editableAlbum,
-                                    year: current[fileKey]?.year ?? editableYear
+                                    year: current[fileKey]?.year ?? editableYear,
+                                    genre: current[fileKey]?.genre ?? editableGenre
                                   }
                                 }));
                               }}
@@ -487,7 +496,8 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
                                     title: current[fileKey]?.title ?? editableTitle,
                                     artist: nextArtist,
                                     album: current[fileKey]?.album ?? editableAlbum,
-                                    year: current[fileKey]?.year ?? editableYear
+                                    year: current[fileKey]?.year ?? editableYear,
+                                    genre: current[fileKey]?.genre ?? editableGenre
                                   }
                                 }));
                               }}
@@ -507,7 +517,8 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
                                     title: current[fileKey]?.title ?? editableTitle,
                                     artist: current[fileKey]?.artist ?? editableArtist,
                                     album: nextAlbum,
-                                    year: current[fileKey]?.year ?? editableYear
+                                    year: current[fileKey]?.year ?? editableYear,
+                                    genre: current[fileKey]?.genre ?? editableGenre
                                   }
                                 }));
                               }}
@@ -530,11 +541,36 @@ export function UploadView({ onUpload, onInspectFile }: UploadViewProps): JSX.El
                                     title: current[fileKey]?.title ?? editableTitle,
                                     artist: current[fileKey]?.artist ?? editableArtist,
                                     album: current[fileKey]?.album ?? editableAlbum,
-                                    year: nextYear
+                                    year: nextYear,
+                                    genre: current[fileKey]?.genre ?? editableGenre
                                   }
                                 }));
                               }}
                             />
+                          </label>
+
+                          <label className="text-flaque-steel">
+                            Genre
+                            <input
+                              className="mt-1 w-full rounded-lg border border-flaque-clay bg-white px-2 py-1 text-flaque-ink"
+                              value={editableGenre}
+                              disabled={uploading}
+                              placeholder="e.g. Rock, Progressive Rock"
+                              onChange={(event) => {
+                                const nextGenre = event.target.value;
+                                setEditableMetadataByFileKey((current) => ({
+                                  ...current,
+                                  [fileKey]: {
+                                    title: current[fileKey]?.title ?? editableTitle,
+                                    artist: current[fileKey]?.artist ?? editableArtist,
+                                    album: current[fileKey]?.album ?? editableAlbum,
+                                    year: current[fileKey]?.year ?? editableYear,
+                                    genre: nextGenre
+                                  }
+                                }));
+                              }}
+                            />
+                            <span className="mt-0.5 block text-[10px] text-flaque-steel/80">Comma-separated</span>
                           </label>
 
                           <p className="text-xs text-flaque-steel">

--- a/frontend/src/hooks/useAutoPlaylists.ts
+++ b/frontend/src/hooks/useAutoPlaylists.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { getAutoPlaylists } from "../api";
+import type { AutoPlaylistSummary } from "../types";
+
+type UseAutoPlaylistsResult = {
+  autoPlaylists: AutoPlaylistSummary[];
+  loading: boolean;
+  refresh: () => void;
+};
+
+export function useAutoPlaylists(): UseAutoPlaylistsResult {
+  const [autoPlaylists, setAutoPlaylists] = useState<AutoPlaylistSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetch = useCallback(() => {
+    setLoading(true);
+    getAutoPlaylists()
+      .then(setAutoPlaylists)
+      .catch(() => setAutoPlaylists([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { autoPlaylists, loading, refresh: fetch };
+}

--- a/frontend/src/hooks/useForYouPlaylists.ts
+++ b/frontend/src/hooks/useForYouPlaylists.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { getForYouPlaylists, dismissForYouPlaylist as apiDismiss } from "../api";
+import type { ForYouPlaylistSummary } from "../types";
+
+type UseForYouPlaylistsResult = {
+  forYouPlaylists: ForYouPlaylistSummary[];
+  loading: boolean;
+  refresh: () => void;
+  dismiss: (playlistId: string) => Promise<void>;
+};
+
+export function useForYouPlaylists(): UseForYouPlaylistsResult {
+  const [forYouPlaylists, setForYouPlaylists] = useState<ForYouPlaylistSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetch = useCallback(() => {
+    setLoading(true);
+    getForYouPlaylists()
+      .then(setForYouPlaylists)
+      .catch(() => setForYouPlaylists([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  const dismiss = useCallback(async (playlistId: string) => {
+    await apiDismiss(playlistId);
+    setForYouPlaylists((prev) => prev.filter((p) => p.id !== playlistId));
+  }, []);
+
+  return { forYouPlaylists, loading, refresh: fetch, dismiss };
+}

--- a/frontend/src/hooks/useLibraryCommands.ts
+++ b/frontend/src/hooks/useLibraryCommands.ts
@@ -6,8 +6,10 @@ import {
   createPlaylist,
   deletePlaylist,
   deleteTrackFile,
+  heartPlaylist,
   patchPlaylist,
   rebuildIndex,
+  reportPlaylistListen,
   updateTrackMetadata,
   uploadTracks,
   type UploadTrackPreview,
@@ -54,6 +56,8 @@ type UseLibraryCommandsResult = {
   handleDeletePlaylist: (playlistId: string) => Promise<void>;
   handleBulkDeleteTracks: (trackIds: string[]) => Promise<void>;
   handleBulkUpdateTrackMetadata: (trackIds: string[], patch: TrackMetadataPatch) => Promise<void>;
+  handleHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
+  handleReportPlaylistListen: (playlistId: string) => Promise<void>;
 };
 
 /**
@@ -232,6 +236,16 @@ export function useLibraryCommands({
     refreshPaginatedLibrary();
   }
 
+  async function handleHeartPlaylist(playlistId: string): Promise<{ hearted: boolean; heartCount: number }> {
+    const result = await heartPlaylist(playlistId);
+    await refreshCurrentLibrary();
+    return result;
+  }
+
+  async function handleReportPlaylistListen(playlistId: string): Promise<void> {
+    await reportPlaylistListen(playlistId);
+  }
+
   return {
     handleUpload,
     handleInspectUploadFile,
@@ -243,6 +257,8 @@ export function useLibraryCommands({
     handleCreatePlaylist,
     handleAddTrackToPlaylist,
     handlePatchPlaylist,
-    handleDeletePlaylist
+    handleDeletePlaylist,
+    handleHeartPlaylist,
+    handleReportPlaylistListen
   };
 }

--- a/frontend/src/hooks/useLibraryCommands.ts
+++ b/frontend/src/hooks/useLibraryCommands.ts
@@ -50,9 +50,9 @@ type UseLibraryCommandsResult = {
   handleRebuildIndex: () => Promise<void>;
   handleDeleteTrack: (trackId: string) => Promise<void>;
   handleUpdateTrackMetadata: (trackId: string, patch: TrackMetadataPatch) => Promise<void>;
-  handleCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility }) => Promise<void>;
+  handleCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   handleAddTrackToPlaylist: (input: { trackId: string; playlistId: string }) => Promise<void>;
-  handlePatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
+  handlePatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   handleDeletePlaylist: (playlistId: string) => Promise<void>;
   handleBulkDeleteTracks: (trackIds: string[]) => Promise<void>;
   handleBulkUpdateTrackMetadata: (trackIds: string[], patch: TrackMetadataPatch) => Promise<void>;
@@ -160,6 +160,7 @@ export function useLibraryCommands({
   async function handleCreatePlaylist(input: {
     name: string;
     visibility: PlaylistVisibility;
+    description?: string;
   }): Promise<void> {
     await createPlaylist(input);
     setAppNotice({
@@ -201,7 +202,7 @@ export function useLibraryCommands({
 
   async function handlePatchPlaylist(
     playlistId: string,
-    patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }
+    patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }
   ): Promise<void> {
     await patchPlaylist(playlistId, patch);
     await Promise.all([refreshCurrentLibrary(), refreshAllTracks()]);

--- a/frontend/src/hooks/usePlaybackState.ts
+++ b/frontend/src/hooks/usePlaybackState.ts
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
 
+import { reportTrackPlay } from "../api";
 import type { RepeatMode, TranscodeMode } from "../components/AudioPlayer";
 import type { Track, User } from "../types";
 import { isTrackLike, parseStoredQueueSnapshot, readShuffleMode, readTranscodeMode, type StoredQueueSnapshot } from "../utils/appUtils";
@@ -55,6 +56,7 @@ export function usePlaybackState({
   const [shuffleEnabled, setShuffleEnabled] = useState<boolean>(() => readShuffleMode(SHUFFLE_MODE_STORAGE_KEY));
   const [queueRestoredFromStorage, setQueueRestoredFromStorage] = useState(false);
   const [recentTracks, setRecentTracks] = useState<Track[]>([]);
+  const lastPlayReportRef = useRef<{ trackId: string; at: number } | null>(null);
 
   const selectedTrackRefreshed = useMemo(() => {
     if (!selectedTrack) {
@@ -244,6 +246,17 @@ export function usePlaybackState({
       const withoutCurrent = current.filter((entry) => entry.id !== track.id);
       return [track, ...withoutCurrent].slice(0, MAX_RECENT_TRACKS);
     });
+
+    if (track.owner === "radio") return;
+
+    const now = Date.now();
+    const last = lastPlayReportRef.current;
+    const isSameTrack = last?.trackId === track.id;
+    const withinDebounce = isSameTrack && now - last.at < 10_000;
+    if (withinDebounce) return;
+
+    lastPlayReportRef.current = { trackId: track.id, at: now };
+    void reportTrackPlay(track.id).catch(() => {});
   }, []);
 
   const removeTrackFromPlayback = useCallback((trackId: string): void => {

--- a/frontend/src/hooks/useSessionRoutingState.ts
+++ b/frontend/src/hooks/useSessionRoutingState.ts
@@ -25,6 +25,8 @@ type UseSessionRoutingStateResult = {
   setActiveLibrarySection: Dispatch<SetStateAction<LibrarySection>>;
   activeConfigSection: ConfigSection;
   setActiveConfigSection: Dispatch<SetStateAction<ConfigSection>>;
+  playlistDetailId: string | null;
+  setPlaylistDetailId: Dispatch<SetStateAction<string | null>>;
   handleLogin: (login: string, password: string) => Promise<void>;
   notifyAuthStateChanged: (kind: AuthSyncEvent["kind"]) => void;
 };
@@ -52,6 +54,10 @@ export function useSessionRoutingState(): UseSessionRoutingStateResult {
     return route.view === "config" && route.section
       ? (route.section as ConfigSection)
       : "index";
+  });
+  const [playlistDetailId, setPlaylistDetailId] = useState<string | null>(() => {
+    const route = getRouteFromLocation();
+    return route.view === "library" && route.section === "playlists" ? route.param : null;
   });
 
   const sourceIdRef = useRef(createTabId());
@@ -151,6 +157,9 @@ export function useSessionRoutingState(): UseSessionRoutingStateResult {
 
       if (route.view === "library" && route.section) {
         setActiveLibrarySection(route.section as LibrarySection);
+        setPlaylistDetailId(route.section === "playlists" ? route.param : null);
+      } else {
+        setPlaylistDetailId(null);
       }
       if (route.view === "config" && route.section) {
         setActiveConfigSection(route.section as ConfigSection);
@@ -179,8 +188,11 @@ export function useSessionRoutingState(): UseSessionRoutingStateResult {
       : resolvedView === "config"
         ? activeConfigSection
         : null;
-    syncRouteToLocation(resolvedView, section);
-  }, [activeView, activeLibrarySection, activeConfigSection, sessionChecked, user?.role]);
+    const param = resolvedView === "library" && activeLibrarySection === "playlists"
+      ? playlistDetailId
+      : null;
+    syncRouteToLocation(resolvedView, section, param);
+  }, [activeView, activeLibrarySection, activeConfigSection, playlistDetailId, sessionChecked, user?.role]);
 
   async function handleLogin(loginValue: string, password: string): Promise<void> {
     const authenticatedUser = await login(loginValue, password);
@@ -200,6 +212,8 @@ export function useSessionRoutingState(): UseSessionRoutingStateResult {
     setActiveLibrarySection,
     activeConfigSection,
     setActiveConfigSection,
+    playlistDetailId,
+    setPlaylistDetailId,
     handleLogin,
     notifyAuthStateChanged
   };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -159,3 +159,16 @@ export type RadioQueueResponse = {
     trackList: RadioTrack[];
   } | null;
 };
+
+export type AutoPlaylistSummary = {
+  id: string;
+  name: string;
+  genre: string;
+  decade: number;
+  trackCount: number;
+  generatedAt: string;
+};
+
+export type AutoPlaylistDetail = AutoPlaylistSummary & {
+  trackIds: string[];
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -112,6 +112,7 @@ export type TrackMetadataPatch = {
   artist?: string | null;
   album?: string | null;
   year?: number | null;
+  genre?: string[] | null;
 };
 
 export type RadioTrack = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -172,3 +172,15 @@ export type AutoPlaylistSummary = {
 export type AutoPlaylistDetail = AutoPlaylistSummary & {
   trackIds: string[];
 };
+
+export type ForYouPlaylistSummary = {
+  id: string;
+  name: string;
+  seedArtist: string;
+  trackCount: number;
+  generatedAt: string;
+};
+
+export type ForYouPlaylistDetail = ForYouPlaylistSummary & {
+  trackIds: string[];
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -94,6 +94,12 @@ export type Playlist = {
   visibility: PlaylistVisibility;
   trackIds: string[];
   trackCount?: number;
+  description: string;
+  cover: string | null;
+  hearts: string[];
+  heartCount: number;
+  listenCount: number;
+  collaborators: string[];
 };
 
 export type LibraryResponse = {

--- a/frontend/src/utils/appUtils.test.ts
+++ b/frontend/src/utils/appUtils.test.ts
@@ -81,29 +81,37 @@ describe("appUtils", () => {
     expect(buildPathForRoute("upload")).toBe("/upload");
     expect(buildPathForRoute("player")).toBe("/player");
     expect(buildPathForRoute("account")).toBe("/account");
+    expect(buildPathForRoute("library", "playlists", "user-1:my-playlist")).toBe("/library/playlists/user-1%3Amy-playlist");
+    expect(buildPathForRoute("library", "playlists", null)).toBe("/library/playlists");
   });
 
   it("reads route from location pathname", () => {
     window.history.replaceState({}, "", "/settings/server");
-    expect(getRouteFromLocation()).toEqual({ view: "config", section: "server" });
+    expect(getRouteFromLocation()).toEqual({ view: "config", section: "server", param: null });
 
     window.history.replaceState({}, "", "/library/artists");
-    expect(getRouteFromLocation()).toEqual({ view: "library", section: "artists" });
+    expect(getRouteFromLocation()).toEqual({ view: "library", section: "artists", param: null });
 
     window.history.replaceState({}, "", "/upload");
-    expect(getRouteFromLocation()).toEqual({ view: "upload", section: null });
+    expect(getRouteFromLocation()).toEqual({ view: "upload", section: null, param: null });
 
     window.history.replaceState({}, "", "/");
-    expect(getRouteFromLocation()).toEqual({ view: "library", section: "home" });
+    expect(getRouteFromLocation()).toEqual({ view: "library", section: "home", param: null });
 
     window.history.replaceState({}, "", "/unknown-path");
-    expect(getRouteFromLocation()).toEqual({ view: "library", section: "home" });
+    expect(getRouteFromLocation()).toEqual({ view: "library", section: "home", param: null });
+  });
+
+  it("parses playlist detail route with dynamic segment", () => {
+    window.history.replaceState({}, "", "/library/playlists/user-1%3Amy-playlist");
+    const route = getRouteFromLocation();
+    expect(route).toEqual({ view: "library", section: "playlists", param: "user-1:my-playlist" });
   });
 
   it("redirects legacy view query param to path", () => {
     window.history.replaceState({}, "", "/?view=config");
     const route = getRouteFromLocation();
-    expect(route).toEqual({ view: "config", section: "index" });
+    expect(route).toEqual({ view: "config", section: "index", param: null });
     expect(window.location.pathname).toBe("/settings");
     expect(window.location.search).toBe("");
   });

--- a/frontend/src/utils/appUtils.ts
+++ b/frontend/src/utils/appUtils.ts
@@ -6,6 +6,7 @@ export type ViewName = "library" | "upload" | "player" | "config" | "account";
 export type AppRoute = {
   view: ViewName;
   section: string | null;
+  param: string | null;
 };
 
 export type StoredQueueSnapshot = {
@@ -159,32 +160,39 @@ export function getAdjacentTrackInQueue(
 }
 
 const PATH_MAP: Record<string, AppRoute> = {
-  "": { view: "library", section: "home" },
-  "library": { view: "library", section: "home" },
-  "library/home": { view: "library", section: "home" },
-  "library/music": { view: "library", section: "music" },
-  "library/artists": { view: "library", section: "artists" },
-  "library/albums": { view: "library", section: "albums" },
-  "library/playlists": { view: "library", section: "playlists" },
-  "upload": { view: "upload", section: null },
-  "player": { view: "player", section: null },
-  "account": { view: "account", section: null },
-  "settings": { view: "config", section: "index" },
-  "settings/index": { view: "config", section: "index" },
-  "settings/files": { view: "config", section: "files" },
-  "settings/users": { view: "config", section: "users" },
-  "settings/server": { view: "config", section: "server" },
-  "settings/backup": { view: "config", section: "backup" }
+  "": { view: "library", section: "home", param: null },
+  "library": { view: "library", section: "home", param: null },
+  "library/home": { view: "library", section: "home", param: null },
+  "library/music": { view: "library", section: "music", param: null },
+  "library/artists": { view: "library", section: "artists", param: null },
+  "library/albums": { view: "library", section: "albums", param: null },
+  "library/playlists": { view: "library", section: "playlists", param: null },
+  "upload": { view: "upload", section: null, param: null },
+  "player": { view: "player", section: null, param: null },
+  "account": { view: "account", section: null, param: null },
+  "settings": { view: "config", section: "index", param: null },
+  "settings/index": { view: "config", section: "index", param: null },
+  "settings/files": { view: "config", section: "files", param: null },
+  "settings/users": { view: "config", section: "users", param: null },
+  "settings/server": { view: "config", section: "server", param: null },
+  "settings/backup": { view: "config", section: "backup", param: null }
 };
+
+const DYNAMIC_PREFIXES: Array<{ prefix: string; route: Omit<AppRoute, "param"> }> = [
+  { prefix: "library/playlists/", route: { view: "library", section: "playlists" } }
+];
 
 const VALID_VIEWS = new Set<string>(["library", "upload", "player", "config", "account"]);
 
 /**
  * Build a URL path for a given view and optional section.
  */
-export function buildPathForRoute(view: ViewName, section?: string | null): string {
+export function buildPathForRoute(view: ViewName, section?: string | null, param?: string | null): string {
   if (view === "library") {
     const s = section ?? "home";
+    if (s === "playlists" && param) {
+      return `/library/playlists/${encodeURIComponent(param)}`;
+    }
     return s === "home" ? "/" : `/library/${s}`;
   }
   if (view === "config") {
@@ -200,7 +208,7 @@ export function buildPathForRoute(view: ViewName, section?: string | null): stri
  */
 export function getRouteFromLocation(): AppRoute {
   if (typeof window === "undefined") {
-    return { view: "library", section: "home" };
+    return { view: "library", section: "home", param: null };
   }
 
   const params = new URLSearchParams(window.location.search);
@@ -212,24 +220,36 @@ export function getRouteFromLocation(): AppRoute {
     window.history.replaceState(null, "", `${path}${search}${window.location.hash}`);
     return {
       view: legacyView as ViewName,
-      section: legacyView === "config" ? "index" : legacyView === "library" ? "home" : null
+      section: legacyView === "config" ? "index" : legacyView === "library" ? "home" : null,
+      param: null
     };
   }
 
   const raw = window.location.pathname.replace(/^\/+/, "").replace(/\/+$/, "");
-  return PATH_MAP[raw] ?? { view: "library", section: "home" };
+
+  const exact = PATH_MAP[raw];
+  if (exact) return exact;
+
+  for (const { prefix, route } of DYNAMIC_PREFIXES) {
+    if (raw.startsWith(prefix)) {
+      const param = decodeURIComponent(raw.slice(prefix.length));
+      if (param) return { ...route, param };
+    }
+  }
+
+  return { view: "library", section: "home", param: null };
 }
 
 /**
  * Synchronize app route state to the URL pathname via replaceState.
  * Preserves existing query params and hash.
  */
-export function syncRouteToLocation(view: ViewName, section?: string | null): void {
+export function syncRouteToLocation(view: ViewName, section?: string | null, param?: string | null): void {
   if (typeof window === "undefined") {
     return;
   }
 
-  const targetPath = buildPathForRoute(view, section);
+  const targetPath = buildPathForRoute(view, section, param);
   if (window.location.pathname === targetPath) {
     return;
   }
@@ -241,12 +261,12 @@ export function syncRouteToLocation(view: ViewName, section?: string | null): vo
  * Navigate to a route via pushState (adds a history entry for back/forward).
  * Preserves existing query params and hash.
  */
-export function navigateTo(view: ViewName, section?: string | null): void {
+export function navigateTo(view: ViewName, section?: string | null, param?: string | null): void {
   if (typeof window === "undefined") {
     return;
   }
 
-  const targetPath = buildPathForRoute(view, section);
+  const targetPath = buildPathForRoute(view, section, param);
   if (window.location.pathname === targetPath) {
     return;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,9 @@
       "name": "flaque-frontend",
       "version": "0.2.2",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "music-metadata": "^10.9.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -382,6 +385,59 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -5916,7 +5972,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {


### PR DESCRIPTION
## Summary
- **Cover images**: upload/delete UI in playlist edit modal (#129)
- **Visibility toggle**: private/public switch in edit modal (#130)
- **Collaborators**: user picker and management UI in edit modal (#131)
- **Heart/favorite**: interactive toggle on playlist cards with optimistic count (#132)
- **Listening stats**: total plays, top artists, and top tracks in account view (#133)
- **Admin genre synonyms**: add/delete/reset synonym mappings (#134)
- **Admin enrichment**: start/stop MusicBrainz enrichment with cache management (#135)
- **Admin auto-playlists**: configure max playlists, min/tracks per playlist, regenerate (#136)
- **Description field**: textarea in playlist creation form (#137)
- **Listen debounce**: per-user hourly deduplication of play counts (#138)

Tracking issue: #139

## Test plan
- [x] TypeScript compiles cleanly (frontend + backend)
- [x] All 34 frontend tests pass
- [x] Verify cover upload/delete in edit modal
- [x] Verify visibility toggle saves correctly
- [ ] Verify collaborators can be added/removed
- [ ] Verify heart button toggles and count updates
- [ ] Verify listening stats display in account view
- [ ] Verify admin Library tab shows genre synonyms, enrichment, and auto-playlist config
- [ ] Verify description field appears in create form
- [ ] Verify listen count debounce prevents duplicate counts within 1 hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)