### PR TITLE
Add playlist test coverage and fix metadata loss on rename

### DIFF
--- a/backend/src/api/playlistRoutes.test.ts
+++ b/backend/src/api/playlistRoutes.test.ts
@@ -3,8 +3,8 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import type { LibraryIndex, Track } from "../types/library";
-import { apiRequest, getDataRoot, login, setupTestServer, teardownTestServer } from "./testHelpers";
+import type { LibraryIndex, Playlist, Track } from "../types/library";
+import { apiRequest, getBaseUrl, getDataRoot, login, setupTestServer, teardownTestServer } from "./testHelpers";
 
 function createTrack(id: string, relativePath: string): Track {
   return {
@@ -54,32 +54,81 @@ class FakeIndexStore {
   }
 }
 
+function makeFakeIndexStore(tracks: Track[] = []): FakeIndexStore {
+  return new FakeIndexStore({
+    generatedAt: new Date().toISOString(),
+    totalTracks: tracks.length,
+    tracks,
+    playlists: []
+  });
+}
+
+const defaultTracks = [
+  createTrack("track-a", "storage/users/owner-1/uploads/a.mp3"),
+  createTrack("track-b", "storage/users/owner-1/uploads/b.mp3")
+];
+
+async function apiMultipartRequest(input: {
+  pathname: string;
+  cookie: string;
+  fileFieldName: string;
+  fileName: string;
+  mimeType: string;
+  bytes: number[];
+}) {
+  const formData = new FormData();
+  const binary = Uint8Array.from(input.bytes);
+  formData.append(input.fileFieldName, new Blob([binary.buffer as ArrayBuffer], { type: input.mimeType }), input.fileName);
+
+  const response = await fetch(`${getBaseUrl()}${input.pathname}`, {
+    method: "POST",
+    headers: { Cookie: input.cookie },
+    body: formData
+  });
+
+  const text = await response.text();
+  let payload: unknown = undefined;
+  if (text) {
+    try { payload = JSON.parse(text) as unknown; } catch { payload = text; }
+  }
+
+  return { status: response.status, payload };
+}
+
 let indexStore: FakeIndexStore;
 
 beforeEach(async () => {
-  indexStore = new FakeIndexStore({
-    generatedAt: new Date().toISOString(),
-    totalTracks: 0,
-    tracks: [],
-    playlists: []
-  });
+  indexStore = makeFakeIndexStore();
 });
 
 afterEach(async () => {
   await teardownTestServer();
 });
 
+// ── Helper: create a playlist and return its id ────────────────────
+async function createPlaylist(
+  cookie: string,
+  overrides: Record<string, unknown> = {}
+): Promise<{ id: string; playlist: Playlist }> {
+  const body = {
+    name: "Test Playlist",
+    visibility: "public",
+    trackIds: ["track-a", "track-b"],
+    ...overrides
+  };
+  const res = await apiRequest("/api/playlists", {
+    method: "POST",
+    headers: { Cookie: cookie },
+    body: JSON.stringify(body)
+  });
+  expect(res.status).toBe(201);
+  const playlist = (res.payload as { playlist: Playlist }).playlist;
+  return { id: playlist.id, playlist };
+}
+
 describe("playlistRoutes", () => {
   it("supports playlist CRUD with file-based storage", async () => {
-    indexStore = new FakeIndexStore({
-      generatedAt: new Date().toISOString(),
-      totalTracks: 2,
-      tracks: [
-        createTrack("track-a", "storage/users/owner-1/uploads/a.mp3"),
-        createTrack("track-b", "storage/users/owner-1/uploads/b.mp3")
-      ],
-      playlists: []
-    });
+    indexStore = makeFakeIndexStore(defaultTracks);
 
     await setupTestServer({
       tempDirPrefix: "flaque-playlist-routes-",
@@ -177,12 +226,7 @@ describe("playlistRoutes", () => {
   });
 
   it("hides private playlists from other users", async () => {
-    indexStore = new FakeIndexStore({
-      generatedAt: new Date().toISOString(),
-      totalTracks: 1,
-      tracks: [createTrack("track-a", "storage/users/owner-1/uploads/a.mp3")],
-      playlists: []
-    });
+    indexStore = makeFakeIndexStore(defaultTracks);
 
     await setupTestServer({
       tempDirPrefix: "flaque-playlist-routes-",
@@ -224,5 +268,385 @@ describe("playlistRoutes", () => {
       headers: { Cookie: aliceCookie }
     });
     expect(getAsAlice.status).toBe(403);
+  });
+
+  // ── Description ──────────────────────────────────────────────────
+
+  it("creates a playlist with a description", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-desc-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { playlist } = await createPlaylist(cookie, {
+      name: "Described",
+      description: "  A nice playlist  "
+    });
+
+    expect(playlist.description).toBe("A nice playlist");
+  });
+
+  it("patches a playlist description", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-desc-patch-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "Patchable" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { Cookie: cookie },
+      body: JSON.stringify({ description: "  Updated desc  " })
+    });
+    expect(res.status).toBe(200);
+    const updated = (res.payload as { playlist: Playlist }).playlist;
+    expect(updated.description).toBe("Updated desc");
+  });
+
+  it("preserves description when patching other fields", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-desc-preserve-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "DescKeep", description: "Keep me" });
+
+    // Patch only visibility — description should survive
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { Cookie: cookie },
+      body: JSON.stringify({ visibility: "private" })
+    });
+    expect(res.status).toBe(200);
+    const updated = (res.payload as { playlist: Playlist }).playlist;
+    expect(updated.description).toBe("Keep me");
+    expect(updated.visibility).toBe("private");
+  });
+
+  // ── Heart ────────────────────────────────────────────────────────
+
+  it("toggles heart on a public playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-heart-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+    const aliceCookie = await login("alice", "alice-password");
+
+    const { id } = await createPlaylist(adminCookie, { name: "Heartable", visibility: "public" });
+
+    // Heart it
+    const heart1 = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/heart`, {
+      method: "POST",
+      headers: { Cookie: aliceCookie }
+    });
+    expect(heart1.status).toBe(200);
+    expect(heart1.payload).toEqual({ hearted: true, heartCount: 1 });
+
+    // Un-heart it
+    const heart2 = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/heart`, {
+      method: "POST",
+      headers: { Cookie: aliceCookie }
+    });
+    expect(heart2.status).toBe(200);
+    expect(heart2.payload).toEqual({ hearted: false, heartCount: 0 });
+  });
+
+  it("rejects heart on own playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-heart-own-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "Mine", visibility: "public" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/heart`, {
+      method: "POST",
+      headers: { Cookie: cookie }
+    });
+    expect(res.status).toBe(400);
+    expect(res.payload).toEqual(expect.objectContaining({ error: expect.stringContaining("own playlist") }));
+  });
+
+  it("rejects heart on private playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-heart-priv-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+    const aliceCookie = await login("alice", "alice-password");
+
+    const { id } = await createPlaylist(adminCookie, { name: "Private", visibility: "private" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/heart`, {
+      method: "POST",
+      headers: { Cookie: aliceCookie }
+    });
+    expect(res.status).toBe(403);
+  });
+
+  // ── Listen count ─────────────────────────────────────────────────
+
+  it("increments listen count", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-listen-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "Listened" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/listen`, {
+      method: "POST",
+      headers: { Cookie: cookie }
+    });
+    expect(res.status).toBe(200);
+    expect(res.payload).toEqual({ listenCount: 1 });
+
+    // Second call within debounce window should not increment further
+    const res2 = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/listen`, {
+      method: "POST",
+      headers: { Cookie: cookie }
+    });
+    expect(res2.status).toBe(200);
+    expect((res2.payload as { listenCount: number }).listenCount).toBeLessThanOrEqual(1);
+  });
+
+  it("returns 404 for listen on non-existent playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-listen-404-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const res = await apiRequest("/api/playlists/nonexistent:playlist/listen", {
+      method: "POST",
+      headers: { Cookie: cookie }
+    });
+    expect(res.status).toBe(404);
+  });
+
+  // ── Collaborators ────────────────────────────────────────────────
+
+  it("adds collaborators to a playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-collabs-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+
+    // Find alice's user id
+    const usersRes = await apiRequest("/api/users", {
+      method: "GET",
+      headers: { Cookie: adminCookie }
+    });
+    const users = (usersRes.payload as { users: Array<{ id: string; username: string }> }).users;
+    const alice = users.find((u) => u.username === "alice")!;
+
+    const { id } = await createPlaylist(adminCookie, { name: "Collab" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { Cookie: adminCookie },
+      body: JSON.stringify({ collaborators: [alice.id] })
+    });
+    expect(res.status).toBe(200);
+    const updated = (res.payload as { playlist: Playlist }).playlist;
+    expect(updated.collaborators).toEqual([alice.id]);
+  });
+
+  it("rejects invalid collaborator user ids", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-collabs-invalid-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "BadCollab" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { Cookie: cookie },
+      body: JSON.stringify({ collaborators: ["nonexistent-user-id"] })
+    });
+    expect(res.status).toBe(400);
+    expect(res.payload).toEqual(expect.objectContaining({ error: expect.stringContaining("Unknown collaborator") }));
+  });
+
+  // ── Cover ────────────────────────────────────────────────────────
+
+  it("returns 404 for cover on playlist without cover", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-cover-none-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "NoCover" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/cover`, {
+      method: "GET",
+      headers: { Cookie: cookie }
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects cover upload with non-image file", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-cover-bad-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "BadCover" });
+
+    const res = await apiMultipartRequest({
+      pathname: `/api/playlists/${encodeURIComponent(id)}/cover`,
+      cookie,
+      fileFieldName: "cover",
+      fileName: "readme.txt",
+      mimeType: "text/plain",
+      bytes: [72, 101, 108, 108, 111] // "Hello"
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects cover delete on another user's playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-cover-authz-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+    const aliceCookie = await login("alice", "alice-password");
+
+    const { id } = await createPlaylist(adminCookie, { name: "NotYours" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/cover`, {
+      method: "DELETE",
+      headers: { Cookie: aliceCookie }
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("blocks cover GET for private playlist from non-owner", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-cover-view-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+    const aliceCookie = await login("alice", "alice-password");
+
+    const { id } = await createPlaylist(adminCookie, { name: "PrivCover", visibility: "private" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/cover`, {
+      method: "GET",
+      headers: { Cookie: aliceCookie }
+    });
+    // Either 404 (no cover) or 403 (access denied) — since there's no cover, the check
+    // should fail with 404 before the visibility check, but if we had a cover it would be 403.
+    // Without a cover: 404 is expected.
+    expect(res.status).toBe(404);
+  });
+
+  // ── Description preserved across rename ──────────────────────────
+
+  it("preserves description when renaming a playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-rename-desc-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "Original", description: "My description" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { Cookie: cookie },
+      body: JSON.stringify({ name: "Renamed", description: "Updated desc" })
+    });
+    expect(res.status).toBe(200);
+    const updated = (res.payload as { playlist: Playlist }).playlist;
+    expect(updated.name).toBe("Renamed");
+    expect(updated.description).toBe("Updated desc");
+  });
+
+  // ── Hearts preserved across updates ──────────────────────────────
+
+  it("preserves hearts when patching a playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-heart-persist-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+    const aliceCookie = await login("alice", "alice-password");
+
+    const { id } = await createPlaylist(adminCookie, { name: "HeartKeep", visibility: "public" });
+
+    // Alice hearts it
+    await apiRequest(`/api/playlists/${encodeURIComponent(id)}/heart`, {
+      method: "POST",
+      headers: { Cookie: aliceCookie }
+    });
+
+    // Admin patches the playlist
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { Cookie: adminCookie },
+      body: JSON.stringify({ name: "HeartKeep Renamed" })
+    });
+    expect(res.status).toBe(200);
+    const updated = (res.payload as { playlist: Playlist }).playlist;
+    expect(updated.heartCount).toBe(1);
+  });
+
+  // ── PUT (full update) ────────────────────────────────────────────
+
+  it("rejects PUT from non-owner", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-put-authz-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+    const aliceCookie = await login("alice", "alice-password");
+
+    const { id } = await createPlaylist(adminCookie, { name: "NotAlice", visibility: "public" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PUT",
+      headers: { Cookie: aliceCookie },
+      body: JSON.stringify({
+        name: "Hijacked",
+        visibility: "public",
+        trackIds: ["track-a"]
+      })
+    });
+    expect(res.status).toBe(403);
   });
 });

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -95,6 +95,9 @@ function findPlaylistById(indexStore: IndexStore, playlistId: string): Playlist 
   return playlists.find((playlist) => playlist.id === playlistId);
 }
 
+const listenDebounceMap = new Map<string, number>();
+const LISTEN_DEBOUNCE_MS = 60 * 60 * 1000; // 1 hour
+
 export function createPlaylistRouter(indexStore: IndexStore): Router {
   const router = Router();
 
@@ -163,13 +166,16 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
+      const description = typeof req.body?.description === "string" ? req.body.description.trim() : undefined;
+
       const snapshot = indexStore.getSnapshot();
       const playlistId = await createFilesystemPlaylist({
         name,
         authorId: authUser.id,
         visibility: visibility ?? "private",
         trackIds: trackIds ?? [],
-        tracksById: getTracksById(snapshot.tracks)
+        tracksById: getTracksById(snapshot.tracks),
+        description
       });
 
       const rebuilt = await indexStore.refreshPlaylists();
@@ -324,6 +330,9 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
       }
 
       const description = typeof req.body?.description === "string" ? req.body.description : undefined;
+      const collaborators = Array.isArray(req.body?.collaborators)
+        ? (req.body.collaborators as unknown[]).filter((c): c is string => typeof c === "string" && c.trim() !== "").map((c) => c.trim())
+        : undefined;
 
       if (description !== undefined) {
         await updatePlaylistDescription(playlistId, description);
@@ -336,7 +345,8 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         authorId: existing.authorId,
         visibility: visibility ?? existing.visibility,
         trackIds: trackIds ?? existing.trackIds,
-        tracksById: getTracksById(snapshot.tracks)
+        tracksById: getTracksById(snapshot.tracks),
+        collaborators
       });
 
       const rebuilt = await indexStore.refreshPlaylists();
@@ -461,6 +471,16 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
+      const debounceKey = `${authUser.id}:${playlistId}`;
+      const lastListen = listenDebounceMap.get(debounceKey);
+      const now = Date.now();
+
+      if (lastListen && now - lastListen < LISTEN_DEBOUNCE_MS) {
+        res.json({ listenCount: playlist.listenCount });
+        return;
+      }
+
+      listenDebounceMap.set(debounceKey, now);
       const listenCount = await incrementPlaylistListenCount(playlistId);
       res.json({ listenCount });
     } catch (error) {

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -20,6 +20,7 @@ const coverUpload = multer({
 });
 import {
   canManagePlaylist,
+  canViewPlaylist,
   createFilesystemPlaylist,
   deleteFilesystemPlaylist,
   filterPlayablePlaylists,
@@ -27,9 +28,9 @@ import {
   incrementPlaylistListenCount,
   togglePlaylistHeart,
   updateFilesystemPlaylist,
-  updatePlaylistCover,
-  updatePlaylistDescription
+  updatePlaylistCover
 } from "../services/playlists/playlistStore";
+import { listUsers } from "../auth/db";
 import type { Playlist, PlaylistVisibility, Track } from "../types/library";
 
 function normalizeVisibility(value: unknown): PlaylistVisibility | null | undefined {
@@ -97,6 +98,16 @@ function findPlaylistById(indexStore: IndexStore, playlistId: string): Playlist 
 
 const listenDebounceMap = new Map<string, number>();
 const LISTEN_DEBOUNCE_MS = 60 * 60 * 1000; // 1 hour
+
+// Sweep expired entries every hour to prevent unbounded growth
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, timestamp] of listenDebounceMap) {
+    if (now - timestamp >= LISTEN_DEBOUNCE_MS) {
+      listenDebounceMap.delete(key);
+    }
+  }
+}, LISTEN_DEBOUNCE_MS).unref();
 
 export function createPlaylistRouter(indexStore: IndexStore): Router {
   const router = Router();
@@ -329,13 +340,18 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
-      const description = typeof req.body?.description === "string" ? req.body.description : undefined;
+      const description = typeof req.body?.description === "string" ? req.body.description.trim() : undefined;
       const collaborators = Array.isArray(req.body?.collaborators)
         ? (req.body.collaborators as unknown[]).filter((c): c is string => typeof c === "string" && c.trim() !== "").map((c) => c.trim())
         : undefined;
 
-      if (description !== undefined) {
-        await updatePlaylistDescription(playlistId, description);
+      if (collaborators !== undefined && collaborators.length > 0) {
+        const validUserIds = new Set(listUsers().map((u) => u.id));
+        const invalid = collaborators.filter((id) => !validUserIds.has(id));
+        if (invalid.length > 0) {
+          res.status(400).json({ error: `Unknown collaborator user ids: ${invalid.join(", ")}` });
+          return;
+        }
       }
 
       const snapshot = indexStore.getSnapshot();
@@ -346,6 +362,7 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         visibility: visibility ?? existing.visibility,
         trackIds: trackIds ?? existing.trackIds,
         tracksById: getTracksById(snapshot.tracks),
+        description,
         collaborators
       });
 
@@ -570,15 +587,21 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
 
   router.get("/playlists/:id/cover", requireAuth, async (req, res, next) => {
     try {
+      const authUser = req.authUser;
       const playlistId = req.params.id;
-      if (!playlistId) {
-        res.status(400).json({ error: "Playlist id is required" });
+      if (!authUser || !playlistId) {
+        res.status(401).json({ error: "Authentication required" });
         return;
       }
 
       const playlist = findPlaylistById(indexStore, playlistId);
       if (!playlist || !playlist.cover) {
         res.status(404).json({ error: "Cover not found" });
+        return;
+      }
+
+      if (!canViewPlaylist(playlist, authUser)) {
+        res.status(403).json({ error: "Not allowed to access this playlist" });
         return;
       }
 

--- a/backend/src/services/playlists/playlistStore.test.ts
+++ b/backend/src/services/playlists/playlistStore.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+let tmpDir: string;
+
+vi.mock("../../utils/paths", async () => {
+  return {
+    get dataRoot() { return path.join(tmpDir, "data"); },
+    get storageRoot() { return path.join(tmpDir, "data", "storage"); },
+    get usersStorageRoot() { return path.join(tmpDir, "data", "storage", "users"); },
+    get configRoot() { return path.join(tmpDir, "data", "config"); },
+    get indexRoot() { return path.join(tmpDir, "data", "index"); },
+    get cacheRoot() { return path.join(tmpDir, "data", "cache"); },
+    get logsRoot() { return path.join(tmpDir, "data", "logs"); },
+    get backupsRoot() { return path.join(tmpDir, "data", "backups"); },
+    get indexFilePath() { return path.join(tmpDir, "data", "index", "library-index.json"); },
+    get metadataOverridesFilePath() { return path.join(tmpDir, "data", "index", "track-metadata-overrides.json"); },
+    get trackActivityLogFilePath() { return path.join(tmpDir, "data", "index", "track-activity-log.json"); }
+  };
+});
+
+vi.mock("../../utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+import type { Playlist, Track } from "../../types/library";
+import type { AuthUser } from "../../types/auth";
+
+function makeTrack(id: string): Track {
+  return {
+    id,
+    owner: "user-1",
+    path: `storage/users/user-1/uploads/${id}.mp3`,
+    duration: 200,
+    mimeType: "audio/mpeg",
+    codec: "mp3",
+    tags: { title: id, artist: "Artist" }
+  };
+}
+
+function makeUser(id: string, role: "admin" | "user" = "user"): AuthUser {
+  return { id, username: id, role, email: `${id}@test.local` };
+}
+
+function makePlaylist(overrides: Partial<Playlist> & { id: string; authorId: string }): Playlist {
+  return {
+    name: "Test",
+    visibility: "public",
+    trackIds: [],
+    description: "",
+    cover: null,
+    hearts: [],
+    heartCount: 0,
+    listenCount: 0,
+    collaborators: [],
+    ...overrides
+  };
+}
+
+describe("playlistStore", () => {
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "plstore-test-"));
+    await fs.mkdir(path.join(tmpDir, "data", "storage", "users"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── canViewPlaylist ────────────────────────────────────────────
+
+  describe("canViewPlaylist", () => {
+    it("allows owner to view private playlist", async () => {
+      const { canViewPlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1", visibility: "private" });
+      expect(canViewPlaylist(playlist, makeUser("u1"))).toBe(true);
+    });
+
+    it("blocks non-owner from private playlist", async () => {
+      const { canViewPlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1", visibility: "private" });
+      expect(canViewPlaylist(playlist, makeUser("u2"))).toBe(false);
+    });
+
+    it("allows anyone to view public playlist", async () => {
+      const { canViewPlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1", visibility: "public" });
+      expect(canViewPlaylist(playlist, makeUser("u2"))).toBe(true);
+    });
+
+    it("allows admin to view private playlist", async () => {
+      const { canViewPlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1", visibility: "private" });
+      expect(canViewPlaylist(playlist, makeUser("admin-user", "admin"))).toBe(true);
+    });
+  });
+
+  // ── canManagePlaylist ──────────────────────────────────────────
+
+  describe("canManagePlaylist", () => {
+    it("allows owner to manage", async () => {
+      const { canManagePlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1" });
+      expect(canManagePlaylist(playlist, makeUser("u1"))).toBe(true);
+    });
+
+    it("allows admin to manage", async () => {
+      const { canManagePlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1" });
+      expect(canManagePlaylist(playlist, makeUser("admin-user", "admin"))).toBe(true);
+    });
+
+    it("blocks non-owner non-admin from managing", async () => {
+      const { canManagePlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1" });
+      expect(canManagePlaylist(playlist, makeUser("u2"))).toBe(false);
+    });
+  });
+
+  // ── filterPlayablePlaylists ────────────────────────────────────
+
+  describe("filterPlayablePlaylists", () => {
+    it("filters private playlists for non-owner", async () => {
+      const { filterPlayablePlaylists } = await import("./playlistStore");
+      const playlists = [
+        makePlaylist({ id: "u1:pub", authorId: "u1", visibility: "public" }),
+        makePlaylist({ id: "u1:priv", authorId: "u1", visibility: "private" }),
+        makePlaylist({ id: "u2:mine", authorId: "u2", visibility: "private" })
+      ];
+      const result = filterPlayablePlaylists(playlists, makeUser("u2"));
+      expect(result.map((p) => p.id)).toEqual(["u1:pub", "u2:mine"]);
+    });
+  });
+
+  // ── togglePlaylistHeart ────────────────────────────────────────
+
+  describe("togglePlaylistHeart", () => {
+    it("hearts and un-hearts a playlist", async () => {
+      const { createFilesystemPlaylist, togglePlaylistHeart, scanFilesystemPlaylists } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Heart Test",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      // Heart
+      const r1 = await togglePlaylistHeart(playlistId, "user-2");
+      expect(r1.hearted).toBe(true);
+      expect(r1.heartCount).toBe(1);
+
+      // Verify persisted
+      const scanned = await scanFilesystemPlaylists(tracks);
+      const found = scanned.find((p) => p.id === playlistId)!;
+      expect(found.hearts).toEqual(["user-2"]);
+      expect(found.heartCount).toBe(1);
+
+      // Un-heart
+      const r2 = await togglePlaylistHeart(playlistId, "user-2");
+      expect(r2.hearted).toBe(false);
+      expect(r2.heartCount).toBe(0);
+    });
+
+    it("supports multiple users hearting", async () => {
+      const { createFilesystemPlaylist, togglePlaylistHeart } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Multi Heart",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      await togglePlaylistHeart(playlistId, "user-2");
+      const r = await togglePlaylistHeart(playlistId, "user-3");
+      expect(r.heartCount).toBe(2);
+    });
+  });
+
+  // ── incrementPlaylistListenCount ───────────────────────────────
+
+  describe("incrementPlaylistListenCount", () => {
+    it("increments listen count", async () => {
+      const { createFilesystemPlaylist, incrementPlaylistListenCount, scanFilesystemPlaylists } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Listen Test",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      const count1 = await incrementPlaylistListenCount(playlistId);
+      expect(count1).toBe(1);
+
+      const count2 = await incrementPlaylistListenCount(playlistId);
+      expect(count2).toBe(2);
+
+      // Verify persisted
+      const scanned = await scanFilesystemPlaylists(tracks);
+      const found = scanned.find((p) => p.id === playlistId)!;
+      expect(found.listenCount).toBe(2);
+    });
+  });
+
+  // ── updatePlaylistCover ────────────────────────────────────────
+
+  describe("updatePlaylistCover", () => {
+    it("sets and clears cover path", async () => {
+      const { createFilesystemPlaylist, updatePlaylistCover, scanFilesystemPlaylists } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Cover Test",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      await updatePlaylistCover(playlistId, "/path/to/cover.webp");
+      let scanned = await scanFilesystemPlaylists(tracks);
+      let found = scanned.find((p) => p.id === playlistId)!;
+      expect(found.cover).toBe("/path/to/cover.webp");
+
+      await updatePlaylistCover(playlistId, null);
+      scanned = await scanFilesystemPlaylists(tracks);
+      found = scanned.find((p) => p.id === playlistId)!;
+      expect(found.cover).toBeNull();
+    });
+  });
+
+  // ── Create and update with new fields ──────────────────────────
+
+  describe("createFilesystemPlaylist", () => {
+    it("persists description", async () => {
+      const { createFilesystemPlaylist, scanFilesystemPlaylists } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Described",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById,
+        description: "My custom description"
+      });
+
+      const scanned = await scanFilesystemPlaylists(tracks);
+      const found = scanned.find((p) => p.id === playlistId)!;
+      expect(found.description).toBe("My custom description");
+      expect(found.hearts).toEqual([]);
+      expect(found.heartCount).toBe(0);
+      expect(found.listenCount).toBe(0);
+      expect(found.collaborators).toEqual([]);
+      expect(found.cover).toBeNull();
+    });
+  });
+
+  describe("updateFilesystemPlaylist", () => {
+    it("updates description and collaborators", async () => {
+      const { createFilesystemPlaylist, updateFilesystemPlaylist, scanFilesystemPlaylists } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Updatable",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      await updateFilesystemPlaylist({
+        id: playlistId,
+        name: "Updatable",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById,
+        description: "New description",
+        collaborators: ["user-2", "user-3"]
+      });
+
+      const scanned = await scanFilesystemPlaylists(tracks);
+      const found = scanned.find((p) => p.id === playlistId)!;
+      expect(found.description).toBe("New description");
+      expect(found.collaborators).toEqual(["user-2", "user-3"]);
+    });
+
+    it("preserves hearts and listen count on update", async () => {
+      const { createFilesystemPlaylist, togglePlaylistHeart, incrementPlaylistListenCount, updateFilesystemPlaylist, scanFilesystemPlaylists } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Persistent",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      await togglePlaylistHeart(playlistId, "user-2");
+      await incrementPlaylistListenCount(playlistId);
+      await incrementPlaylistListenCount(playlistId);
+
+      // Update name — hearts and listen count should survive
+      await updateFilesystemPlaylist({
+        id: playlistId,
+        name: "Persistent Renamed",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      const scanned = await scanFilesystemPlaylists(tracks);
+      const found = scanned.find((p) => p.name === "Persistent Renamed")!;
+      expect(found).toBeDefined();
+      expect(found.hearts).toEqual(["user-2"]);
+      expect(found.heartCount).toBe(1);
+      expect(found.listenCount).toBe(2);
+    });
+  });
+});

--- a/backend/src/services/playlists/playlistStore.ts
+++ b/backend/src/services/playlists/playlistStore.ts
@@ -459,6 +459,8 @@ export async function updateFilesystemPlaylist(input: UpdatePlaylistInput & { au
   const currentDir = getPlaylistDir(parsed.authorId, parsed.slug);
   const nextDir = getPlaylistDir(parsed.authorId, nextSlug);
 
+  const existingMetadata = await readPlaylistMetadata(input.id);
+
   if (parsed.slug !== nextSlug) {
     try {
       await fs.access(nextDir);
@@ -471,8 +473,6 @@ export async function updateFilesystemPlaylist(input: UpdatePlaylistInput & { au
 
     await fs.rename(currentDir, nextDir);
   }
-
-  const existingMetadata = await readPlaylistMetadata(input.id);
 
   await writePlaylistContents({
     authorId: input.authorId,

--- a/backend/src/services/playlists/playlistStore.ts
+++ b/backend/src/services/playlists/playlistStore.ts
@@ -37,6 +37,7 @@ type UpdatePlaylistInput = {
   visibility: PlaylistVisibility;
   trackIds: string[];
   tracksById: Map<string, Track>;
+  description?: string;
   collaborators?: string[];
 };
 
@@ -100,7 +101,7 @@ function getPlaylistMetadataPath(authorId: string, playlistSlug: string): string
   return path.join(getPlaylistDir(authorId, playlistSlug), PLAYLIST_METADATA_FILE);
 }
 
-function canViewPlaylist(playlist: Playlist, user: AuthUser): boolean {
+export function canViewPlaylist(playlist: Playlist, user: AuthUser): boolean {
   return playlist.visibility === "public" || playlist.authorId === user.id || user.role === "admin";
 }
 
@@ -173,10 +174,6 @@ export async function migrateLegacyPlaylists(): Promise<void> {
 
 export function canManagePlaylist(playlist: Playlist, user: AuthUser): boolean {
   return playlist.authorId === user.id || user.role === "admin";
-}
-
-export function canEditPlaylistTracks(playlist: Playlist, user: AuthUser): boolean {
-  return canManagePlaylist(playlist, user) || playlist.collaborators.includes(user.id);
 }
 
 export function filterPlayablePlaylists(playlists: Playlist[], user: AuthUser): Playlist[] {
@@ -484,7 +481,7 @@ export async function updateFilesystemPlaylist(input: UpdatePlaylistInput & { au
     visibility: input.visibility,
     trackIds: input.trackIds,
     tracksById: input.tracksById,
-    description: existingMetadata?.description,
+    description: input.description ?? existingMetadata?.description,
     cover: existingMetadata?.cover,
     hearts: existingMetadata?.hearts,
     listenCount: existingMetadata?.listenCount,
@@ -538,16 +535,6 @@ export async function incrementPlaylistListenCount(playlistId: string): Promise<
     listenCount: metadata.listenCount + 1
   }));
   return updated.listenCount;
-}
-
-export async function updatePlaylistDescription(
-  playlistId: string,
-  description: string
-): Promise<void> {
-  await patchPlaylistMetadataFile(playlistId, (metadata) => ({
-    ...metadata,
-    description
-  }));
 }
 
 export async function updatePlaylistCover(

--- a/backend/src/services/playlists/playlistStore.ts
+++ b/backend/src/services/playlists/playlistStore.ts
@@ -28,6 +28,7 @@ type CreatePlaylistInput = {
   visibility: PlaylistVisibility;
   trackIds: string[];
   tracksById: Map<string, Track>;
+  description?: string;
 };
 
 type UpdatePlaylistInput = {
@@ -36,6 +37,7 @@ type UpdatePlaylistInput = {
   visibility: PlaylistVisibility;
   trackIds: string[];
   tracksById: Map<string, Track>;
+  collaborators?: string[];
 };
 
 function normalizeVisibility(value: unknown): PlaylistVisibility | null {
@@ -436,7 +438,8 @@ export async function createFilesystemPlaylist(input: CreatePlaylistInput): Prom
     name,
     visibility: input.visibility,
     trackIds: input.trackIds,
-    tracksById: input.tracksById
+    tracksById: input.tracksById,
+    description: input.description
   });
 
   return createPlaylistId(input.authorId, playlistSlug);
@@ -485,7 +488,7 @@ export async function updateFilesystemPlaylist(input: UpdatePlaylistInput & { au
     cover: existingMetadata?.cover,
     hearts: existingMetadata?.hearts,
     listenCount: existingMetadata?.listenCount,
-    collaborators: existingMetadata?.collaborators
+    collaborators: input.collaborators ?? existingMetadata?.collaborators
   });
 }
 

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -442,6 +442,7 @@ export function AuthenticatedApp({
       accountViewProps={{
         user,
         avatarUrl,
+        allTracksById,
         onUpdatePhoto: handleUpdateProfilePhoto,
         onUpdateEmail: handleUpdateEmail,
         onChangePassword: handleUpdateOwnPassword,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -725,9 +725,8 @@ export async function uploadPlaylistCover(playlistId: string, file: File): Promi
 }
 
 export async function deletePlaylistCover(playlistId: string): Promise<void> {
-  await requestJson<void>(`/api/playlists/${encodeURIComponent(playlistId)}/cover`, {
-    method: "DELETE",
-    skipJson: true
+  await requestJson<{ ok: boolean }>(`/api/playlists/${encodeURIComponent(playlistId)}/cover`, {
+    method: "DELETE"
   });
 }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -657,6 +657,7 @@ export async function rebuildIndex(): Promise<{ generatedAt: string; totalTracks
 export async function createPlaylist(input: {
   name: string;
   visibility: PlaylistVisibility;
+  description?: string;
 }): Promise<Playlist> {
   const payload = await requestJson<{ playlist: Playlist }>("/api/playlists", {
     method: "POST",
@@ -675,6 +676,8 @@ export async function patchPlaylist(
     name?: string;
     visibility?: PlaylistVisibility;
     trackIds?: string[];
+    description?: string;
+    collaborators?: string[];
   }
 ): Promise<Playlist> {
   const payload = await requestJson<{ playlist: Playlist }>(`/api/playlists/${encodeURIComponent(playlistId)}`, {
@@ -710,6 +713,22 @@ export async function reportPlaylistListen(playlistId: string): Promise<void> {
 
 export function playlistCoverUrl(playlistId: string): string {
   return withApiBase(`/api/playlists/${encodeURIComponent(playlistId)}/cover`);
+}
+
+export async function uploadPlaylistCover(playlistId: string, file: File): Promise<void> {
+  const formData = new FormData();
+  formData.append("cover", file);
+  await requestJson<{ ok: boolean }>(`/api/playlists/${encodeURIComponent(playlistId)}/cover`, {
+    method: "POST",
+    body: formData
+  });
+}
+
+export async function deletePlaylistCover(playlistId: string): Promise<void> {
+  await requestJson<void>(`/api/playlists/${encodeURIComponent(playlistId)}/cover`, {
+    method: "DELETE",
+    skipJson: true
+  });
 }
 
 export async function getAutoPlaylists(): Promise<AutoPlaylistSummary[]> {
@@ -964,6 +983,86 @@ export type PlayStatsResponse = {
 
 export async function getMyPlayStats(): Promise<PlayStatsResponse> {
   return requestJson<PlayStatsResponse>("/api/me/play-stats");
+}
+
+// ── Admin: Genre Management ───────────────────────────────────────────
+
+export type GenreSynonyms = Record<string, string>;
+
+export async function getGenreSynonyms(): Promise<GenreSynonyms> {
+  const payload = await requestJson<{ synonyms: GenreSynonyms }>("/api/genre/synonyms");
+  return payload.synonyms;
+}
+
+export async function putGenreSynonym(key: string, value: string): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/synonyms", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, value })
+  });
+}
+
+export async function deleteGenreSynonym(key: string): Promise<void> {
+  await requestJson<void>(`/api/genre/synonyms/${encodeURIComponent(key)}`, {
+    method: "DELETE",
+    skipJson: true
+  });
+}
+
+export async function resetGenreSynonyms(): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/synonyms/reset", { method: "POST" });
+}
+
+export type EnrichmentStatus = {
+  running: boolean;
+  processed?: number;
+  total?: number;
+  startedAt?: string;
+};
+
+export async function getEnrichmentStatus(): Promise<EnrichmentStatus> {
+  return requestJson<EnrichmentStatus>("/api/genre/enrichment/status");
+}
+
+export async function startEnrichment(): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/enrichment/start", { method: "POST" });
+}
+
+export async function stopEnrichment(): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/enrichment/stop", { method: "POST" });
+}
+
+export type GenreCacheStats = {
+  entries: number;
+  sizeBytes: number;
+};
+
+export async function getGenreCacheStats(): Promise<GenreCacheStats> {
+  return requestJson<GenreCacheStats>("/api/genre/cache/stats");
+}
+
+export async function clearGenreCache(): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/cache/clear", { method: "POST" });
+}
+
+// ── Admin: Auto-Playlist Config ──────────────────────────────────────
+
+export type AutoPlaylistConfig = {
+  maxPlaylists: number;
+  minTracksPerPlaylist: number;
+  tracksPerPlaylist: number;
+};
+
+export async function getAutoPlaylistConfig(): Promise<AutoPlaylistConfig> {
+  return requestJson<AutoPlaylistConfig>("/api/config/auto-playlists");
+}
+
+export async function patchAutoPlaylistConfig(patch: Partial<AutoPlaylistConfig>): Promise<AutoPlaylistConfig> {
+  return requestJson<AutoPlaylistConfig>("/api/config/auto-playlists", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch)
+  });
 }
 
 // ── Admin: Server Logs ────────────────────────────────────────────────

--- a/frontend/src/components/AccountView.test.tsx
+++ b/frontend/src/components/AccountView.test.tsx
@@ -55,6 +55,7 @@ describe("AccountView", () => {
       <AccountView
         user={createUser()}
         avatarUrl="/api/users/me/photo"
+        allTracksById={new Map()}
         onUpdatePhoto={vi.fn().mockResolvedValue(undefined)}
         onUpdateEmail={vi.fn().mockResolvedValue(undefined)}
         onChangePassword={vi.fn().mockResolvedValue(undefined)}
@@ -93,6 +94,7 @@ describe("AccountView", () => {
       <AccountView
         user={createUser()}
         avatarUrl="/api/users/me/photo"
+        allTracksById={new Map()}
         onUpdatePhoto={vi.fn().mockResolvedValue(undefined)}
         onUpdateEmail={vi.fn().mockResolvedValue(undefined)}
         onChangePassword={vi.fn().mockResolvedValue(undefined)}
@@ -127,6 +129,7 @@ describe("AccountView", () => {
       <AccountView
         user={createUser()}
         avatarUrl="/api/users/me/photo"
+        allTracksById={new Map()}
         onUpdatePhoto={vi.fn().mockResolvedValue(undefined)}
         onUpdateEmail={vi.fn().mockResolvedValue(undefined)}
         onChangePassword={vi.fn().mockResolvedValue(undefined)}

--- a/frontend/src/components/AccountView.tsx
+++ b/frontend/src/components/AccountView.tsx
@@ -1,10 +1,12 @@
 import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { User, UserSession } from "../types";
+import { coverUrl, getMyPlayStats, type PlayStatsResponse } from "../api";
+import type { Track, User, UserSession } from "../types";
 
 type AccountViewProps = {
   user: User;
   avatarUrl: string;
+  allTracksById: Map<string, Track>;
   onUpdatePhoto: (file: File) => Promise<void>;
   onUpdateEmail: (email: string) => Promise<void>;
   onChangePassword: (input: { currentPassword: string; newPassword: string }) => Promise<void>;
@@ -50,6 +52,7 @@ function getSessionTitle(session: UserSession): string {
 export function AccountView({
   user,
   avatarUrl,
+  allTracksById,
   onUpdatePhoto,
   onUpdateEmail,
   onChangePassword,
@@ -80,6 +83,17 @@ export function AccountView({
   const [sessionsMessage, setSessionsMessage] = useState<string | null>(null);
   const [revokingSessionId, setRevokingSessionId] = useState<string | null>(null);
   const [loggingOutOtherSessions, setLoggingOutOtherSessions] = useState(false);
+
+  const [playStats, setPlayStats] = useState<PlayStatsResponse | null>(null);
+  const [loadingStats, setLoadingStats] = useState(true);
+
+  useEffect(() => {
+    setLoadingStats(true);
+    void getMyPlayStats()
+      .then(setPlayStats)
+      .catch(() => {})
+      .finally(() => setLoadingStats(false));
+  }, []);
 
   const initial = useMemo(() => getUserInitial(user), [user]);
   const displayedAvatarUrl = selectedPhotoPreviewUrl ?? avatarUrl;
@@ -458,6 +472,74 @@ export function AccountView({
             {passwordMessage.text}
           </p>
         ) : null}
+      </section>
+
+      <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <h3 className="font-display text-xl text-flaque-ink">Listening Stats</h3>
+
+        {loadingStats ? (
+          <p className="mt-3 text-sm text-flaque-steel">Loading stats...</p>
+        ) : !playStats || playStats.totalPlays === 0 ? (
+          <p className="mt-3 text-sm text-flaque-steel">No listening history yet. Start playing some music!</p>
+        ) : (
+          <div className="mt-3 space-y-4">
+            <div className="flex flex-wrap gap-4">
+              <div className="rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-4 py-3">
+                <p className="font-display text-2xl text-flaque-ink">{playStats.totalPlays}</p>
+                <p className="text-xs text-flaque-steel">Total plays</p>
+              </div>
+              <div className="rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-4 py-3">
+                <p className="font-display text-2xl text-flaque-ink">{playStats.uniqueTracksPlayed}</p>
+                <p className="text-xs text-flaque-steel">Unique tracks</p>
+              </div>
+              <div className="rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-4 py-3">
+                <p className="font-display text-2xl text-flaque-ink">{playStats.topArtists.length}</p>
+                <p className="text-xs text-flaque-steel">Artists</p>
+              </div>
+            </div>
+
+            {playStats.topArtists.length > 0 ? (
+              <div>
+                <h4 className="text-sm font-medium text-flaque-ink">Top Artists</h4>
+                <div className="mt-2 space-y-1">
+                  {playStats.topArtists.slice(0, 10).map((entry, i) => (
+                    <div key={entry.artist} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-3 py-1.5">
+                      <span className="w-5 shrink-0 text-right text-xs text-flaque-steel/60">{i + 1}</span>
+                      <span className="min-w-0 flex-1 truncate text-sm text-flaque-ink">{entry.artist}</span>
+                      <span className="shrink-0 text-xs text-flaque-steel">{entry.playCount} play{entry.playCount !== 1 ? "s" : ""}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {playStats.topTracks.length > 0 ? (
+              <div>
+                <h4 className="text-sm font-medium text-flaque-ink">Top Tracks</h4>
+                <div className="mt-2 space-y-1">
+                  {playStats.topTracks.slice(0, 10).map((entry, i) => {
+                    const track = allTracksById.get(entry.trackId);
+                    return (
+                      <div key={entry.trackId} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-2 py-1.5">
+                        <span className="w-5 shrink-0 text-right text-xs text-flaque-steel/60">{i + 1}</span>
+                        {track ? (
+                          <img src={coverUrl(track.id)} alt="" className="h-8 w-8 shrink-0 rounded-md object-cover" loading="lazy" />
+                        ) : (
+                          <div className="h-8 w-8 shrink-0 rounded-md bg-flaque-clay/30" />
+                        )}
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm text-flaque-ink">{track?.tags.title ?? entry.trackId}</p>
+                          <p className="truncate text-xs text-flaque-steel">{track?.tags.artist ?? "Unknown"}</p>
+                        </div>
+                        <span className="shrink-0 text-xs text-flaque-steel">{entry.count}x</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        )}
       </section>
 
       <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">

--- a/frontend/src/components/AdminLibraryView.tsx
+++ b/frontend/src/components/AdminLibraryView.tsx
@@ -1,0 +1,380 @@
+import { FormEvent, useEffect, useState } from "react";
+
+import {
+  clearGenreCache,
+  deleteGenreSynonym,
+  getAutoPlaylistConfig,
+  getEnrichmentStatus,
+  getGenreCacheStats,
+  getGenreSynonyms,
+  patchAutoPlaylistConfig,
+  putGenreSynonym,
+  regenerateAutoPlaylists,
+  resetGenreSynonyms,
+  startEnrichment,
+  stopEnrichment,
+  type AutoPlaylistConfig,
+  type EnrichmentStatus,
+  type GenreCacheStats,
+  type GenreSynonyms
+} from "../api";
+
+export function AdminLibraryView(): JSX.Element {
+  // ── Genre synonyms ─────────────────────────────────────────────
+  const [synonyms, setSynonyms] = useState<GenreSynonyms>({});
+  const [loadingSynonyms, setLoadingSynonyms] = useState(true);
+  const [synonymKey, setSynonymKey] = useState("");
+  const [synonymValue, setSynonymValue] = useState("");
+  const [synonymMessage, setSynonymMessage] = useState<string | null>(null);
+
+  // ── Enrichment ─────────────────────────────────────────────────
+  const [enrichStatus, setEnrichStatus] = useState<EnrichmentStatus | null>(null);
+  const [enrichLoading, setEnrichLoading] = useState(false);
+
+  // ── Cache ──────────────────────────────────────────────────────
+  const [cacheStats, setCacheStats] = useState<GenreCacheStats | null>(null);
+
+  // ── Auto-playlist config ───────────────────────────────────────
+  const [config, setConfig] = useState<AutoPlaylistConfig | null>(null);
+  const [loadingConfig, setLoadingConfig] = useState(true);
+  const [configMax, setConfigMax] = useState("");
+  const [configMin, setConfigMin] = useState("");
+  const [configTracks, setConfigTracks] = useState("");
+  const [configMessage, setConfigMessage] = useState<string | null>(null);
+  const [savingConfig, setSavingConfig] = useState(false);
+  const [regenerating, setRegenerating] = useState(false);
+  const [regenMessage, setRegenMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    void loadSynonyms();
+    void loadEnrichStatus();
+    void loadCacheStats();
+    void loadConfig();
+  }, []);
+
+  async function loadSynonyms(): Promise<void> {
+    setLoadingSynonyms(true);
+    try {
+      const data = await getGenreSynonyms();
+      setSynonyms(data);
+    } catch {
+      setSynonymMessage("Failed to load synonyms.");
+    } finally {
+      setLoadingSynonyms(false);
+    }
+  }
+
+  async function loadEnrichStatus(): Promise<void> {
+    try {
+      const status = await getEnrichmentStatus();
+      setEnrichStatus(status);
+    } catch {}
+  }
+
+  async function loadCacheStats(): Promise<void> {
+    try {
+      const stats = await getGenreCacheStats();
+      setCacheStats(stats);
+    } catch {}
+  }
+
+  async function loadConfig(): Promise<void> {
+    setLoadingConfig(true);
+    try {
+      const cfg = await getAutoPlaylistConfig();
+      setConfig(cfg);
+      setConfigMax(String(cfg.maxPlaylists));
+      setConfigMin(String(cfg.minTracksPerPlaylist));
+      setConfigTracks(String(cfg.tracksPerPlaylist));
+    } catch {} finally {
+      setLoadingConfig(false);
+    }
+  }
+
+  async function handleAddSynonym(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    const k = synonymKey.trim().toLowerCase();
+    const v = synonymValue.trim();
+    if (!k || !v) return;
+    try {
+      await putGenreSynonym(k, v);
+      setSynonymKey("");
+      setSynonymValue("");
+      await loadSynonyms();
+    } catch (err) {
+      setSynonymMessage(err instanceof Error ? err.message : "Failed to save synonym.");
+    }
+  }
+
+  async function handleDeleteSynonym(key: string): Promise<void> {
+    try {
+      await deleteGenreSynonym(key);
+      await loadSynonyms();
+    } catch {}
+  }
+
+  async function handleResetSynonyms(): Promise<void> {
+    try {
+      await resetGenreSynonyms();
+      await loadSynonyms();
+      setSynonymMessage("Synonyms reset to defaults.");
+    } catch {}
+  }
+
+  async function handleToggleEnrichment(): Promise<void> {
+    setEnrichLoading(true);
+    try {
+      if (enrichStatus?.running) {
+        await stopEnrichment();
+      } else {
+        await startEnrichment();
+      }
+      await loadEnrichStatus();
+    } catch {} finally {
+      setEnrichLoading(false);
+    }
+  }
+
+  async function handleClearCache(): Promise<void> {
+    try {
+      await clearGenreCache();
+      await loadCacheStats();
+    } catch {}
+  }
+
+  async function handleSaveConfig(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    setSavingConfig(true);
+    setConfigMessage(null);
+    try {
+      const patch: Partial<AutoPlaylistConfig> = {};
+      const maxVal = parseInt(configMax);
+      const minVal = parseInt(configMin);
+      const tracksVal = parseInt(configTracks);
+      if (!isNaN(maxVal)) patch.maxPlaylists = maxVal;
+      if (!isNaN(minVal)) patch.minTracksPerPlaylist = minVal;
+      if (!isNaN(tracksVal)) patch.tracksPerPlaylist = tracksVal;
+      const updated = await patchAutoPlaylistConfig(patch);
+      setConfig(updated);
+      setConfigMessage("Configuration saved.");
+    } catch (err) {
+      setConfigMessage(err instanceof Error ? err.message : "Failed to save config.");
+    } finally {
+      setSavingConfig(false);
+    }
+  }
+
+  async function handleRegenerate(): Promise<void> {
+    setRegenerating(true);
+    setRegenMessage(null);
+    try {
+      const result = await regenerateAutoPlaylists();
+      setRegenMessage(`Regenerated ${result.regenerated} playlist${result.regenerated !== 1 ? "s" : ""}.`);
+    } catch (err) {
+      setRegenMessage(err instanceof Error ? err.message : "Failed to regenerate.");
+    } finally {
+      setRegenerating(false);
+    }
+  }
+
+  const synonymEntries = Object.entries(synonyms).sort(([a], [b]) => a.localeCompare(b));
+
+  return (
+    <div className="m-4 space-y-4">
+      {/* ── Genre Synonyms ──────────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="font-display text-xl text-flaque-ink">Genre Synonyms</h3>
+          <button
+            type="button"
+            className="rounded-xl border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+            onClick={() => { void handleResetSynonyms(); }}
+          >
+            Reset to defaults
+          </button>
+        </div>
+
+        <form className="mt-3 flex flex-wrap items-end gap-2" onSubmit={(e) => { void handleAddSynonym(e); }}>
+          <label className="text-sm text-flaque-ink">
+            From
+            <input
+              className="mt-1 block w-40 rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              value={synonymKey}
+              onChange={(e) => setSynonymKey(e.target.value)}
+              placeholder="e.g. hiphop"
+            />
+          </label>
+          <label className="text-sm text-flaque-ink">
+            To
+            <input
+              className="mt-1 block w-40 rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              value={synonymValue}
+              onChange={(e) => setSynonymValue(e.target.value)}
+              placeholder="e.g. hip-hop"
+            />
+          </label>
+          <button
+            type="submit"
+            className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:opacity-60"
+            disabled={!synonymKey.trim() || !synonymValue.trim()}
+          >
+            Add
+          </button>
+        </form>
+
+        {synonymMessage ? <p className="mt-2 text-xs text-flaque-steel">{synonymMessage}</p> : null}
+
+        {loadingSynonyms ? (
+          <p className="mt-3 text-sm text-flaque-steel">Loading...</p>
+        ) : synonymEntries.length === 0 ? (
+          <p className="mt-3 text-sm text-flaque-steel">No synonyms configured.</p>
+        ) : (
+          <div className="mt-3 max-h-60 overflow-y-auto rounded-xl border border-flaque-clay/40">
+            <table className="w-full text-left text-sm">
+              <thead className="sticky top-0 bg-flaque-cream/95 text-flaque-ink">
+                <tr>
+                  <th className="px-3 py-2 font-medium">From</th>
+                  <th className="px-3 py-2 font-medium">To</th>
+                  <th className="w-16 px-3 py-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {synonymEntries.map(([key, value]) => (
+                  <tr key={key} className="border-t border-flaque-clay/30">
+                    <td className="px-3 py-1.5 text-flaque-ink">{key}</td>
+                    <td className="px-3 py-1.5 text-flaque-steel">{value}</td>
+                    <td className="px-3 py-1.5">
+                      <button
+                        type="button"
+                        className="text-xs text-red-500 hover:text-red-700"
+                        onClick={() => { void handleDeleteSynonym(key); }}
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* ── Genre Enrichment ────────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <h3 className="font-display text-xl text-flaque-ink">MusicBrainz Enrichment</h3>
+        <p className="mt-1 text-sm text-flaque-steel">
+          Enrich tracks missing genre data by looking them up on MusicBrainz.
+        </p>
+
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            className={`rounded-xl px-4 py-2 text-sm font-medium transition ${
+              enrichStatus?.running
+                ? "border border-red-300 bg-red-50 text-red-700 hover:bg-red-100"
+                : "bg-flaque-ink text-flaque-cream hover:bg-black"
+            }`}
+            onClick={() => { void handleToggleEnrichment(); }}
+            disabled={enrichLoading}
+          >
+            {enrichLoading
+              ? "..."
+              : enrichStatus?.running
+                ? "Stop enrichment"
+                : "Start enrichment"}
+          </button>
+
+          {enrichStatus?.running && enrichStatus.processed !== undefined ? (
+            <span className="text-sm text-flaque-steel">
+              {enrichStatus.processed}{enrichStatus.total !== undefined ? ` / ${enrichStatus.total}` : ""} tracks processed
+            </span>
+          ) : null}
+        </div>
+
+        {cacheStats ? (
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <span className="text-sm text-flaque-steel">
+              Cache: {cacheStats.entries} entries ({(cacheStats.sizeBytes / 1024).toFixed(1)} KB)
+            </span>
+            <button
+              type="button"
+              className="rounded-lg border border-flaque-clay px-3 py-1 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+              onClick={() => { void handleClearCache(); }}
+            >
+              Clear cache
+            </button>
+          </div>
+        ) : null}
+      </section>
+
+      {/* ── Auto-Playlist Config ────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <h3 className="font-display text-xl text-flaque-ink">Automatic Playlists</h3>
+        <p className="mt-1 text-sm text-flaque-steel">
+          Configure how genre/decade playlists are generated.
+        </p>
+
+        {loadingConfig ? (
+          <p className="mt-3 text-sm text-flaque-steel">Loading...</p>
+        ) : (
+          <form className="mt-3 space-y-3" onSubmit={(e) => { void handleSaveConfig(e); }}>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <label className="text-sm text-flaque-ink">
+                Max playlists
+                <input
+                  className="mt-1 block w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                  type="number"
+                  min={0}
+                  value={configMax}
+                  onChange={(e) => setConfigMax(e.target.value)}
+                />
+              </label>
+              <label className="text-sm text-flaque-ink">
+                Min tracks per playlist
+                <input
+                  className="mt-1 block w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                  type="number"
+                  min={1}
+                  value={configMin}
+                  onChange={(e) => setConfigMin(e.target.value)}
+                />
+              </label>
+              <label className="text-sm text-flaque-ink">
+                Tracks per playlist
+                <input
+                  className="mt-1 block w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                  type="number"
+                  min={1}
+                  value={configTracks}
+                  onChange={(e) => setConfigTracks(e.target.value)}
+                />
+              </label>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="submit"
+                className="rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-flaque-cream transition hover:bg-black disabled:opacity-60"
+                disabled={savingConfig}
+              >
+                {savingConfig ? "Saving..." : "Save configuration"}
+              </button>
+              <button
+                type="button"
+                className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:opacity-60"
+                onClick={() => { void handleRegenerate(); }}
+                disabled={regenerating}
+              >
+                {regenerating ? "Regenerating..." : "Regenerate now"}
+              </button>
+            </div>
+
+            {configMessage ? <p className="text-sm text-flaque-steel">{configMessage}</p> : null}
+            {regenMessage ? <p className="text-sm text-flaque-steel">{regenMessage}</p> : null}
+          </form>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -2,6 +2,7 @@ import type { User } from "../types";
 import { navigateTo, type ViewName } from "../utils/appUtils";
 import { AccountView } from "./AccountView";
 import { AdminBackupView } from "./AdminBackupView";
+import { AdminLibraryView } from "./AdminLibraryView";
 import { AdminServerView } from "./AdminServerView";
 import { AdminUsersView } from "./AdminUsersView";
 import { AudioPlayer } from "./AudioPlayer";
@@ -75,7 +76,7 @@ export function AppShell({
     }`;
 
   const configSections: Array<[ConfigSection, string]> = [
-    ["index", "Index"], ["files", "Files"], ["users", "Users"], ["server", "Server"], ["backup", "Backup"]
+    ["index", "Index"], ["files", "Files"], ["users", "Users"], ["library", "Library"], ["server", "Server"], ["backup", "Backup"]
   ];
 
   const sectionSwitcher = activeView === "config" && user.role === "admin" ? (
@@ -145,6 +146,10 @@ export function AppShell({
 
             {configViewProps.activeSection === "backup" ? (
               <AdminBackupView {...backupViewProps} />
+            ) : null}
+
+            {configViewProps.activeSection === "library" ? (
+              <AdminLibraryView />
             ) : null}
           </div>
         ) : null}

--- a/frontend/src/components/ConfigView.tsx
+++ b/frontend/src/components/ConfigView.tsx
@@ -27,7 +27,7 @@ export type ConfigViewProps = {
   onSectionChange: (section: ConfigSection) => void;
 };
 
-export type ConfigSection = "index" | "files" | "users" | "server" | "backup";
+export type ConfigSection = "index" | "files" | "users" | "server" | "backup" | "library";
 
 function normalizeSearch(value: string): string {
   return value.trim().toLowerCase();

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -3,7 +3,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { Playlist } from "../types";
+import type { AutoPlaylistSummary, ForYouPlaylistSummary, Playlist } from "../types";
 import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
 
 function createPlaylist(input: {
@@ -12,6 +12,11 @@ function createPlaylist(input: {
   authorId: string;
   visibility?: "private" | "public";
   trackIds?: string[];
+  description?: string;
+  hearts?: string[];
+  heartCount?: number;
+  listenCount?: number;
+  collaborators?: string[];
 }): Playlist {
   return {
     id: input.id,
@@ -19,12 +24,12 @@ function createPlaylist(input: {
     authorId: input.authorId,
     visibility: input.visibility ?? "private",
     trackIds: input.trackIds ?? [],
-    description: "",
+    description: input.description ?? "",
     cover: null,
-    hearts: [],
-    heartCount: 0,
-    listenCount: 0,
-    collaborators: []
+    hearts: input.hearts ?? [],
+    heartCount: input.heartCount ?? 0,
+    listenCount: input.listenCount ?? 0,
+    collaborators: input.collaborators ?? []
   };
 }
 
@@ -36,9 +41,9 @@ const defaultProps = {
   onDeletePlaylist: vi.fn().mockResolvedValue(undefined),
   onNavigateToPlaylist: vi.fn(),
   onReportPlaylistListen: vi.fn().mockResolvedValue(undefined),
-  autoPlaylists: [],
+  autoPlaylists: [] as AutoPlaylistSummary[],
   loadingAutoPlaylists: false,
-  forYouPlaylists: [],
+  forYouPlaylists: [] as ForYouPlaylistSummary[],
   loadingForYouPlaylists: false,
   onDismissForYouPlaylist: vi.fn().mockResolvedValue(undefined),
   onHeartPlaylist: vi.fn().mockResolvedValue(undefined)
@@ -47,7 +52,10 @@ const defaultProps = {
 describe("LibraryPlaylistSection", () => {
   afterEach(() => {
     cleanup();
+    vi.clearAllMocks();
   });
+
+  // ── Basic CRUD ───────────────────────────────────────────────
 
   it("shows empty state when no playlists exist", () => {
     render(
@@ -140,5 +148,429 @@ describe("LibraryPlaylistSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "Play Night Drive" }));
 
     expect(onPlayPlaylist).toHaveBeenCalledWith(playlist);
+  });
+
+  // ── Description field in create form ─────────────────────────
+
+  it("shows description field when name is filled", () => {
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    // No description field initially
+    expect(screen.queryByPlaceholderText("Description (optional)")).toBeNull();
+
+    // Type a name — description field should appear
+    fireEvent.change(screen.getByPlaceholderText("New playlist name"), { target: { value: "Test" } });
+    expect(screen.getByPlaceholderText("Description (optional)")).toBeTruthy();
+  });
+
+  it("submits description along with create", async () => {
+    const onCreatePlaylist = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={onCreatePlaylist}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("New playlist name"), { target: { value: "Described" } });
+    fireEvent.change(screen.getByPlaceholderText("Description (optional)"), { target: { value: "My description" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(onCreatePlaylist).toHaveBeenCalledWith({
+        name: "Described",
+        visibility: "private",
+        description: "My description"
+      });
+    });
+  });
+
+  it("omits description when empty", async () => {
+    const onCreatePlaylist = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={onCreatePlaylist}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("New playlist name"), { target: { value: "NoDesc" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(onCreatePlaylist).toHaveBeenCalledWith({
+        name: "NoDesc",
+        visibility: "private"
+      });
+    });
+  });
+
+  // ── Popular Playlists section ────────────────────────────────
+
+  it("renders Popular Playlists section for public playlists from other users", () => {
+    const publicPlaylist = createPlaylist({
+      id: "playlist-pub",
+      name: "Top Hits",
+      authorId: "user-2",
+      visibility: "public",
+      heartCount: 5,
+      listenCount: 20
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[publicPlaylist]}
+        ownerNameById={{ "user-2": "Bob" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Popular Playlists")).toBeTruthy();
+    expect(screen.getByText("Top Hits")).toBeTruthy();
+  });
+
+  it("shows heart button on popular playlist cards", () => {
+    const publicPlaylist = createPlaylist({
+      id: "playlist-pub",
+      name: "Hearted Mix",
+      authorId: "user-2",
+      visibility: "public",
+      heartCount: 3
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[publicPlaylist]}
+        ownerNameById={{ "user-2": "Bob" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText("Heart playlist")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+  });
+
+  it("calls onHeartPlaylist when heart is clicked", () => {
+    const onHeartPlaylist = vi.fn().mockResolvedValue(undefined);
+    const publicPlaylist = createPlaylist({
+      id: "playlist-pub",
+      name: "Heart Me",
+      authorId: "user-2",
+      visibility: "public"
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[publicPlaylist]}
+        ownerNameById={{ "user-2": "Bob" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        onHeartPlaylist={onHeartPlaylist}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Heart playlist"));
+    expect(onHeartPlaylist).toHaveBeenCalledWith("playlist-pub");
+  });
+
+  it("does not show Popular Playlists when no public playlists from others exist", () => {
+    const myPlaylist = createPlaylist({
+      id: "playlist-mine",
+      name: "Mine",
+      authorId: "user-1",
+      visibility: "public"
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[myPlaylist]}
+        ownerNameById={{ "user-1": "Alice" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("Popular Playlists")).toBeNull();
+  });
+
+  // ── Playlist card info ───────────────────────────────────────
+
+  it("shows description on playlist card when set", () => {
+    const playlist = createPlaylist({
+      id: "playlist-desc",
+      name: "With Desc",
+      authorId: "user-1",
+      description: "A cool playlist"
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        ownerNameById={{ "user-1": "Alice" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("A cool playlist")).toBeTruthy();
+  });
+
+  it("navigates to playlist detail on card click", () => {
+    const onNavigateToPlaylist = vi.fn();
+    const playlist = createPlaylist({
+      id: "playlist-nav",
+      name: "Navigable",
+      authorId: "user-1"
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        ownerNameById={{ "user-1": "Alice" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        onNavigateToPlaylist={onNavigateToPlaylist}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Navigable"));
+    expect(onNavigateToPlaylist).toHaveBeenCalledWith("playlist-nav");
+  });
+
+  // ── Automatic Playlists section ──────────────────────────────
+
+  it("renders Automatic Playlists section with cards", () => {
+    const autoPlaylists: AutoPlaylistSummary[] = [
+      {
+        id: "auto:rock-1970",
+        name: "70s Rock",
+        genre: "Rock",
+        decade: 1970,
+        trackCount: 25,
+        generatedAt: "2026-04-01T00:00:00Z"
+      }
+    ];
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        autoPlaylists={autoPlaylists}
+      />
+    );
+
+    expect(screen.getByText("Automatic Playlists")).toBeTruthy();
+    expect(screen.getByText("70s Rock")).toBeTruthy();
+    expect(screen.getByText("Rock")).toBeTruthy();
+    expect(screen.getByText(/25 tracks/)).toBeTruthy();
+  });
+
+  it("shows loading state for auto playlists", () => {
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        loadingAutoPlaylists={true}
+      />
+    );
+
+    expect(screen.getByText("Loading...")).toBeTruthy();
+  });
+
+  it("shows empty message when no auto playlists", () => {
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        autoPlaylists={[]}
+      />
+    );
+
+    expect(screen.getByText("Automatic playlists will appear here once generated.")).toBeTruthy();
+  });
+
+  it("navigates to auto playlist on click", () => {
+    const onNavigateToPlaylist = vi.fn();
+    const autoPlaylists: AutoPlaylistSummary[] = [
+      {
+        id: "auto:jazz-1960",
+        name: "60s Jazz",
+        genre: "Jazz",
+        decade: 1960,
+        trackCount: 15,
+        generatedAt: "2026-04-01T00:00:00Z"
+      }
+    ];
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        autoPlaylists={autoPlaylists}
+        onNavigateToPlaylist={onNavigateToPlaylist}
+      />
+    );
+
+    fireEvent.click(screen.getByText("60s Jazz"));
+    expect(onNavigateToPlaylist).toHaveBeenCalledWith("auto:jazz-1960");
+  });
+
+  // ── Made for you section ─────────────────────────────────────
+
+  it("renders Made for you section", () => {
+    const forYouPlaylists: ForYouPlaylistSummary[] = [
+      {
+        id: "for-you:pink-floyd",
+        name: "Because you listen to Pink Floyd",
+        seedArtist: "Pink Floyd",
+        trackCount: 20,
+        generatedAt: "2026-04-01T00:00:00Z"
+      }
+    ];
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        forYouPlaylists={forYouPlaylists}
+      />
+    );
+
+    expect(screen.getByText("Made for you")).toBeTruthy();
+    expect(screen.getByText("Because you listen to Pink Floyd")).toBeTruthy();
+    expect(screen.getByText("Pink Floyd")).toBeTruthy();
+    expect(screen.getByText(/20 tracks/)).toBeTruthy();
+  });
+
+  it("hides Made for you section when empty", () => {
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        forYouPlaylists={[]}
+      />
+    );
+
+    expect(screen.queryByText("Made for you")).toBeNull();
+  });
+
+  it("calls dismiss on for-you playlist", () => {
+    const onDismissForYouPlaylist = vi.fn().mockResolvedValue(undefined);
+    const forYouPlaylists: ForYouPlaylistSummary[] = [
+      {
+        id: "for-you:artist",
+        name: "Because you listen to Artist",
+        seedArtist: "Artist",
+        trackCount: 10,
+        generatedAt: "2026-04-01T00:00:00Z"
+      }
+    ];
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        forYouPlaylists={forYouPlaylists}
+        onDismissForYouPlaylist={onDismissForYouPlaylist}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Hide Because you listen to Artist"));
+    expect(onDismissForYouPlaylist).toHaveBeenCalledWith("for-you:artist");
+  });
+
+  // ── Listen count badges ──────────────────────────────────────
+
+  it("shows listen count badge on popular playlist cards", () => {
+    const publicPlaylist = createPlaylist({
+      id: "playlist-listened",
+      name: "Listened Mix",
+      authorId: "user-2",
+      visibility: "public",
+      listenCount: 42
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[publicPlaylist]}
+        ownerNameById={{ "user-2": "Bob" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("42")).toBeTruthy();
+  });
+
+  // ── Reports listen on play ───────────────────────────────────
+
+  it("reports listen when playing a playlist", () => {
+    const onReportPlaylistListen = vi.fn().mockResolvedValue(undefined);
+    const playlist = createPlaylist({
+      id: "playlist-report",
+      name: "Report Me",
+      authorId: "user-1",
+      trackIds: ["t1"]
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        ownerNameById={{ "user-1": "Alice" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        onReportPlaylistListen={onReportPlaylistListen}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Play Report Me" }));
+    expect(onReportPlaylistListen).toHaveBeenCalledWith("playlist-report");
   });
 });

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -40,7 +40,8 @@ const defaultProps = {
   loadingAutoPlaylists: false,
   forYouPlaylists: [],
   loadingForYouPlaylists: false,
-  onDismissForYouPlaylist: vi.fn().mockResolvedValue(undefined)
+  onDismissForYouPlaylist: vi.fn().mockResolvedValue(undefined),
+  onHeartPlaylist: vi.fn().mockResolvedValue(undefined)
 };
 
 describe("LibraryPlaylistSection", () => {

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -9,11 +9,12 @@ type LibraryPlaylistSectionProps = {
   ownerNameById: Record<string, string>;
   allTracksById: Map<string, Track>;
   user: User;
-  onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility }) => Promise<void>;
+  onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
-  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
+  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onNavigateToPlaylist: (playlistId: string) => void;
+  onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
   autoPlaylists: AutoPlaylistSummary[];
   loadingAutoPlaylists: boolean;
@@ -82,9 +83,11 @@ type PlaylistCardProps = {
   onNavigate: () => void;
   onPlay: () => void;
   showBadges?: boolean;
+  onHeart?: () => void;
+  hasHearted?: boolean;
 };
 
-function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPlay, showBadges }: PlaylistCardProps): JSX.Element {
+function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPlay, showBadges, onHeart, hasHearted }: PlaylistCardProps): JSX.Element {
   const mosaicTracks = getPlaylistMosaicTracks(playlist.trackIds, allTracksById);
   const owner = ownerNameById[playlist.authorId] ?? playlist.authorId;
 
@@ -130,7 +133,21 @@ function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPl
         {/* Badges */}
         {showBadges ? (
           <div className="mt-1.5 flex items-center gap-2">
-            {playlist.heartCount > 0 ? (
+            {onHeart ? (
+              <button
+                type="button"
+                className={`flex items-center gap-0.5 text-[10px] transition ${
+                  hasHearted ? "text-red-500 hover:text-red-600" : "text-flaque-steel hover:text-red-400"
+                }`}
+                onClick={(e) => { e.stopPropagation(); onHeart(); }}
+                aria-label={hasHearted ? "Remove heart" : "Heart playlist"}
+              >
+                <svg className="h-3 w-3" fill={hasHearted ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                </svg>
+                {playlist.heartCount > 0 ? playlist.heartCount : ""}
+              </button>
+            ) : playlist.heartCount > 0 ? (
               <span className="flex items-center gap-0.5 text-[10px] text-red-400">
                 <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
@@ -173,6 +190,7 @@ export function LibraryPlaylistSection({
   onPatchPlaylist: _onPatchPlaylist,
   onDeletePlaylist: _onDeletePlaylist,
   onNavigateToPlaylist,
+  onHeartPlaylist,
   onReportPlaylistListen,
   autoPlaylists,
   loadingAutoPlaylists,
@@ -181,6 +199,7 @@ export function LibraryPlaylistSection({
   onDismissForYouPlaylist
 }: LibraryPlaylistSectionProps): JSX.Element {
   const [playlistName, setPlaylistName] = useState("");
+  const [playlistDescription, setPlaylistDescription] = useState("");
   const [playlistVisibility, setPlaylistVisibility] = useState<PlaylistVisibility>("private");
   const [submitting, setSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -196,8 +215,13 @@ export function LibraryPlaylistSection({
     setSubmitting(true);
     setStatusMessage(null);
     try {
-      await onCreatePlaylist({ name: playlistName, visibility: playlistVisibility });
+      await onCreatePlaylist({
+        name: playlistName,
+        visibility: playlistVisibility,
+        description: playlistDescription.trim() || undefined
+      });
       setPlaylistName("");
+      setPlaylistDescription("");
       setStatusMessage("Playlist created.");
     } catch (error) {
       setStatusMessage(error instanceof Error ? error.message : "Unable to create playlist");
@@ -218,31 +242,42 @@ export function LibraryPlaylistSection({
         <SectionHeader title="My Playlists" />
 
         <form
-          className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]"
+          className="mt-4 space-y-3"
           onSubmit={(event) => { void handleSubmit(event); }}
         >
-          <input
-            className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-            type="text"
-            placeholder="New playlist name"
-            value={playlistName}
-            onChange={(event) => setPlaylistName(event.target.value)}
-          />
-          <select
-            className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-            value={playlistVisibility}
-            onChange={(event) => setPlaylistVisibility(event.target.value as PlaylistVisibility)}
-          >
-            <option value="private">Private</option>
-            <option value="public">Public</option>
-          </select>
-          <button
-            className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
-            type="submit"
-            disabled={submitting || !playlistName.trim()}
-          >
-            {submitting ? "Creating..." : "Create"}
-          </button>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]">
+            <input
+              className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              type="text"
+              placeholder="New playlist name"
+              value={playlistName}
+              onChange={(event) => setPlaylistName(event.target.value)}
+            />
+            <select
+              className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              value={playlistVisibility}
+              onChange={(event) => setPlaylistVisibility(event.target.value as PlaylistVisibility)}
+            >
+              <option value="private">Private</option>
+              <option value="public">Public</option>
+            </select>
+            <button
+              className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+              type="submit"
+              disabled={submitting || !playlistName.trim()}
+            >
+              {submitting ? "Creating..." : "Create"}
+            </button>
+          </div>
+          {playlistName.trim() ? (
+            <textarea
+              className="w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              rows={2}
+              placeholder="Description (optional)"
+              value={playlistDescription}
+              onChange={(event) => setPlaylistDescription(event.target.value)}
+            />
+          ) : null}
         </form>
 
         {statusMessage ? <p className="mt-2 text-sm text-flaque-steel">{statusMessage}</p> : null}
@@ -329,6 +364,8 @@ export function LibraryPlaylistSection({
                 onNavigate={() => onNavigateToPlaylist(playlist.id)}
                 onPlay={() => handlePlay(playlist)}
                 showBadges
+                onHeart={() => { void onHeartPlaylist(playlist.id); }}
+                hasHearted={playlist.hearts.includes(user.id)}
               />
             ))}
           </div>

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -19,9 +19,9 @@ type LibraryWorkspaceProps = {
   user: User;
   playlistDetailId: string | null;
   onPlaylistDetailNavigate: (id: string | null) => void;
-  onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility }) => Promise<void>;
+  onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
-  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
+  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
@@ -202,6 +202,7 @@ export function LibraryWorkspace({
             onPatchPlaylist={onPatchPlaylist}
             onDeletePlaylist={onDeletePlaylist}
             onNavigateToPlaylist={onPlaylistDetailNavigate}
+            onHeartPlaylist={onHeartPlaylist}
             onReportPlaylistListen={onReportPlaylistListen}
             autoPlaylists={autoPlaylists}
             loadingAutoPlaylists={loadingAutoPlaylists}

--- a/frontend/src/components/PlaylistDetailView.test.tsx
+++ b/frontend/src/components/PlaylistDetailView.test.tsx
@@ -1,0 +1,416 @@
+/* @vitest-environment happy-dom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Playlist, Track, User } from "../types";
+
+const { getUsersMock } = vi.hoisted(() => ({
+  getUsersMock: vi.fn<() => Promise<User[]>>().mockResolvedValue([])
+}));
+
+vi.mock("../api", () => ({
+  coverUrl: (id: string) => `/api/covers/${id}`,
+  playlistCoverUrl: (id: string) => `/api/playlists/${id}/cover`,
+  getUsers: getUsersMock,
+  uploadPlaylistCover: vi.fn().mockResolvedValue(undefined),
+  deletePlaylistCover: vi.fn().mockResolvedValue(undefined)
+}));
+
+import { PlaylistDetailView } from "./PlaylistDetailView";
+
+function makeTrack(id: string, title?: string, artist?: string): Track {
+  return {
+    id,
+    owner: "user-1",
+    path: `/uploads/${id}.mp3`,
+    duration: 200,
+    mimeType: "audio/mpeg",
+    codec: "mp3",
+    tags: {
+      title: title ?? id,
+      artist: artist ?? "Test Artist"
+    }
+  };
+}
+
+function makePlaylist(overrides: Partial<Playlist> = {}): Playlist {
+  return {
+    id: "user-1:my-playlist",
+    name: "My Playlist",
+    authorId: "user-1",
+    visibility: "public",
+    trackIds: ["t1", "t2"],
+    description: "A test playlist",
+    cover: null,
+    hearts: [],
+    heartCount: 0,
+    listenCount: 5,
+    collaborators: [],
+    ...overrides
+  };
+}
+
+const defaultUser: User = { id: "user-1", username: "alice", email: "alice@test.local", role: "user" };
+const otherUser: User = { id: "user-2", username: "bob", email: "bob@test.local", role: "user" };
+
+function createTracksMap(tracks: Track[]): Map<string, Track> {
+  return new Map(tracks.map((t) => [t.id, t]));
+}
+
+const defaultTracks = [makeTrack("t1", "Song One", "Artist A"), makeTrack("t2", "Song Two", "Artist B")];
+const defaultTracksById = createTracksMap(defaultTracks);
+
+const defaultProps = {
+  playlistId: "user-1:my-playlist",
+  availablePlaylists: [makePlaylist()],
+  manageablePlaylists: [makePlaylist()],
+  allTracksById: defaultTracksById,
+  ownerNameById: { "user-1": "alice", "user-2": "bob" } as Record<string, string>,
+  user: defaultUser,
+  onBack: vi.fn(),
+  onPlay: vi.fn(),
+  onPatch: vi.fn().mockResolvedValue(undefined),
+  onDelete: vi.fn().mockResolvedValue(undefined),
+  onHeart: vi.fn().mockResolvedValue({ hearted: true, heartCount: 1 }),
+  onReportListen: vi.fn().mockResolvedValue(undefined)
+};
+
+describe("PlaylistDetailView", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders playlist info, tracks, and stats", () => {
+    render(<PlaylistDetailView {...defaultProps} />);
+
+    expect(screen.getByText("My Playlist")).toBeTruthy();
+    expect(screen.getByText("A test playlist")).toBeTruthy();
+    expect(screen.getByText("by alice")).toBeTruthy();
+    expect(screen.getByText(/2 tracks/)).toBeTruthy();
+    expect(screen.getByText("Song One")).toBeTruthy();
+    expect(screen.getByText("Song Two")).toBeTruthy();
+  });
+
+  it("shows not found when playlist doesn't exist", () => {
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        playlistId="nonexistent:id"
+      />
+    );
+
+    expect(screen.getByText("Playlist not found.")).toBeTruthy();
+  });
+
+  it("shows back button and navigates on click", () => {
+    const onBack = vi.fn();
+    render(<PlaylistDetailView {...defaultProps} onBack={onBack} />);
+
+    fireEvent.click(screen.getByText("Back to playlists"));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("plays all tracks on Play all click", () => {
+    const onPlay = vi.fn();
+    const onReportListen = vi.fn().mockResolvedValue(undefined);
+    render(<PlaylistDetailView {...defaultProps} onPlay={onPlay} onReportListen={onReportListen} />);
+
+    fireEvent.click(screen.getByText("Play all"));
+    expect(onPlay).toHaveBeenCalledTimes(1);
+    expect(onReportListen).toHaveBeenCalledWith("user-1:my-playlist");
+  });
+
+  it("shuffles tracks on Shuffle click", () => {
+    const onPlay = vi.fn();
+    render(<PlaylistDetailView {...defaultProps} onPlay={onPlay} />);
+
+    fireEvent.click(screen.getByText("Shuffle"));
+    expect(onPlay).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Heart button ─────────────────────────────────────────────
+
+  it("shows heart button for public playlist from other user", () => {
+    const playlist = makePlaylist({ id: "user-2:other-playlist", authorId: "user-2", visibility: "public" });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        playlistId="user-2:other-playlist"
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[]}
+        user={defaultUser}
+      />
+    );
+
+    expect(screen.getByLabelText("Heart playlist")).toBeTruthy();
+  });
+
+  it("does not show heart button for own playlist", () => {
+    render(<PlaylistDetailView {...defaultProps} />);
+
+    expect(screen.queryByLabelText("Heart playlist")).toBeNull();
+    expect(screen.queryByLabelText("Remove heart")).toBeNull();
+  });
+
+  it("toggles heart on click", async () => {
+    const onHeart = vi.fn().mockResolvedValue({ hearted: true, heartCount: 1 });
+    const playlist = makePlaylist({ id: "user-2:heartable", authorId: "user-2", visibility: "public" });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        playlistId="user-2:heartable"
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[]}
+        user={defaultUser}
+        onHeart={onHeart}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Heart playlist"));
+
+    await waitFor(() => {
+      expect(onHeart).toHaveBeenCalledWith("user-2:heartable");
+    });
+  });
+
+  it("shows filled heart when already hearted", () => {
+    const playlist = makePlaylist({
+      id: "user-2:hearted",
+      authorId: "user-2",
+      visibility: "public",
+      hearts: ["user-1"],
+      heartCount: 1
+    });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        playlistId="user-2:hearted"
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[]}
+        user={defaultUser}
+      />
+    );
+
+    expect(screen.getByLabelText("Remove heart")).toBeTruthy();
+  });
+
+  // ── Visibility badge ─────────────────────────────────────────
+
+  it("shows visibility badge", () => {
+    render(<PlaylistDetailView {...defaultProps} />);
+    expect(screen.getByText("public")).toBeTruthy();
+  });
+
+  it("shows private badge for private playlist", () => {
+    const playlist = makePlaylist({ visibility: "private" });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[playlist]}
+      />
+    );
+    expect(screen.getByText("private")).toBeTruthy();
+  });
+
+  // ── Listen count ─────────────────────────────────────────────
+
+  it("shows listen count when > 0", () => {
+    const playlist = makePlaylist({ listenCount: 42 });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[playlist]}
+      />
+    );
+    expect(screen.getByText("42")).toBeTruthy();
+  });
+
+  // ── Collaborators ────────────────────────────────────────────
+
+  it("displays collaborators", () => {
+    const playlist = makePlaylist({ collaborators: ["user-2"] });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[playlist]}
+      />
+    );
+
+    expect(screen.getByText("Collaborators:")).toBeTruthy();
+    expect(screen.getByText("bob")).toBeTruthy();
+  });
+
+  // ── Edit button visibility ───────────────────────────────────
+
+  it("shows Edit button for manageable playlist", () => {
+    render(<PlaylistDetailView {...defaultProps} />);
+    expect(screen.getByText("Edit")).toBeTruthy();
+  });
+
+  it("shows Edit button for collaborator", () => {
+    const playlist = makePlaylist({ id: "user-2:collab", authorId: "user-2", collaborators: ["user-1"] });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        playlistId="user-2:collab"
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[]}
+      />
+    );
+    expect(screen.getByText("Edit")).toBeTruthy();
+  });
+
+  it("hides Edit and Delete for non-owner non-collaborator", () => {
+    const playlist = makePlaylist({ id: "user-2:foreign", authorId: "user-2" });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        playlistId="user-2:foreign"
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[]}
+      />
+    );
+    expect(screen.queryByText("Edit")).toBeNull();
+    expect(screen.queryByText("Delete")).toBeNull();
+  });
+
+  // ── Delete ───────────────────────────────────────────────────
+
+  it("deletes playlist and navigates back", async () => {
+    const onDelete = vi.fn().mockResolvedValue(undefined);
+    const onBack = vi.fn();
+    render(<PlaylistDetailView {...defaultProps} onDelete={onDelete} onBack={onBack} />);
+
+    fireEvent.click(screen.getByText("Delete"));
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith("user-1:my-playlist");
+      expect(onBack).toHaveBeenCalled();
+    });
+  });
+
+  // ── Edit modal ───────────────────────────────────────────────
+
+  it("opens edit modal and saves changes", async () => {
+    const onPatch = vi.fn().mockResolvedValue(undefined);
+    render(<PlaylistDetailView {...defaultProps} onPatch={onPatch} />);
+
+    fireEvent.click(screen.getByText("Edit"));
+    expect(screen.getByText("Edit playlist")).toBeTruthy();
+
+    // Change name
+    const nameInput = screen.getByDisplayValue("My Playlist") as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "Renamed" } });
+
+    // Change description
+    const descTextarea = screen.getByDisplayValue("A test playlist") as HTMLTextAreaElement;
+    fireEvent.change(descTextarea, { target: { value: "New desc" } });
+
+    // Submit
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(onPatch).toHaveBeenCalledWith(
+        "user-1:my-playlist",
+        expect.objectContaining({
+          name: "Renamed",
+          description: "New desc"
+        })
+      );
+    });
+  });
+
+  it("edit modal shows visibility selector", async () => {
+    render(<PlaylistDetailView {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    const selects = screen.getAllByRole("combobox");
+    const visibilitySelect = selects.find(
+      (s) => (s as HTMLSelectElement).value === "public"
+    ) as HTMLSelectElement;
+    expect(visibilitySelect).toBeTruthy();
+  });
+
+  it("edit modal shows track list with drag handles", () => {
+    render(<PlaylistDetailView {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    // Should show track names in the modal
+    const songOnes = screen.getAllByText("Song One");
+    expect(songOnes.length).toBeGreaterThanOrEqual(2); // one in list, one in modal
+
+    // Drag handles
+    const dragHandles = screen.getAllByLabelText("Drag to reorder");
+    expect(dragHandles.length).toBe(2);
+  });
+
+  it("edit modal allows removing tracks", async () => {
+    const onPatch = vi.fn().mockResolvedValue(undefined);
+    render(<PlaylistDetailView {...defaultProps} onPatch={onPatch} />);
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    // Remove first track
+    const removeButtons = screen.getAllByLabelText("Remove track");
+    fireEvent.click(removeButtons[0]!);
+
+    // Save
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(onPatch).toHaveBeenCalledWith(
+        "user-1:my-playlist",
+        expect.objectContaining({
+          trackIds: ["t2"]
+        })
+      );
+    });
+  });
+
+  it("edit modal cancel closes without saving", () => {
+    const onPatch = vi.fn();
+    render(<PlaylistDetailView {...defaultProps} onPatch={onPatch} />);
+
+    fireEvent.click(screen.getByText("Edit"));
+    expect(screen.getByText("Edit playlist")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(screen.queryByText("Edit playlist")).toBeNull();
+    expect(onPatch).not.toHaveBeenCalled();
+  });
+
+  // ── Description display ──────────────────────────────────────
+
+  it("hides description when empty", () => {
+    const playlist = makePlaylist({ description: "" });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[playlist]}
+      />
+    );
+
+    // The description paragraph should not be rendered
+    expect(screen.queryByText("A test playlist")).toBeNull();
+  });
+
+  // ── Reports listen only once ─────────────────────────────────
+
+  it("reports listen only once per playlist view", () => {
+    const onReportListen = vi.fn().mockResolvedValue(undefined);
+    render(<PlaylistDetailView {...defaultProps} onReportListen={onReportListen} />);
+
+    fireEvent.click(screen.getByText("Play all"));
+    fireEvent.click(screen.getByText("Shuffle"));
+
+    expect(onReportListen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -268,14 +268,18 @@ function EditModal({ playlist, allTracksById, isOwner, saving, onSave, onClose }
 
   async function handleSubmit(e: FormEvent): Promise<void> {
     e.preventDefault();
-    setCoverUploading(true);
-    try {
-      if (coverFile) {
-        await uploadPlaylistCover(playlist.id, coverFile);
-      } else if (coverRemoved && playlist.cover) {
-        await deletePlaylistCover(playlist.id);
+    if (coverFile || (coverRemoved && playlist.cover)) {
+      setCoverUploading(true);
+      try {
+        if (coverFile) {
+          await uploadPlaylistCover(playlist.id, coverFile);
+        } else {
+          await deletePlaylistCover(playlist.id);
+        }
+      } catch {
+        setCoverUploading(false);
+        return;
       }
-    } finally {
       setCoverUploading(false);
     }
     await onSave({

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { type ChangeEvent, FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -17,7 +17,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
-import { coverUrl, playlistCoverUrl } from "../api";
+import { coverUrl, deletePlaylistCover, getUsers, playlistCoverUrl, uploadPlaylistCover } from "../api";
 import type { Playlist, PlaylistVisibility, Track, User } from "../types";
 import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
 
@@ -30,7 +30,7 @@ type PlaylistDetailViewProps = {
   user: User;
   onBack: () => void;
   onPlay: (playlist: Playlist) => void;
-  onPatch: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string }) => Promise<void>;
+  onPatch: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   onDelete: (playlistId: string) => Promise<void>;
   onHeart: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportListen: (playlistId: string) => Promise<void>;
@@ -117,8 +117,9 @@ function PlaylistCover({ playlist, mosaicTracks }: { playlist: Playlist; mosaicT
 type EditModalProps = {
   playlist: Playlist;
   allTracksById: Map<string, Track>;
+  isOwner: boolean;
   saving: boolean;
-  onSave: (patch: { name?: string; trackIds?: string[]; description?: string }) => Promise<void>;
+  onSave: (patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   onClose: () => void;
 };
 
@@ -204,15 +205,51 @@ function SortableTrackItem({
   );
 }
 
-function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditModalProps): JSX.Element {
+function EditModal({ playlist, allTracksById, isOwner, saving, onSave, onClose }: EditModalProps): JSX.Element {
   const [name, setName] = useState(playlist.name);
   const [description, setDescription] = useState(playlist.description);
+  const [visibility, setVisibility] = useState<PlaylistVisibility>(playlist.visibility);
   const [trackIds, setTrackIds] = useState<string[]>([...playlist.trackIds]);
+  const [collaboratorIds, setCollaboratorIds] = useState<string[]>([...playlist.collaborators]);
+  const [allUsers, setAllUsers] = useState<User[]>([]);
+  const [coverPreview, setCoverPreview] = useState<string | null>(null);
+  const [coverFile, setCoverFile] = useState<File | null>(null);
+  const [coverRemoved, setCoverRemoved] = useState(false);
+  const [coverUploading, setCoverUploading] = useState(false);
+  const coverInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOwner) {
+      void getUsers().then(setAllUsers).catch(() => {});
+    }
+  }, [isOwner]);
+
+  const availableCollaborators = useMemo(() =>
+    allUsers.filter((u) => u.id !== playlist.authorId && !collaboratorIds.includes(u.id)),
+    [allUsers, playlist.authorId, collaboratorIds]
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
+
+  function handleCoverSelect(e: ChangeEvent<HTMLInputElement>): void {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setCoverFile(file);
+    setCoverRemoved(false);
+    const url = URL.createObjectURL(file);
+    setCoverPreview(url);
+  }
+
+  function handleCoverRemove(): void {
+    setCoverFile(null);
+    if (coverPreview) URL.revokeObjectURL(coverPreview);
+    setCoverPreview(null);
+    setCoverRemoved(true);
+    if (coverInputRef.current) coverInputRef.current.value = "";
+  }
 
   function removeTrack(id: string): void {
     setTrackIds((prev) => prev.filter((t) => t !== id));
@@ -231,10 +268,22 @@ function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditMod
 
   async function handleSubmit(e: FormEvent): Promise<void> {
     e.preventDefault();
+    setCoverUploading(true);
+    try {
+      if (coverFile) {
+        await uploadPlaylistCover(playlist.id, coverFile);
+      } else if (coverRemoved && playlist.cover) {
+        await deletePlaylistCover(playlist.id);
+      }
+    } finally {
+      setCoverUploading(false);
+    }
     await onSave({
       name: name.trim() || playlist.name,
+      visibility,
       description: description.trim(),
-      trackIds
+      trackIds,
+      collaborators: isOwner ? collaboratorIds : undefined
     });
   }
 
@@ -280,6 +329,110 @@ function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditMod
                 placeholder="Add a description..."
               />
             </div>
+            <div>
+              <label className="block text-sm font-medium text-flaque-ink">Visibility</label>
+              <select
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                value={visibility}
+                onChange={(e) => setVisibility(e.target.value as PlaylistVisibility)}
+                disabled={saving}
+              >
+                <option value="private">Private</option>
+                <option value="public">Public</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-flaque-ink">Cover image</label>
+              <div className="mt-1 flex items-center gap-3">
+                {(coverPreview ?? (!coverRemoved && playlist.cover)) ? (
+                  <img
+                    src={coverPreview ?? playlistCoverUrl(playlist.id)}
+                    alt="Cover preview"
+                    className="h-14 w-14 shrink-0 rounded-lg object-cover"
+                  />
+                ) : (
+                  <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-lg bg-flaque-clay/20">
+                    <svg className="h-6 w-6 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                  </div>
+                )}
+                <div className="flex flex-col gap-1">
+                  <input
+                    ref={coverInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleCoverSelect}
+                    disabled={saving || coverUploading}
+                  />
+                  <button
+                    type="button"
+                    className="rounded-lg border border-flaque-clay px-3 py-1 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+                    onClick={() => coverInputRef.current?.click()}
+                    disabled={saving || coverUploading}
+                  >
+                    {coverFile ? "Change" : "Upload"}
+                  </button>
+                  {(coverPreview ?? (!coverRemoved && playlist.cover)) ? (
+                    <button
+                      type="button"
+                      className="rounded-lg px-3 py-1 text-xs text-red-500 transition hover:text-red-700"
+                      onClick={handleCoverRemove}
+                      disabled={saving || coverUploading}
+                    >
+                      Remove
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+            {isOwner ? (
+              <div>
+                <label className="block text-sm font-medium text-flaque-ink">Collaborators</label>
+                {collaboratorIds.length > 0 ? (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {collaboratorIds.map((collab) => {
+                      const u = allUsers.find((usr) => usr.id === collab);
+                      return (
+                        <span key={collab} className="inline-flex items-center gap-1 rounded-full bg-flaque-cream px-2 py-0.5 text-xs text-flaque-ink">
+                          {u?.username ?? collab}
+                          <button
+                            type="button"
+                            className="text-flaque-steel hover:text-red-500"
+                            onClick={() => setCollaboratorIds((prev) => prev.filter((c) => c !== collab))}
+                            aria-label={`Remove ${u?.username ?? collab}`}
+                          >
+                            <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                          </button>
+                        </span>
+                      );
+                    })}
+                  </div>
+                ) : null}
+                {availableCollaborators.length > 0 ? (
+                  <select
+                    className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                    value=""
+                    onChange={(e) => {
+                      if (e.target.value) setCollaboratorIds((prev) => [...prev, e.target.value]);
+                    }}
+                    disabled={saving}
+                  >
+                    <option value="">Add a collaborator...</option>
+                    {availableCollaborators.map((u) => (
+                      <option key={u.id} value={u.id}>{u.username}</option>
+                    ))}
+                  </select>
+                ) : (
+                  <p className="mt-1 text-xs text-flaque-steel">
+                    {collaboratorIds.length > 0 ? "All users added." : "No other users available."}
+                  </p>
+                )}
+              </div>
+            ) : null}
           </div>
 
           <div className="mt-4 flex-1 overflow-y-auto px-5">
@@ -323,9 +476,9 @@ function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditMod
             <button
               type="submit"
               className="rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-flaque-cream transition hover:bg-black disabled:opacity-60"
-              disabled={saving}
+              disabled={saving || coverUploading}
             >
-              {saving ? "Saving..." : "Save"}
+              {coverUploading ? "Uploading cover..." : saving ? "Saving..." : "Save"}
             </button>
           </div>
         </form>
@@ -443,7 +596,7 @@ export function PlaylistDetailView({
     }
   }
 
-  async function handleSave(patch: { name?: string; trackIds?: string[]; description?: string }): Promise<void> {
+  async function handleSave(patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }): Promise<void> {
     setSaving(true);
     try {
       await onPatch(playlist!.id, patch);
@@ -645,6 +798,7 @@ export function PlaylistDetailView({
         <EditModal
           playlist={playlist}
           allTracksById={allTracksById}
+          isOwner={playlist.authorId === user.id}
           saving={saving}
           onSave={handleSave}
           onClose={() => setEditOpen(false)}

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -714,6 +714,7 @@ export function PlaylistDetailView({
                   }`}
                   onClick={() => { void handleHeart(); }}
                   disabled={hearting}
+                  aria-label={hasHearted ? "Remove heart" : "Heart playlist"}
                 >
                   <svg className="h-4 w-4" fill={hasHearted ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />

--- a/frontend/src/hooks/useLibraryCommands.ts
+++ b/frontend/src/hooks/useLibraryCommands.ts
@@ -50,9 +50,9 @@ type UseLibraryCommandsResult = {
   handleRebuildIndex: () => Promise<void>;
   handleDeleteTrack: (trackId: string) => Promise<void>;
   handleUpdateTrackMetadata: (trackId: string, patch: TrackMetadataPatch) => Promise<void>;
-  handleCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility }) => Promise<void>;
+  handleCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   handleAddTrackToPlaylist: (input: { trackId: string; playlistId: string }) => Promise<void>;
-  handlePatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
+  handlePatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   handleDeletePlaylist: (playlistId: string) => Promise<void>;
   handleBulkDeleteTracks: (trackIds: string[]) => Promise<void>;
   handleBulkUpdateTrackMetadata: (trackIds: string[], patch: TrackMetadataPatch) => Promise<void>;
@@ -160,6 +160,7 @@ export function useLibraryCommands({
   async function handleCreatePlaylist(input: {
     name: string;
     visibility: PlaylistVisibility;
+    description?: string;
   }): Promise<void> {
     await createPlaylist(input);
     setAppNotice({
@@ -201,7 +202,7 @@ export function useLibraryCommands({
 
   async function handlePatchPlaylist(
     playlistId: string,
-    patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }
+    patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }
   ): Promise<void> {
     await patchPlaylist(playlistId, patch);
     await Promise.all([refreshCurrentLibrary(), refreshAllTracks()]);


### PR DESCRIPTION
## Summary
- **Bug fix**: `readPlaylistMetadata` was called after `fs.rename` in `updateFilesystemPlaylist`, silently losing hearts, listenCount, and collaborators when a playlist was renamed. Moved the read before the rename.
- **Backend playlistStore**: 15 new unit tests covering auth helpers, heart toggle, listen count, cover update, and CRUD with metadata persistence.
- **Backend playlistRoutes**: expanded from 2 to 19 integration tests covering description, hearts, listen debounce, collaborator validation, cover auth, rename preservation, and authorization.
- **Frontend PlaylistDetailView**: 24 new component tests covering rendering, edit modal, hearts, visibility badges, collaborators, delete, and listen reporting.
- **Frontend LibraryPlaylistSection**: expanded from 4 to 22 tests covering description field, popular playlists, auto/for-you sections, listen count badges, and navigation.

## Test plan
- [x] `npx vitest run backend/src/services/playlists/playlistStore.test.ts` — 15 pass
- [x] `npx vitest run backend/src/api/playlistRoutes.test.ts` — 19 pass
- [x] `npx vitest run frontend/` — 76 pass across 8 files
- [x] TypeScript clean on both backend and frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)