### PR TITLE
Playlist visual improvements, inline editing & bug fixes

### DIFF
--- a/backend/src/api/autoPlaylistRoutes.ts
+++ b/backend/src/api/autoPlaylistRoutes.ts
@@ -1,0 +1,98 @@
+import { Router } from "express";
+
+import { createLogger } from "../utils/logger";
+import { requireAdmin, requireAuth } from "../auth/middleware";
+import type { IndexStore } from "../services/indexer/indexStore";
+import {
+  getAutoPlaylistConfig,
+  updateAutoPlaylistConfig,
+  loadAutoPlaylists,
+  getAutoPlaylistById,
+  regenerateAutoPlaylists
+} from "../services/playlists/autoPlaylistService";
+
+const log = createLogger("auto-playlist-routes");
+
+export function createAutoPlaylistRouter(indexStore: IndexStore): Router {
+  const router = Router();
+
+  router.get("/config/auto-playlists", requireAdmin, async (_req, res, next) => {
+    try {
+      const config = await getAutoPlaylistConfig();
+      res.json(config);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.patch("/config/auto-playlists", requireAdmin, async (req, res, next) => {
+    try {
+      const body = req.body as Record<string, unknown>;
+      const patch: Record<string, number> = {};
+
+      if (typeof body.maxPlaylists === "number") patch.maxPlaylists = body.maxPlaylists;
+      if (typeof body.minTracksPerPlaylist === "number") patch.minTracksPerPlaylist = body.minTracksPerPlaylist;
+      if (typeof body.tracksPerPlaylist === "number") patch.tracksPerPlaylist = body.tracksPerPlaylist;
+
+      const updated = await updateAutoPlaylistConfig(patch);
+      res.json(updated);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/playlists/automatic", requireAuth, async (_req, res, next) => {
+    try {
+      const playlists = await loadAutoPlaylists();
+      res.json({
+        playlists: playlists.map((p) => ({
+          id: p.id,
+          name: p.name,
+          genre: p.genre,
+          decade: p.decade,
+          trackCount: p.trackCount,
+          generatedAt: p.generatedAt
+        }))
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/playlists/automatic/:id", requireAuth, async (req, res, next) => {
+    try {
+      const id = req.params.id;
+      if (!id) {
+        res.status(400).json({ error: "Playlist id is required" });
+        return;
+      }
+
+      const playlist = await getAutoPlaylistById(id);
+      if (!playlist) {
+        res.status(404).json({ error: "Auto playlist not found" });
+        return;
+      }
+
+      const tracks = playlist.trackIds
+        .map((trackId) => indexStore.getTrackById(trackId))
+        .filter((t) => t !== undefined);
+
+      res.json({ playlist, tracks });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/playlists/automatic/regenerate", requireAdmin, async (_req, res, next) => {
+    try {
+      const allTracks = indexStore.getSnapshot().tracks;
+      const playlists = await regenerateAutoPlaylists(allTracks);
+      log.info(`Admin triggered auto playlist regeneration: ${playlists.length} playlist(s)`);
+      res.json({ regenerated: playlists.length, playlists: playlists.map((p) => ({ id: p.id, name: p.name, trackCount: p.trackCount })) });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/backend/src/api/forYouPlaylistRoutes.ts
+++ b/backend/src/api/forYouPlaylistRoutes.ts
@@ -1,0 +1,122 @@
+import { Router } from "express";
+
+import { createLogger } from "../utils/logger";
+import { requireAuth } from "../auth/middleware";
+import type { IndexStore } from "../services/indexer/indexStore";
+import {
+  loadForYouPlaylists,
+  getForYouPlaylistById,
+  regenerateForYouPlaylists,
+  dismissForYouPlaylist,
+  getUserDismissals
+} from "../services/playlists/forYouPlaylistService";
+
+const log = createLogger("for-you-routes");
+
+export function createForYouPlaylistRouter(indexStore: IndexStore): Router {
+  const router = Router();
+
+  router.get("/playlists/for-you", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlists = await loadForYouPlaylists(userId);
+      const dismissals = await getUserDismissals(userId);
+
+      const visible = playlists.filter((p) => !dismissals.has(p.id));
+
+      res.json({
+        playlists: visible.map((p) => ({
+          id: p.id,
+          name: p.name,
+          seedArtist: p.seedArtist,
+          trackCount: p.trackCount,
+          generatedAt: p.generatedAt
+        }))
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/playlists/for-you/:id", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const id = req.params.id;
+      if (!id) {
+        res.status(400).json({ error: "Playlist id is required" });
+        return;
+      }
+
+      const playlist = await getForYouPlaylistById(userId, id);
+      if (!playlist) {
+        res.status(404).json({ error: "For-you playlist not found" });
+        return;
+      }
+
+      const tracks = playlist.trackIds
+        .map((trackId) => indexStore.getTrackById(trackId))
+        .filter((t) => t !== undefined);
+
+      res.json({ playlist, tracks });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/playlists/for-you/regenerate", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlists = await regenerateForYouPlaylists(userId, indexStore);
+      log.info(`User ${userId} triggered for-you regeneration: ${playlists.length} playlist(s)`);
+      res.json({
+        regenerated: playlists.length,
+        playlists: playlists.map((p) => ({
+          id: p.id,
+          name: p.name,
+          seedArtist: p.seedArtist,
+          trackCount: p.trackCount
+        }))
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/playlists/for-you/:id/dismiss", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const playlistId = req.params.id;
+      if (!playlistId) {
+        res.status(400).json({ error: "Playlist id is required" });
+        return;
+      }
+
+      await dismissForYouPlaylist(userId, playlistId);
+      res.status(204).end();
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/backend/src/api/libraryRoutes.ts
+++ b/backend/src/api/libraryRoutes.ts
@@ -122,6 +122,7 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       totalTracks: tracks.length,
       totalPlaylists: playlists.length,
       owners: listOwners(filteredTracks),
+      ownerNamesById: Object.fromEntries(ownerNamesById),
       artists: listArtists(tracks),
       albums: listAlbums(tracks),
       tracks,

--- a/backend/src/api/playlistRoutes.test.ts
+++ b/backend/src/api/playlistRoutes.test.ts
@@ -3,8 +3,8 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import type { LibraryIndex, Track } from "../types/library";
-import { apiRequest, getDataRoot, login, setupTestServer, teardownTestServer } from "./testHelpers";
+import type { LibraryIndex, Playlist, Track } from "../types/library";
+import { apiRequest, getBaseUrl, getDataRoot, login, setupTestServer, teardownTestServer } from "./testHelpers";
 
 function createTrack(id: string, relativePath: string): Track {
   return {
@@ -54,32 +54,81 @@ class FakeIndexStore {
   }
 }
 
+function makeFakeIndexStore(tracks: Track[] = []): FakeIndexStore {
+  return new FakeIndexStore({
+    generatedAt: new Date().toISOString(),
+    totalTracks: tracks.length,
+    tracks,
+    playlists: []
+  });
+}
+
+const defaultTracks = [
+  createTrack("track-a", "storage/users/owner-1/uploads/a.mp3"),
+  createTrack("track-b", "storage/users/owner-1/uploads/b.mp3")
+];
+
+async function apiMultipartRequest(input: {
+  pathname: string;
+  cookie: string;
+  fileFieldName: string;
+  fileName: string;
+  mimeType: string;
+  bytes: number[];
+}) {
+  const formData = new FormData();
+  const binary = Uint8Array.from(input.bytes);
+  formData.append(input.fileFieldName, new Blob([binary.buffer as ArrayBuffer], { type: input.mimeType }), input.fileName);
+
+  const response = await fetch(`${getBaseUrl()}${input.pathname}`, {
+    method: "POST",
+    headers: { Cookie: input.cookie },
+    body: formData
+  });
+
+  const text = await response.text();
+  let payload: unknown = undefined;
+  if (text) {
+    try { payload = JSON.parse(text) as unknown; } catch { payload = text; }
+  }
+
+  return { status: response.status, payload };
+}
+
 let indexStore: FakeIndexStore;
 
 beforeEach(async () => {
-  indexStore = new FakeIndexStore({
-    generatedAt: new Date().toISOString(),
-    totalTracks: 0,
-    tracks: [],
-    playlists: []
-  });
+  indexStore = makeFakeIndexStore();
 });
 
 afterEach(async () => {
   await teardownTestServer();
 });
 
+// ── Helper: create a playlist and return its id ────────────────────
+async function createPlaylist(
+  cookie: string,
+  overrides: Record<string, unknown> = {}
+): Promise<{ id: string; playlist: Playlist }> {
+  const body = {
+    name: "Test Playlist",
+    visibility: "public",
+    trackIds: ["track-a", "track-b"],
+    ...overrides
+  };
+  const res = await apiRequest("/api/playlists", {
+    method: "POST",
+    headers: { Cookie: cookie },
+    body: JSON.stringify(body)
+  });
+  expect(res.status).toBe(201);
+  const playlist = (res.payload as { playlist: Playlist }).playlist;
+  return { id: playlist.id, playlist };
+}
+
 describe("playlistRoutes", () => {
   it("supports playlist CRUD with file-based storage", async () => {
-    indexStore = new FakeIndexStore({
-      generatedAt: new Date().toISOString(),
-      totalTracks: 2,
-      tracks: [
-        createTrack("track-a", "storage/users/owner-1/uploads/a.mp3"),
-        createTrack("track-b", "storage/users/owner-1/uploads/b.mp3")
-      ],
-      playlists: []
-    });
+    indexStore = makeFakeIndexStore(defaultTracks);
 
     await setupTestServer({
       tempDirPrefix: "flaque-playlist-routes-",
@@ -177,12 +226,7 @@ describe("playlistRoutes", () => {
   });
 
   it("hides private playlists from other users", async () => {
-    indexStore = new FakeIndexStore({
-      generatedAt: new Date().toISOString(),
-      totalTracks: 1,
-      tracks: [createTrack("track-a", "storage/users/owner-1/uploads/a.mp3")],
-      playlists: []
-    });
+    indexStore = makeFakeIndexStore(defaultTracks);
 
     await setupTestServer({
       tempDirPrefix: "flaque-playlist-routes-",
@@ -224,5 +268,385 @@ describe("playlistRoutes", () => {
       headers: { Cookie: aliceCookie }
     });
     expect(getAsAlice.status).toBe(403);
+  });
+
+  // ── Description ──────────────────────────────────────────────────
+
+  it("creates a playlist with a description", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-desc-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { playlist } = await createPlaylist(cookie, {
+      name: "Described",
+      description: "  A nice playlist  "
+    });
+
+    expect(playlist.description).toBe("A nice playlist");
+  });
+
+  it("patches a playlist description", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-desc-patch-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "Patchable" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { Cookie: cookie },
+      body: JSON.stringify({ description: "  Updated desc  " })
+    });
+    expect(res.status).toBe(200);
+    const updated = (res.payload as { playlist: Playlist }).playlist;
+    expect(updated.description).toBe("Updated desc");
+  });
+
+  it("preserves description when patching other fields", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-desc-preserve-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "DescKeep", description: "Keep me" });
+
+    // Patch only visibility — description should survive
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { Cookie: cookie },
+      body: JSON.stringify({ visibility: "private" })
+    });
+    expect(res.status).toBe(200);
+    const updated = (res.payload as { playlist: Playlist }).playlist;
+    expect(updated.description).toBe("Keep me");
+    expect(updated.visibility).toBe("private");
+  });
+
+  // ── Heart ────────────────────────────────────────────────────────
+
+  it("toggles heart on a public playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-heart-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+    const aliceCookie = await login("alice", "alice-password");
+
+    const { id } = await createPlaylist(adminCookie, { name: "Heartable", visibility: "public" });
+
+    // Heart it
+    const heart1 = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/heart`, {
+      method: "POST",
+      headers: { Cookie: aliceCookie }
+    });
+    expect(heart1.status).toBe(200);
+    expect(heart1.payload).toEqual({ hearted: true, heartCount: 1 });
+
+    // Un-heart it
+    const heart2 = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/heart`, {
+      method: "POST",
+      headers: { Cookie: aliceCookie }
+    });
+    expect(heart2.status).toBe(200);
+    expect(heart2.payload).toEqual({ hearted: false, heartCount: 0 });
+  });
+
+  it("rejects heart on own playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-heart-own-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "Mine", visibility: "public" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/heart`, {
+      method: "POST",
+      headers: { Cookie: cookie }
+    });
+    expect(res.status).toBe(400);
+    expect(res.payload).toEqual(expect.objectContaining({ error: expect.stringContaining("own playlist") }));
+  });
+
+  it("rejects heart on private playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-heart-priv-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+    const aliceCookie = await login("alice", "alice-password");
+
+    const { id } = await createPlaylist(adminCookie, { name: "Private", visibility: "private" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/heart`, {
+      method: "POST",
+      headers: { Cookie: aliceCookie }
+    });
+    expect(res.status).toBe(403);
+  });
+
+  // ── Listen count ─────────────────────────────────────────────────
+
+  it("increments listen count", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-listen-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "Listened" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/listen`, {
+      method: "POST",
+      headers: { Cookie: cookie }
+    });
+    expect(res.status).toBe(200);
+    expect(res.payload).toEqual({ listenCount: 1 });
+
+    // Second call within debounce window should not increment further
+    const res2 = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/listen`, {
+      method: "POST",
+      headers: { Cookie: cookie }
+    });
+    expect(res2.status).toBe(200);
+    expect((res2.payload as { listenCount: number }).listenCount).toBeLessThanOrEqual(1);
+  });
+
+  it("returns 404 for listen on non-existent playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-listen-404-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const res = await apiRequest("/api/playlists/nonexistent:playlist/listen", {
+      method: "POST",
+      headers: { Cookie: cookie }
+    });
+    expect(res.status).toBe(404);
+  });
+
+  // ── Collaborators ────────────────────────────────────────────────
+
+  it("adds collaborators to a playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-collabs-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+
+    // Find alice's user id
+    const usersRes = await apiRequest("/api/users", {
+      method: "GET",
+      headers: { Cookie: adminCookie }
+    });
+    const users = (usersRes.payload as { users: Array<{ id: string; username: string }> }).users;
+    const alice = users.find((u) => u.username === "alice")!;
+
+    const { id } = await createPlaylist(adminCookie, { name: "Collab" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { Cookie: adminCookie },
+      body: JSON.stringify({ collaborators: [alice.id] })
+    });
+    expect(res.status).toBe(200);
+    const updated = (res.payload as { playlist: Playlist }).playlist;
+    expect(updated.collaborators).toEqual([alice.id]);
+  });
+
+  it("rejects invalid collaborator user ids", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-collabs-invalid-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "BadCollab" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { Cookie: cookie },
+      body: JSON.stringify({ collaborators: ["nonexistent-user-id"] })
+    });
+    expect(res.status).toBe(400);
+    expect(res.payload).toEqual(expect.objectContaining({ error: expect.stringContaining("Unknown collaborator") }));
+  });
+
+  // ── Cover ────────────────────────────────────────────────────────
+
+  it("returns 404 for cover on playlist without cover", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-cover-none-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "NoCover" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/cover`, {
+      method: "GET",
+      headers: { Cookie: cookie }
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects cover upload with non-image file", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-cover-bad-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "BadCover" });
+
+    const res = await apiMultipartRequest({
+      pathname: `/api/playlists/${encodeURIComponent(id)}/cover`,
+      cookie,
+      fileFieldName: "cover",
+      fileName: "readme.txt",
+      mimeType: "text/plain",
+      bytes: [72, 101, 108, 108, 111] // "Hello"
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects cover delete on another user's playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-cover-authz-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+    const aliceCookie = await login("alice", "alice-password");
+
+    const { id } = await createPlaylist(adminCookie, { name: "NotYours" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/cover`, {
+      method: "DELETE",
+      headers: { Cookie: aliceCookie }
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("blocks cover GET for private playlist from non-owner", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-cover-view-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+    const aliceCookie = await login("alice", "alice-password");
+
+    const { id } = await createPlaylist(adminCookie, { name: "PrivCover", visibility: "private" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}/cover`, {
+      method: "GET",
+      headers: { Cookie: aliceCookie }
+    });
+    // Either 404 (no cover) or 403 (access denied) — since there's no cover, the check
+    // should fail with 404 before the visibility check, but if we had a cover it would be 403.
+    // Without a cover: 404 is expected.
+    expect(res.status).toBe(404);
+  });
+
+  // ── Description preserved across rename ──────────────────────────
+
+  it("preserves description when renaming a playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-rename-desc-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const { id } = await createPlaylist(cookie, { name: "Original", description: "My description" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { Cookie: cookie },
+      body: JSON.stringify({ name: "Renamed", description: "Updated desc" })
+    });
+    expect(res.status).toBe(200);
+    const updated = (res.payload as { playlist: Playlist }).playlist;
+    expect(updated.name).toBe("Renamed");
+    expect(updated.description).toBe("Updated desc");
+  });
+
+  // ── Hearts preserved across updates ──────────────────────────────
+
+  it("preserves hearts when patching a playlist", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-heart-persist-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+    const aliceCookie = await login("alice", "alice-password");
+
+    const { id } = await createPlaylist(adminCookie, { name: "HeartKeep", visibility: "public" });
+
+    // Alice hearts it
+    await apiRequest(`/api/playlists/${encodeURIComponent(id)}/heart`, {
+      method: "POST",
+      headers: { Cookie: aliceCookie }
+    });
+
+    // Admin patches the playlist
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { Cookie: adminCookie },
+      body: JSON.stringify({ name: "HeartKeep Renamed" })
+    });
+    expect(res.status).toBe(200);
+    const updated = (res.payload as { playlist: Playlist }).playlist;
+    expect(updated.heartCount).toBe(1);
+  });
+
+  // ── PUT (full update) ────────────────────────────────────────────
+
+  it("rejects PUT from non-owner", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-put-authz-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const adminCookie = await login("admin", "admin-secret-123");
+    const aliceCookie = await login("alice", "alice-password");
+
+    const { id } = await createPlaylist(adminCookie, { name: "NotAlice", visibility: "public" });
+
+    const res = await apiRequest(`/api/playlists/${encodeURIComponent(id)}`, {
+      method: "PUT",
+      headers: { Cookie: aliceCookie },
+      body: JSON.stringify({
+        name: "Hijacked",
+        visibility: "public",
+        trackIds: ["track-a"]
+      })
+    });
+    expect(res.status).toBe(403);
   });
 });

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -20,6 +20,7 @@ const coverUpload = multer({
 });
 import {
   canManagePlaylist,
+  canViewPlaylist,
   createFilesystemPlaylist,
   deleteFilesystemPlaylist,
   filterPlayablePlaylists,
@@ -27,9 +28,9 @@ import {
   incrementPlaylistListenCount,
   togglePlaylistHeart,
   updateFilesystemPlaylist,
-  updatePlaylistCover,
-  updatePlaylistDescription
+  updatePlaylistCover
 } from "../services/playlists/playlistStore";
+import { listUsers } from "../auth/db";
 import type { Playlist, PlaylistVisibility, Track } from "../types/library";
 
 function normalizeVisibility(value: unknown): PlaylistVisibility | null | undefined {
@@ -94,6 +95,19 @@ function findPlaylistById(indexStore: IndexStore, playlistId: string): Playlist 
   const playlists = indexStore.getSnapshot().playlists ?? [];
   return playlists.find((playlist) => playlist.id === playlistId);
 }
+
+const listenDebounceMap = new Map<string, number>();
+const LISTEN_DEBOUNCE_MS = 60 * 60 * 1000; // 1 hour
+
+// Sweep expired entries every hour to prevent unbounded growth
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, timestamp] of listenDebounceMap) {
+    if (now - timestamp >= LISTEN_DEBOUNCE_MS) {
+      listenDebounceMap.delete(key);
+    }
+  }
+}, LISTEN_DEBOUNCE_MS).unref();
 
 export function createPlaylistRouter(indexStore: IndexStore): Router {
   const router = Router();
@@ -163,13 +177,16 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
+      const description = typeof req.body?.description === "string" ? req.body.description.trim() : undefined;
+
       const snapshot = indexStore.getSnapshot();
       const playlistId = await createFilesystemPlaylist({
         name,
         authorId: authUser.id,
         visibility: visibility ?? "private",
         trackIds: trackIds ?? [],
-        tracksById: getTracksById(snapshot.tracks)
+        tracksById: getTracksById(snapshot.tracks),
+        description
       });
 
       const rebuilt = await indexStore.refreshPlaylists();
@@ -323,10 +340,18 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
-      const description = typeof req.body?.description === "string" ? req.body.description : undefined;
+      const description = typeof req.body?.description === "string" ? req.body.description.trim() : undefined;
+      const collaborators = Array.isArray(req.body?.collaborators)
+        ? (req.body.collaborators as unknown[]).filter((c): c is string => typeof c === "string" && c.trim() !== "").map((c) => c.trim())
+        : undefined;
 
-      if (description !== undefined) {
-        await updatePlaylistDescription(playlistId, description);
+      if (collaborators !== undefined && collaborators.length > 0) {
+        const validUserIds = new Set(listUsers().map((u) => u.id));
+        const invalid = collaborators.filter((id) => !validUserIds.has(id));
+        if (invalid.length > 0) {
+          res.status(400).json({ error: `Unknown collaborator user ids: ${invalid.join(", ")}` });
+          return;
+        }
       }
 
       const snapshot = indexStore.getSnapshot();
@@ -336,7 +361,9 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         authorId: existing.authorId,
         visibility: visibility ?? existing.visibility,
         trackIds: trackIds ?? existing.trackIds,
-        tracksById: getTracksById(snapshot.tracks)
+        tracksById: getTracksById(snapshot.tracks),
+        description,
+        collaborators
       });
 
       const rebuilt = await indexStore.refreshPlaylists();
@@ -461,6 +488,16 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
+      const debounceKey = `${authUser.id}:${playlistId}`;
+      const lastListen = listenDebounceMap.get(debounceKey);
+      const now = Date.now();
+
+      if (lastListen && now - lastListen < LISTEN_DEBOUNCE_MS) {
+        res.json({ listenCount: playlist.listenCount });
+        return;
+      }
+
+      listenDebounceMap.set(debounceKey, now);
       const listenCount = await incrementPlaylistListenCount(playlistId);
       res.json({ listenCount });
     } catch (error) {
@@ -550,15 +587,21 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
 
   router.get("/playlists/:id/cover", requireAuth, async (req, res, next) => {
     try {
+      const authUser = req.authUser;
       const playlistId = req.params.id;
-      if (!playlistId) {
-        res.status(400).json({ error: "Playlist id is required" });
+      if (!authUser || !playlistId) {
+        res.status(401).json({ error: "Authentication required" });
         return;
       }
 
       const playlist = findPlaylistById(indexStore, playlistId);
       if (!playlist || !playlist.cover) {
         res.status(404).json({ error: "Cover not found" });
+        return;
+      }
+
+      if (!canViewPlaylist(playlist, authUser)) {
+        res.status(403).json({ error: "Not allowed to access this playlist" });
         return;
       }
 

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -19,6 +19,7 @@ const coverUpload = multer({
   limits: { fileSize: COVER_MAX_BYTES, files: 1 }
 });
 import {
+  canEditPlaylist,
   canManagePlaylist,
   canViewPlaylist,
   createFilesystemPlaylist,
@@ -236,7 +237,7 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
-      if (!canManagePlaylist(existing, authUser)) {
+      if (!canEditPlaylist(existing, authUser)) {
         res.status(403).json({ error: "Not allowed to modify this playlist" });
         return;
       }
@@ -317,7 +318,7 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
-      if (!canManagePlaylist(existing, authUser)) {
+      if (!canEditPlaylist(existing, authUser)) {
         res.status(403).json({ error: "Not allowed to modify this playlist" });
         return;
       }
@@ -537,7 +538,7 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
           return;
         }
 
-        if (!canManagePlaylist(playlist, authUser)) {
+        if (!canEditPlaylist(playlist, authUser)) {
           res.status(403).json({ error: "Not allowed to modify this playlist" });
           return;
         }
@@ -628,7 +629,7 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return;
       }
 
-      if (!canManagePlaylist(playlist, authUser)) {
+      if (!canEditPlaylist(playlist, authUser)) {
         res.status(403).json({ error: "Not allowed to modify this playlist" });
         return;
       }

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -346,8 +346,9 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         : undefined;
 
       if (collaborators !== undefined && collaborators.length > 0) {
+        // Validate each collaborator: either a valid user ID or the special "everyone" value
         const validUserIds = new Set(listUsers().map((u) => u.id));
-        const invalid = collaborators.filter((id) => !validUserIds.has(id));
+        const invalid = collaborators.filter((id) => id !== "everyone" && !validUserIds.has(id));
         if (invalid.length > 0) {
           res.status(400).json({ error: `Unknown collaborator user ids: ${invalid.join(", ")}` });
           return;

--- a/backend/src/api/router.ts
+++ b/backend/src/api/router.ts
@@ -3,6 +3,7 @@ import { Router } from "express";
 import { IndexStore } from "../services/indexer/indexStore";
 import { createAutoPlaylistRouter } from "./autoPlaylistRoutes";
 import { createAuthRouter } from "./authRoutes";
+import { createForYouPlaylistRouter } from "./forYouPlaylistRoutes";
 import { createBackupRouter } from "./backupRoutes";
 import { createCoverRouter } from "./coverRoutes";
 import { createGenreRouter } from "./genreRoutes";
@@ -31,6 +32,7 @@ export function createApiRouter(indexStore: IndexStore): Router {
   router.use(createIndexRouter(indexStore));
   router.use(createGenreRouter(indexStore));
   router.use(createAutoPlaylistRouter(indexStore));
+  router.use(createForYouPlaylistRouter(indexStore));
   router.use(createUserRouter());
   router.use(createLogRouter());
   router.use(createServerRouter());

--- a/backend/src/api/router.ts
+++ b/backend/src/api/router.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 import { IndexStore } from "../services/indexer/indexStore";
+import { createAutoPlaylistRouter } from "./autoPlaylistRoutes";
 import { createAuthRouter } from "./authRoutes";
 import { createBackupRouter } from "./backupRoutes";
 import { createCoverRouter } from "./coverRoutes";
@@ -29,6 +30,7 @@ export function createApiRouter(indexStore: IndexStore): Router {
   router.use(createCoverRouter(indexStore));
   router.use(createIndexRouter(indexStore));
   router.use(createGenreRouter(indexStore));
+  router.use(createAutoPlaylistRouter(indexStore));
   router.use(createUserRouter());
   router.use(createLogRouter());
   router.use(createServerRouter());

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -16,6 +16,8 @@ import { startBackupScheduler } from "./services/backup/backupService";
 import { startVersionCheckSchedule } from "./services/versionCheck";
 import { ensureBaseDirectories } from "./utils/fs";
 import { checkAndRegenerateOnBoot } from "./services/playlists/autoPlaylistService";
+import { checkAndRegenerateForYouOnBoot } from "./services/playlists/forYouPlaylistService";
+import { listUsers } from "./auth/db";
 
 const SESSION_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
 const SHUTDOWN_TIMEOUT_MS = 10_000;
@@ -90,6 +92,9 @@ async function bootstrap(): Promise<void> {
   startVersionCheckSchedule();
   void startBackupScheduler();
   void checkAndRegenerateOnBoot(indexStore.getSnapshot().tracks);
+  void Promise.all(
+    listUsers().map((user) => checkAndRegenerateForYouOnBoot(user.id, indexStore))
+  );
 }
 
 bootstrap().catch((error: unknown) => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -15,6 +15,7 @@ import { migratePerUserUploadsToSharedMusic } from "./services/storage/storageSe
 import { startBackupScheduler } from "./services/backup/backupService";
 import { startVersionCheckSchedule } from "./services/versionCheck";
 import { ensureBaseDirectories } from "./utils/fs";
+import { checkAndRegenerateOnBoot } from "./services/playlists/autoPlaylistService";
 
 const SESSION_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
 const SHUTDOWN_TIMEOUT_MS = 10_000;
@@ -88,6 +89,7 @@ async function bootstrap(): Promise<void> {
 
   startVersionCheckSchedule();
   void startBackupScheduler();
+  void checkAndRegenerateOnBoot(indexStore.getSnapshot().tracks);
 }
 
 bootstrap().catch((error: unknown) => {

--- a/backend/src/services/playlists/autoPlaylistService.ts
+++ b/backend/src/services/playlists/autoPlaylistService.ts
@@ -1,0 +1,266 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { dataRoot } from "../../utils/paths";
+import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
+import { normalizeGenreLabel } from "../genre/genreSynonymService";
+import type { Track } from "../../types/library";
+
+const log = createLogger("auto-playlists");
+
+const AUTO_PLAYLISTS_DIR = path.join(dataRoot, "auto-playlists");
+const META_FILE = path.join(AUTO_PLAYLISTS_DIR, "_meta.json");
+const CONFIG_FILE = path.join(dataRoot, "config", "auto-playlist-config.json");
+
+const REGENERATION_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000;
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export type AutoPlaylist = {
+  id: string;
+  name: string;
+  genre: string;
+  decade: number;
+  trackIds: string[];
+  trackCount: number;
+  generatedAt: string;
+};
+
+export type AutoPlaylistConfig = {
+  maxPlaylists: number;
+  minTracksPerPlaylist: number;
+  tracksPerPlaylist: number;
+};
+
+type AutoPlaylistMeta = {
+  lastGeneratedAt: string;
+};
+
+// ── Config ─────────────────────────────────────────────────────────
+
+const DEFAULT_CONFIG: AutoPlaylistConfig = {
+  maxPlaylists: 0,
+  minTracksPerPlaylist: 8,
+  tracksPerPlaylist: 30
+};
+
+export async function getAutoPlaylistConfig(): Promise<AutoPlaylistConfig> {
+  const raw = await readJsonFile<Partial<AutoPlaylistConfig>>(CONFIG_FILE, {});
+  return {
+    maxPlaylists: typeof raw.maxPlaylists === "number" && raw.maxPlaylists >= 0
+      ? raw.maxPlaylists : DEFAULT_CONFIG.maxPlaylists,
+    minTracksPerPlaylist: typeof raw.minTracksPerPlaylist === "number" && raw.minTracksPerPlaylist >= 1
+      ? raw.minTracksPerPlaylist : DEFAULT_CONFIG.minTracksPerPlaylist,
+    tracksPerPlaylist: typeof raw.tracksPerPlaylist === "number" && raw.tracksPerPlaylist >= 1
+      ? raw.tracksPerPlaylist : DEFAULT_CONFIG.tracksPerPlaylist
+  };
+}
+
+export async function updateAutoPlaylistConfig(patch: Partial<AutoPlaylistConfig>): Promise<AutoPlaylistConfig> {
+  const current = await getAutoPlaylistConfig();
+  const next: AutoPlaylistConfig = {
+    maxPlaylists: typeof patch.maxPlaylists === "number" && patch.maxPlaylists >= 0
+      ? patch.maxPlaylists : current.maxPlaylists,
+    minTracksPerPlaylist: typeof patch.minTracksPerPlaylist === "number" && patch.minTracksPerPlaylist >= 1
+      ? patch.minTracksPerPlaylist : current.minTracksPerPlaylist,
+    tracksPerPlaylist: typeof patch.tracksPerPlaylist === "number" && patch.tracksPerPlaylist >= 1
+      ? patch.tracksPerPlaylist : current.tracksPerPlaylist
+  };
+  await writeJsonAtomic(CONFIG_FILE, next);
+  return next;
+}
+
+// ── Diversity selection ────────────────────────────────────────────
+
+type ScoredTrack = {
+  track: Track;
+  artist: string;
+  album: string;
+};
+
+function selectDiverseTracks(candidates: ScoredTrack[], maxTracks: number): Track[] {
+  const pool = [...candidates].sort(() => Math.random() - 0.5);
+  const selected: ScoredTrack[] = [];
+
+  while (selected.length < maxTracks && pool.length > 0) {
+    let bestIndex = 0;
+    let bestScore = Number.NEGATIVE_INFINITY;
+
+    for (let i = 0; i < pool.length; i++) {
+      const candidate = pool[i]!;
+      let score = 100;
+
+      const prev = selected[selected.length - 1];
+      if (prev) {
+        if (prev.artist === candidate.artist) score -= 1000;
+        if (prev.album === candidate.album) score -= 500;
+      }
+
+      const recentArtists = selected.slice(-3).map((s) => s.artist);
+      if (recentArtists.includes(candidate.artist)) score -= 250;
+
+      score += Math.random() * 40;
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestIndex = i;
+      }
+    }
+
+    selected.push(pool[bestIndex]!);
+    pool.splice(bestIndex, 1);
+  }
+
+  return selected.map((s) => s.track);
+}
+
+// ── Generation ─────────────────────────────────────────────────────
+
+function toDecadeLabel(decade: number): string {
+  return `${decade % 100 === 0 ? decade : decade % 100}s`;
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export async function generateAutoPlaylists(tracks: Track[]): Promise<AutoPlaylist[]> {
+  const config = await getAutoPlaylistConfig();
+
+  const groups = new Map<string, { genre: string; decade: number; tracks: ScoredTrack[] }>();
+
+  for (const track of tracks) {
+    const genres = track.tags.genre;
+    const year = track.tags.year;
+    if (!genres || genres.length === 0 || !year) continue;
+
+    const primaryGenre = normalizeGenreLabel(genres[0]!);
+    const decade = Math.floor(year / 10) * 10;
+    const key = `${decade}:${primaryGenre.toLowerCase()}`;
+
+    let group = groups.get(key);
+    if (!group) {
+      group = { genre: primaryGenre, decade, tracks: [] };
+      groups.set(key, group);
+    }
+
+    group.tracks.push({
+      track,
+      artist: (track.tags.artist ?? "").toLowerCase(),
+      album: (track.tags.album ?? "").toLowerCase()
+    });
+  }
+
+  let qualifyingGroups = Array.from(groups.values())
+    .filter((g) => g.tracks.length >= config.minTracksPerPlaylist)
+    .sort((a, b) => b.tracks.length - a.tracks.length);
+
+  if (config.maxPlaylists > 0) {
+    qualifyingGroups = qualifyingGroups.slice(0, config.maxPlaylists);
+  }
+
+  const generatedAt = new Date().toISOString();
+  const playlists: AutoPlaylist[] = [];
+
+  for (const group of qualifyingGroups) {
+    const decadeLabel = toDecadeLabel(group.decade);
+    const name = `${decadeLabel} ${group.genre}`;
+    const id = `auto:${slugify(name)}`;
+    const selectedTracks = selectDiverseTracks(group.tracks, config.tracksPerPlaylist);
+
+    playlists.push({
+      id,
+      name,
+      genre: group.genre,
+      decade: group.decade,
+      trackIds: selectedTracks.map((t) => t.id),
+      trackCount: selectedTracks.length,
+      generatedAt
+    });
+  }
+
+  return playlists;
+}
+
+// ── Storage ────────────────────────────────────────────────────────
+
+export async function saveAutoPlaylists(playlists: AutoPlaylist[]): Promise<void> {
+  await ensureDir(AUTO_PLAYLISTS_DIR);
+
+  const existing = await fs.readdir(AUTO_PLAYLISTS_DIR).catch(() => []);
+  for (const file of existing) {
+    if (file.endsWith(".json") && file !== "_meta.json") {
+      await fs.unlink(path.join(AUTO_PLAYLISTS_DIR, file)).catch(() => {});
+    }
+  }
+
+  for (const playlist of playlists) {
+    const fileName = `${slugify(playlist.name)}.json`;
+    await writeJsonAtomic(path.join(AUTO_PLAYLISTS_DIR, fileName), playlist);
+  }
+
+  const meta: AutoPlaylistMeta = { lastGeneratedAt: new Date().toISOString() };
+  await writeJsonAtomic(META_FILE, meta);
+
+  log.info(`Saved ${playlists.length} auto playlist(s)`);
+}
+
+export async function loadAutoPlaylists(): Promise<AutoPlaylist[]> {
+  await ensureDir(AUTO_PLAYLISTS_DIR);
+
+  const files = await fs.readdir(AUTO_PLAYLISTS_DIR).catch(() => []);
+  const playlists: AutoPlaylist[] = [];
+
+  for (const file of files) {
+    if (!file.endsWith(".json") || file === "_meta.json") continue;
+    const data = await readJsonFile<AutoPlaylist>(
+      path.join(AUTO_PLAYLISTS_DIR, file),
+      null as unknown as AutoPlaylist
+    );
+    if (data && data.id && data.trackIds) {
+      playlists.push(data);
+    }
+  }
+
+  return playlists.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getAutoPlaylistById(id: string): Promise<AutoPlaylist | null> {
+  const all = await loadAutoPlaylists();
+  return all.find((p) => p.id === id) ?? null;
+}
+
+// ── Regeneration check ─────────────────────────────────────────────
+
+export async function needsRegeneration(): Promise<boolean> {
+  const meta = await readJsonFile<AutoPlaylistMeta>(META_FILE, { lastGeneratedAt: "" });
+  if (!meta.lastGeneratedAt) return true;
+
+  const lastGenerated = new Date(meta.lastGeneratedAt).getTime();
+  if (isNaN(lastGenerated)) return true;
+
+  return Date.now() - lastGenerated > REGENERATION_INTERVAL_MS;
+}
+
+export async function regenerateAutoPlaylists(tracks: Track[]): Promise<AutoPlaylist[]> {
+  log.info("Regenerating auto playlists...");
+  const playlists = await generateAutoPlaylists(tracks);
+  await saveAutoPlaylists(playlists);
+  log.info(`Generated ${playlists.length} auto playlist(s)`);
+  return playlists;
+}
+
+export async function checkAndRegenerateOnBoot(tracks: Track[]): Promise<void> {
+  const shouldRegenerate = await needsRegeneration();
+  if (!shouldRegenerate) {
+    const existing = await loadAutoPlaylists();
+    log.info(`Auto playlists up to date (${existing.length} playlist(s))`);
+    return;
+  }
+
+  await regenerateAutoPlaylists(tracks);
+}

--- a/backend/src/services/playlists/forYouPlaylistService.test.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+let tmpDir: string;
+
+vi.mock("../../utils/paths", async () => {
+  return {
+    get dataRoot() { return path.join(tmpDir, "data"); },
+    get usersStorageRoot() { return path.join(tmpDir, "data", "storage", "users"); },
+    get configRoot() { return path.join(tmpDir, "data", "config"); }
+  };
+});
+
+vi.mock("../../utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+vi.mock("../genre/genreSynonymService", () => ({
+  normalizeGenreLabel: (g: string) => g
+}));
+
+import type { Track } from "../../types/library";
+import type { IndexStore } from "../indexer/indexStore";
+
+function makeTrack(overrides: Partial<Track> & { id: string }): Track {
+  return {
+    owner: "user-1",
+    path: `/music/${overrides.id}.flac`,
+    duration: 240,
+    mimeType: "audio/flac",
+    codec: "flac",
+    tags: {},
+    ...overrides
+  };
+}
+
+function makeMockIndexStore(tracks: Track[]): IndexStore {
+  const byId = new Map(tracks.map((t) => [t.id, t]));
+  const byArtist = new Map<string, Track[]>();
+  for (const t of tracks) {
+    const artist = (t.tags.artist ?? "Unknown").toLowerCase();
+    const list = byArtist.get(artist) ?? [];
+    list.push(t);
+    byArtist.set(artist, list);
+  }
+
+  return {
+    getSnapshot: () => ({ tracks, totalTracks: tracks.length, generatedAt: "", playlists: [] }),
+    getTrackById: (id: string) => byId.get(id),
+    getTracksByArtist: (artist: string) => byArtist.get(artist.toLowerCase()) ?? [],
+    hasTrack: (id: string) => byId.has(id)
+  } as unknown as IndexStore;
+}
+
+describe("forYouPlaylistService", () => {
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "foryou-test-"));
+    await fs.mkdir(path.join(tmpDir, "data", "config"), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, "data", "storage", "users"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("skips generation when user has too few plays", async () => {
+    const { generateForYouPlaylists } = await import("./forYouPlaylistService");
+
+    const tracks = Array.from({ length: 30 }, (_, i) =>
+      makeTrack({
+        id: `track-${i}`,
+        tags: { artist: `Artist ${i % 5}`, genre: ["Rock"], year: 2000 }
+      })
+    );
+    const indexStore = makeMockIndexStore(tracks);
+
+    const result = await generateForYouPlaylists("user-1", indexStore);
+    expect(result).toEqual([]);
+  });
+
+  it("generates playlists when user meets thresholds", async () => {
+    const { generateForYouPlaylists } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    const artists = ["Pink Floyd", "Led Zeppelin", "Deep Purple", "Black Sabbath", "Jethro Tull"];
+    const tracks: Track[] = [];
+
+    for (let i = 0; i < 60; i++) {
+      const artist = artists[i % 5]!;
+      tracks.push(
+        makeTrack({
+          id: `track-${i}`,
+          tags: { artist, genre: ["Rock"], year: 1970 + (i % 10) }
+        })
+      );
+    }
+
+    const indexStore = makeMockIndexStore(tracks);
+
+    const playCountsDir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(playCountsDir);
+
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 30; i++) {
+      playCounts[`track-${i}`] = { count: 2, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    }
+    await writeJsonAtomic(path.join(playCountsDir, "play-counts.json"), { tracks: playCounts });
+
+    const result = await generateForYouPlaylists("user-1", indexStore);
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.length).toBeLessThanOrEqual(3);
+
+    for (const playlist of result) {
+      expect(playlist.id).toMatch(/^for-you:/);
+      expect(playlist.name).toMatch(/^Because you listen to /);
+      expect(playlist.trackIds.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("dismisses and stores dismissal", async () => {
+    const { dismissForYouPlaylist, getUserDismissals } = await import("./forYouPlaylistService");
+
+    await dismissForYouPlaylist("user-1", "for-you:pink-floyd");
+
+    const dismissals = await getUserDismissals("user-1");
+    expect(dismissals.has("for-you:pink-floyd")).toBe(true);
+    expect(dismissals.has("for-you:led-zeppelin")).toBe(false);
+  });
+
+  it("saves and loads for-you playlists", async () => {
+    const { saveForYouPlaylists, loadForYouPlaylists } = await import("./forYouPlaylistService");
+
+    const playlists = [
+      {
+        id: "for-you:pink-floyd",
+        name: "Because you listen to Pink Floyd",
+        seedArtist: "Pink Floyd",
+        trackIds: ["t1", "t2", "t3"],
+        trackCount: 3,
+        generatedAt: "2026-04-01T00:00:00Z"
+      }
+    ];
+
+    await saveForYouPlaylists("user-1", playlists);
+    const loaded = await loadForYouPlaylists("user-1");
+
+    expect(loaded.length).toBe(1);
+    expect(loaded[0]!.id).toBe("for-you:pink-floyd");
+    expect(loaded[0]!.trackIds).toEqual(["t1", "t2", "t3"]);
+  });
+});

--- a/backend/src/services/playlists/forYouPlaylistService.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.ts
@@ -1,0 +1,401 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { dataRoot, usersStorageRoot } from "../../utils/paths";
+import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
+import { normalizeGenreLabel } from "../genre/genreSynonymService";
+import { getUserTopArtists, getUserPlayCounts } from "../activity/playCountStore";
+import type { IndexStore } from "../indexer/indexStore";
+import type { Track } from "../../types/library";
+
+const log = createLogger("for-you-playlists");
+
+const FOR_YOU_DIR = path.join(dataRoot, "auto-playlists", "for-you");
+const REGENERATION_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000;
+
+const MIN_TOTAL_PLAYS = 20;
+const MIN_DISTINCT_ARTISTS = 3;
+const MAX_TOP_ARTISTS = 3;
+const TRACKS_PER_PLAYLIST = 25;
+const SEED_ARTIST_RATIO = 0.4;
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export type ForYouPlaylist = {
+  id: string;
+  name: string;
+  seedArtist: string;
+  trackIds: string[];
+  trackCount: number;
+  generatedAt: string;
+};
+
+type ForYouMeta = {
+  lastGeneratedAt: string;
+};
+
+type DismissedEntry = {
+  playlistId: string;
+  dismissedAt: string;
+};
+
+type DismissedFile = {
+  dismissed: DismissedEntry[];
+};
+
+// ── Paths ──────────────────────────────────────────────────────────
+
+function userForYouDir(userId: string): string {
+  return path.join(FOR_YOU_DIR, userId);
+}
+
+function userForYouMetaPath(userId: string): string {
+  return path.join(userForYouDir(userId), "_meta.json");
+}
+
+function dismissedPath(userId: string): string {
+  return path.join(usersStorageRoot, userId, "dismissed-playlists.json");
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+// ── Diversity selection (reused from auto playlist service) ───────
+
+type ScoredTrack = {
+  track: Track;
+  artist: string;
+  album: string;
+};
+
+function selectDiverseTracks(candidates: ScoredTrack[], maxTracks: number): Track[] {
+  const pool = [...candidates].sort(() => Math.random() - 0.5);
+  const selected: ScoredTrack[] = [];
+
+  while (selected.length < maxTracks && pool.length > 0) {
+    let bestIndex = 0;
+    let bestScore = Number.NEGATIVE_INFINITY;
+
+    for (let i = 0; i < pool.length; i++) {
+      const candidate = pool[i]!;
+      let score = 100;
+
+      const prev = selected[selected.length - 1];
+      if (prev) {
+        if (prev.artist === candidate.artist) score -= 1000;
+        if (prev.album === candidate.album) score -= 500;
+      }
+
+      const recentArtists = selected.slice(-3).map((s) => s.artist);
+      if (recentArtists.includes(candidate.artist)) score -= 250;
+
+      score += Math.random() * 40;
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestIndex = i;
+      }
+    }
+
+    selected.push(pool[bestIndex]!);
+    pool.splice(bestIndex, 1);
+  }
+
+  return selected.map((s) => s.track);
+}
+
+// ── Dismissal store ───────────────────────────────────────────────
+
+const DISMISSAL_EXPIRY_MS = 90 * 24 * 60 * 60 * 1000; // 3 months
+
+async function readDismissals(userId: string): Promise<DismissedEntry[]> {
+  const data = await readJsonFile<DismissedFile>(dismissedPath(userId), { dismissed: [] });
+  if (!data || !Array.isArray(data.dismissed)) return [];
+  return data.dismissed;
+}
+
+async function writeDismissals(userId: string, entries: DismissedEntry[]): Promise<void> {
+  const filePath = dismissedPath(userId);
+  await ensureDir(path.dirname(filePath));
+  await writeJsonAtomic(filePath, { dismissed: entries });
+}
+
+function getActiveDismissals(entries: DismissedEntry[]): Set<string> {
+  const now = Date.now();
+  const active = new Set<string>();
+  for (const entry of entries) {
+    const dismissedAt = new Date(entry.dismissedAt).getTime();
+    if (!isNaN(dismissedAt) && now - dismissedAt < DISMISSAL_EXPIRY_MS) {
+      active.add(entry.playlistId);
+    }
+  }
+  return active;
+}
+
+export async function dismissForYouPlaylist(userId: string, playlistId: string): Promise<void> {
+  const entries = await readDismissals(userId);
+  const existing = entries.find((e) => e.playlistId === playlistId);
+  if (existing) {
+    existing.dismissedAt = new Date().toISOString();
+  } else {
+    entries.push({ playlistId, dismissedAt: new Date().toISOString() });
+  }
+  await writeDismissals(userId, entries);
+  log.info(`User ${userId} dismissed for-you playlist ${playlistId}`);
+}
+
+export async function getUserDismissals(userId: string): Promise<Set<string>> {
+  const entries = await readDismissals(userId);
+  return getActiveDismissals(entries);
+}
+
+// ── Playlist generation ───────────────────────────────────────────
+
+function getArtistProfile(
+  artist: string,
+  indexStore: IndexStore
+): { genres: string[]; minYear: number; maxYear: number } {
+  const tracks = indexStore.getTracksByArtist(artist);
+  const genres = new Set<string>();
+  let minYear = Infinity;
+  let maxYear = -Infinity;
+
+  for (const track of tracks) {
+    if (track.tags.genre) {
+      for (const g of track.tags.genre) {
+        genres.add(normalizeGenreLabel(g).toLowerCase());
+      }
+    }
+    if (track.tags.year) {
+      if (track.tags.year < minYear) minYear = track.tags.year;
+      if (track.tags.year > maxYear) maxYear = track.tags.year;
+    }
+  }
+
+  return {
+    genres: Array.from(genres),
+    minYear: minYear === Infinity ? 1970 : minYear,
+    maxYear: maxYear === -Infinity ? 2026 : maxYear
+  };
+}
+
+function findPeerTracks(
+  seedArtist: string,
+  profile: { genres: string[]; minYear: number; maxYear: number },
+  allTracks: Track[]
+): ScoredTrack[] {
+  const yearLow = profile.minYear - 10;
+  const yearHigh = profile.maxYear + 10;
+  const genreSet = new Set(profile.genres);
+  const seedArtistLower = seedArtist.toLowerCase();
+  const peers: ScoredTrack[] = [];
+
+  for (const track of allTracks) {
+    const trackArtist = (track.tags.artist ?? "").toLowerCase();
+    if (trackArtist === seedArtistLower) continue;
+
+    const year = track.tags.year;
+    if (year && (year < yearLow || year > yearHigh)) continue;
+
+    const trackGenres = track.tags.genre;
+    if (!trackGenres || trackGenres.length === 0) continue;
+
+    const hasMatchingGenre = trackGenres.some(
+      (g) => genreSet.has(normalizeGenreLabel(g).toLowerCase())
+    );
+    if (!hasMatchingGenre) continue;
+
+    peers.push({
+      track,
+      artist: trackArtist,
+      album: (track.tags.album ?? "").toLowerCase()
+    });
+  }
+
+  return peers;
+}
+
+function buildForYouPlaylist(
+  seedArtist: string,
+  indexStore: IndexStore,
+  allTracks: Track[]
+): ForYouPlaylist | null {
+  const profile = getArtistProfile(seedArtist, indexStore);
+  if (profile.genres.length === 0) return null;
+
+  const seedTracks = indexStore.getTracksByArtist(seedArtist);
+  const seedScored: ScoredTrack[] = seedTracks.map((t) => ({
+    track: t,
+    artist: (t.tags.artist ?? "").toLowerCase(),
+    album: (t.tags.album ?? "").toLowerCase()
+  }));
+
+  const peerTracks = findPeerTracks(seedArtist, profile, allTracks);
+  if (peerTracks.length < 3) return null;
+
+  const seedCount = Math.round(TRACKS_PER_PLAYLIST * SEED_ARTIST_RATIO);
+  const peerCount = TRACKS_PER_PLAYLIST - seedCount;
+
+  const selectedSeed = selectDiverseTracks(seedScored, seedCount);
+  const selectedPeers = selectDiverseTracks(peerTracks, peerCount);
+
+  const combined: ScoredTrack[] = [
+    ...selectedSeed.map((t) => ({
+      track: t,
+      artist: (t.tags.artist ?? "").toLowerCase(),
+      album: (t.tags.album ?? "").toLowerCase()
+    })),
+    ...selectedPeers.map((t) => ({
+      track: t,
+      artist: (t.tags.artist ?? "").toLowerCase(),
+      album: (t.tags.album ?? "").toLowerCase()
+    }))
+  ];
+
+  const finalTracks = selectDiverseTracks(combined, TRACKS_PER_PLAYLIST);
+  if (finalTracks.length < 5) return null;
+
+  const id = `for-you:${slugify(seedArtist)}`;
+  return {
+    id,
+    name: `Because you listen to ${seedArtist}`,
+    seedArtist,
+    trackIds: finalTracks.map((t) => t.id),
+    trackCount: finalTracks.length,
+    generatedAt: new Date().toISOString()
+  };
+}
+
+export async function generateForYouPlaylists(
+  userId: string,
+  indexStore: IndexStore
+): Promise<ForYouPlaylist[]> {
+  const playCounts = await getUserPlayCounts(userId);
+  const entries = Object.entries(playCounts);
+  const totalPlays = entries.reduce((sum, [, e]) => sum + e.count, 0);
+
+  if (totalPlays < MIN_TOTAL_PLAYS) {
+    log.debug(`User ${userId} has only ${totalPlays} plays, skipping for-you generation`);
+    return [];
+  }
+
+  const topArtists = await getUserTopArtists(userId, MAX_TOP_ARTISTS + 5, indexStore);
+  const distinctArtists = topArtists.length;
+
+  if (distinctArtists < MIN_DISTINCT_ARTISTS) {
+    log.debug(`User ${userId} has only ${distinctArtists} distinct artists, skipping`);
+    return [];
+  }
+
+  const dismissals = await getUserDismissals(userId);
+  const allTracks = indexStore.getSnapshot().tracks;
+  const playlists: ForYouPlaylist[] = [];
+
+  for (const entry of topArtists.slice(0, MAX_TOP_ARTISTS)) {
+    const candidateId = `for-you:${slugify(entry.artist)}`;
+    if (dismissals.has(candidateId)) continue;
+
+    const playlist = buildForYouPlaylist(entry.artist, indexStore, allTracks);
+    if (playlist) {
+      playlists.push(playlist);
+    }
+  }
+
+  return playlists;
+}
+
+// ── Storage ───────────────────────────────────────────────────────
+
+export async function saveForYouPlaylists(userId: string, playlists: ForYouPlaylist[]): Promise<void> {
+  const dir = userForYouDir(userId);
+  await ensureDir(dir);
+
+  const existing = await fs.readdir(dir).catch(() => []);
+  for (const file of existing) {
+    if (file.endsWith(".json") && file !== "_meta.json") {
+      await fs.unlink(path.join(dir, file)).catch(() => {});
+    }
+  }
+
+  for (const playlist of playlists) {
+    const fileName = `${slugify(playlist.seedArtist)}.json`;
+    await writeJsonAtomic(path.join(dir, fileName), playlist);
+  }
+
+  const meta: ForYouMeta = { lastGeneratedAt: new Date().toISOString() };
+  await writeJsonAtomic(userForYouMetaPath(userId), meta);
+
+  log.info(`Saved ${playlists.length} for-you playlist(s) for user ${userId}`);
+}
+
+export async function loadForYouPlaylists(userId: string): Promise<ForYouPlaylist[]> {
+  const dir = userForYouDir(userId);
+  await ensureDir(dir);
+
+  const files = await fs.readdir(dir).catch(() => []);
+  const playlists: ForYouPlaylist[] = [];
+
+  for (const file of files) {
+    if (!file.endsWith(".json") || file === "_meta.json") continue;
+    const data = await readJsonFile<ForYouPlaylist>(
+      path.join(dir, file),
+      null as unknown as ForYouPlaylist
+    );
+    if (data && data.id && data.trackIds) {
+      playlists.push(data);
+    }
+  }
+
+  return playlists.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getForYouPlaylistById(
+  userId: string,
+  playlistId: string
+): Promise<ForYouPlaylist | null> {
+  const all = await loadForYouPlaylists(userId);
+  return all.find((p) => p.id === playlistId) ?? null;
+}
+
+// ── Regeneration ──────────────────────────────────────────────────
+
+export async function needsForYouRegeneration(userId: string): Promise<boolean> {
+  const metaPath = userForYouMetaPath(userId);
+  const meta = await readJsonFile<ForYouMeta>(metaPath, { lastGeneratedAt: "" });
+  if (!meta.lastGeneratedAt) return true;
+
+  const lastGenerated = new Date(meta.lastGeneratedAt).getTime();
+  if (isNaN(lastGenerated)) return true;
+
+  return Date.now() - lastGenerated > REGENERATION_INTERVAL_MS;
+}
+
+export async function regenerateForYouPlaylists(
+  userId: string,
+  indexStore: IndexStore
+): Promise<ForYouPlaylist[]> {
+  log.info(`Regenerating for-you playlists for user ${userId}...`);
+  const playlists = await generateForYouPlaylists(userId, indexStore);
+  await saveForYouPlaylists(userId, playlists);
+  log.info(`Generated ${playlists.length} for-you playlist(s) for user ${userId}`);
+  return playlists;
+}
+
+export async function checkAndRegenerateForYouOnBoot(
+  userId: string,
+  indexStore: IndexStore
+): Promise<void> {
+  const shouldRegenerate = await needsForYouRegeneration(userId);
+  if (!shouldRegenerate) {
+    const existing = await loadForYouPlaylists(userId);
+    log.debug(`For-you playlists up to date for user ${userId} (${existing.length} playlist(s))`);
+    return;
+  }
+
+  await regenerateForYouPlaylists(userId, indexStore);
+}

--- a/backend/src/services/playlists/playlistStore.test.ts
+++ b/backend/src/services/playlists/playlistStore.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+let tmpDir: string;
+
+vi.mock("../../utils/paths", async () => {
+  return {
+    get dataRoot() { return path.join(tmpDir, "data"); },
+    get storageRoot() { return path.join(tmpDir, "data", "storage"); },
+    get usersStorageRoot() { return path.join(tmpDir, "data", "storage", "users"); },
+    get configRoot() { return path.join(tmpDir, "data", "config"); },
+    get indexRoot() { return path.join(tmpDir, "data", "index"); },
+    get cacheRoot() { return path.join(tmpDir, "data", "cache"); },
+    get logsRoot() { return path.join(tmpDir, "data", "logs"); },
+    get backupsRoot() { return path.join(tmpDir, "data", "backups"); },
+    get indexFilePath() { return path.join(tmpDir, "data", "index", "library-index.json"); },
+    get metadataOverridesFilePath() { return path.join(tmpDir, "data", "index", "track-metadata-overrides.json"); },
+    get trackActivityLogFilePath() { return path.join(tmpDir, "data", "index", "track-activity-log.json"); }
+  };
+});
+
+vi.mock("../../utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+import type { Playlist, Track } from "../../types/library";
+import type { AuthUser } from "../../types/auth";
+
+function makeTrack(id: string): Track {
+  return {
+    id,
+    owner: "user-1",
+    path: `storage/users/user-1/uploads/${id}.mp3`,
+    duration: 200,
+    mimeType: "audio/mpeg",
+    codec: "mp3",
+    tags: { title: id, artist: "Artist" }
+  };
+}
+
+function makeUser(id: string, role: "admin" | "user" = "user"): AuthUser {
+  return { id, username: id, role, email: `${id}@test.local` };
+}
+
+function makePlaylist(overrides: Partial<Playlist> & { id: string; authorId: string }): Playlist {
+  return {
+    name: "Test",
+    visibility: "public",
+    trackIds: [],
+    description: "",
+    cover: null,
+    hearts: [],
+    heartCount: 0,
+    listenCount: 0,
+    collaborators: [],
+    ...overrides
+  };
+}
+
+describe("playlistStore", () => {
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "plstore-test-"));
+    await fs.mkdir(path.join(tmpDir, "data", "storage", "users"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── canViewPlaylist ────────────────────────────────────────────
+
+  describe("canViewPlaylist", () => {
+    it("allows owner to view private playlist", async () => {
+      const { canViewPlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1", visibility: "private" });
+      expect(canViewPlaylist(playlist, makeUser("u1"))).toBe(true);
+    });
+
+    it("blocks non-owner from private playlist", async () => {
+      const { canViewPlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1", visibility: "private" });
+      expect(canViewPlaylist(playlist, makeUser("u2"))).toBe(false);
+    });
+
+    it("allows anyone to view public playlist", async () => {
+      const { canViewPlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1", visibility: "public" });
+      expect(canViewPlaylist(playlist, makeUser("u2"))).toBe(true);
+    });
+
+    it("allows admin to view private playlist", async () => {
+      const { canViewPlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1", visibility: "private" });
+      expect(canViewPlaylist(playlist, makeUser("admin-user", "admin"))).toBe(true);
+    });
+  });
+
+  // ── canManagePlaylist ──────────────────────────────────────────
+
+  describe("canManagePlaylist", () => {
+    it("allows owner to manage", async () => {
+      const { canManagePlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1" });
+      expect(canManagePlaylist(playlist, makeUser("u1"))).toBe(true);
+    });
+
+    it("allows admin to manage", async () => {
+      const { canManagePlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1" });
+      expect(canManagePlaylist(playlist, makeUser("admin-user", "admin"))).toBe(true);
+    });
+
+    it("blocks non-owner non-admin from managing", async () => {
+      const { canManagePlaylist } = await import("./playlistStore");
+      const playlist = makePlaylist({ id: "u1:test", authorId: "u1" });
+      expect(canManagePlaylist(playlist, makeUser("u2"))).toBe(false);
+    });
+  });
+
+  // ── filterPlayablePlaylists ────────────────────────────────────
+
+  describe("filterPlayablePlaylists", () => {
+    it("filters private playlists for non-owner", async () => {
+      const { filterPlayablePlaylists } = await import("./playlistStore");
+      const playlists = [
+        makePlaylist({ id: "u1:pub", authorId: "u1", visibility: "public" }),
+        makePlaylist({ id: "u1:priv", authorId: "u1", visibility: "private" }),
+        makePlaylist({ id: "u2:mine", authorId: "u2", visibility: "private" })
+      ];
+      const result = filterPlayablePlaylists(playlists, makeUser("u2"));
+      expect(result.map((p) => p.id)).toEqual(["u1:pub", "u2:mine"]);
+    });
+  });
+
+  // ── togglePlaylistHeart ────────────────────────────────────────
+
+  describe("togglePlaylistHeart", () => {
+    it("hearts and un-hearts a playlist", async () => {
+      const { createFilesystemPlaylist, togglePlaylistHeart, scanFilesystemPlaylists } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Heart Test",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      // Heart
+      const r1 = await togglePlaylistHeart(playlistId, "user-2");
+      expect(r1.hearted).toBe(true);
+      expect(r1.heartCount).toBe(1);
+
+      // Verify persisted
+      const scanned = await scanFilesystemPlaylists(tracks);
+      const found = scanned.find((p) => p.id === playlistId)!;
+      expect(found.hearts).toEqual(["user-2"]);
+      expect(found.heartCount).toBe(1);
+
+      // Un-heart
+      const r2 = await togglePlaylistHeart(playlistId, "user-2");
+      expect(r2.hearted).toBe(false);
+      expect(r2.heartCount).toBe(0);
+    });
+
+    it("supports multiple users hearting", async () => {
+      const { createFilesystemPlaylist, togglePlaylistHeart } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Multi Heart",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      await togglePlaylistHeart(playlistId, "user-2");
+      const r = await togglePlaylistHeart(playlistId, "user-3");
+      expect(r.heartCount).toBe(2);
+    });
+  });
+
+  // ── incrementPlaylistListenCount ───────────────────────────────
+
+  describe("incrementPlaylistListenCount", () => {
+    it("increments listen count", async () => {
+      const { createFilesystemPlaylist, incrementPlaylistListenCount, scanFilesystemPlaylists } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Listen Test",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      const count1 = await incrementPlaylistListenCount(playlistId);
+      expect(count1).toBe(1);
+
+      const count2 = await incrementPlaylistListenCount(playlistId);
+      expect(count2).toBe(2);
+
+      // Verify persisted
+      const scanned = await scanFilesystemPlaylists(tracks);
+      const found = scanned.find((p) => p.id === playlistId)!;
+      expect(found.listenCount).toBe(2);
+    });
+  });
+
+  // ── updatePlaylistCover ────────────────────────────────────────
+
+  describe("updatePlaylistCover", () => {
+    it("sets and clears cover path", async () => {
+      const { createFilesystemPlaylist, updatePlaylistCover, scanFilesystemPlaylists } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Cover Test",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      await updatePlaylistCover(playlistId, "/path/to/cover.webp");
+      let scanned = await scanFilesystemPlaylists(tracks);
+      let found = scanned.find((p) => p.id === playlistId)!;
+      expect(found.cover).toBe("/path/to/cover.webp");
+
+      await updatePlaylistCover(playlistId, null);
+      scanned = await scanFilesystemPlaylists(tracks);
+      found = scanned.find((p) => p.id === playlistId)!;
+      expect(found.cover).toBeNull();
+    });
+  });
+
+  // ── Create and update with new fields ──────────────────────────
+
+  describe("createFilesystemPlaylist", () => {
+    it("persists description", async () => {
+      const { createFilesystemPlaylist, scanFilesystemPlaylists } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Described",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById,
+        description: "My custom description"
+      });
+
+      const scanned = await scanFilesystemPlaylists(tracks);
+      const found = scanned.find((p) => p.id === playlistId)!;
+      expect(found.description).toBe("My custom description");
+      expect(found.hearts).toEqual([]);
+      expect(found.heartCount).toBe(0);
+      expect(found.listenCount).toBe(0);
+      expect(found.collaborators).toEqual([]);
+      expect(found.cover).toBeNull();
+    });
+  });
+
+  describe("updateFilesystemPlaylist", () => {
+    it("updates description and collaborators", async () => {
+      const { createFilesystemPlaylist, updateFilesystemPlaylist, scanFilesystemPlaylists } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Updatable",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      await updateFilesystemPlaylist({
+        id: playlistId,
+        name: "Updatable",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById,
+        description: "New description",
+        collaborators: ["user-2", "user-3"]
+      });
+
+      const scanned = await scanFilesystemPlaylists(tracks);
+      const found = scanned.find((p) => p.id === playlistId)!;
+      expect(found.description).toBe("New description");
+      expect(found.collaborators).toEqual(["user-2", "user-3"]);
+    });
+
+    it("preserves hearts and listen count on update", async () => {
+      const { createFilesystemPlaylist, togglePlaylistHeart, incrementPlaylistListenCount, updateFilesystemPlaylist, scanFilesystemPlaylists } = await import("./playlistStore");
+      const tracks = [makeTrack("t1")];
+      const tracksById = new Map(tracks.map((t) => [t.id, t]));
+
+      const playlistId = await createFilesystemPlaylist({
+        name: "Persistent",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      await togglePlaylistHeart(playlistId, "user-2");
+      await incrementPlaylistListenCount(playlistId);
+      await incrementPlaylistListenCount(playlistId);
+
+      // Update name — hearts and listen count should survive
+      await updateFilesystemPlaylist({
+        id: playlistId,
+        name: "Persistent Renamed",
+        authorId: "user-1",
+        visibility: "public",
+        trackIds: ["t1"],
+        tracksById
+      });
+
+      const scanned = await scanFilesystemPlaylists(tracks);
+      const found = scanned.find((p) => p.name === "Persistent Renamed")!;
+      expect(found).toBeDefined();
+      expect(found.hearts).toEqual(["user-2"]);
+      expect(found.heartCount).toBe(1);
+      expect(found.listenCount).toBe(2);
+    });
+  });
+});

--- a/backend/src/services/playlists/playlistStore.ts
+++ b/backend/src/services/playlists/playlistStore.ts
@@ -105,6 +105,24 @@ export function canViewPlaylist(playlist: Playlist, user: AuthUser): boolean {
   return playlist.visibility === "public" || playlist.authorId === user.id || user.role === "admin";
 }
 
+/**
+ * Check if playlist has "everyone" collaborator
+ * @param collaborators Array of collaborator IDs
+ * @returns True if "everyone" is in the collaborators array
+ */
+function hasEveryoneCollaborator(collaborators: string[]): boolean {
+  return collaborators.includes("everyone");
+}
+
+/**
+ * Get display collaborators for UI - hides individual collaborators when "everyone" is present
+ * @param collaborators Array of collaborator IDs
+ * @returns Array containing either "everyone" or individual collaborators
+ */
+function getDisplayCollaborators(collaborators: string[]): string[] {
+  return hasEveryoneCollaborator(collaborators) ? ["everyone"] : collaborators;
+}
+
 async function pathExists(pathToCheck: string): Promise<boolean> {
   try {
     await fs.access(pathToCheck);

--- a/backend/src/services/playlists/playlistStore.ts
+++ b/backend/src/services/playlists/playlistStore.ts
@@ -28,6 +28,7 @@ type CreatePlaylistInput = {
   visibility: PlaylistVisibility;
   trackIds: string[];
   tracksById: Map<string, Track>;
+  description?: string;
 };
 
 type UpdatePlaylistInput = {
@@ -36,6 +37,8 @@ type UpdatePlaylistInput = {
   visibility: PlaylistVisibility;
   trackIds: string[];
   tracksById: Map<string, Track>;
+  description?: string;
+  collaborators?: string[];
 };
 
 function normalizeVisibility(value: unknown): PlaylistVisibility | null {
@@ -98,7 +101,7 @@ function getPlaylistMetadataPath(authorId: string, playlistSlug: string): string
   return path.join(getPlaylistDir(authorId, playlistSlug), PLAYLIST_METADATA_FILE);
 }
 
-function canViewPlaylist(playlist: Playlist, user: AuthUser): boolean {
+export function canViewPlaylist(playlist: Playlist, user: AuthUser): boolean {
   return playlist.visibility === "public" || playlist.authorId === user.id || user.role === "admin";
 }
 
@@ -171,10 +174,6 @@ export async function migrateLegacyPlaylists(): Promise<void> {
 
 export function canManagePlaylist(playlist: Playlist, user: AuthUser): boolean {
   return playlist.authorId === user.id || user.role === "admin";
-}
-
-export function canEditPlaylistTracks(playlist: Playlist, user: AuthUser): boolean {
-  return canManagePlaylist(playlist, user) || playlist.collaborators.includes(user.id);
 }
 
 export function filterPlayablePlaylists(playlists: Playlist[], user: AuthUser): Playlist[] {
@@ -436,7 +435,8 @@ export async function createFilesystemPlaylist(input: CreatePlaylistInput): Prom
     name,
     visibility: input.visibility,
     trackIds: input.trackIds,
-    tracksById: input.tracksById
+    tracksById: input.tracksById,
+    description: input.description
   });
 
   return createPlaylistId(input.authorId, playlistSlug);
@@ -459,6 +459,8 @@ export async function updateFilesystemPlaylist(input: UpdatePlaylistInput & { au
   const currentDir = getPlaylistDir(parsed.authorId, parsed.slug);
   const nextDir = getPlaylistDir(parsed.authorId, nextSlug);
 
+  const existingMetadata = await readPlaylistMetadata(input.id);
+
   if (parsed.slug !== nextSlug) {
     try {
       await fs.access(nextDir);
@@ -472,8 +474,6 @@ export async function updateFilesystemPlaylist(input: UpdatePlaylistInput & { au
     await fs.rename(currentDir, nextDir);
   }
 
-  const existingMetadata = await readPlaylistMetadata(input.id);
-
   await writePlaylistContents({
     authorId: input.authorId,
     playlistSlug: nextSlug,
@@ -481,11 +481,11 @@ export async function updateFilesystemPlaylist(input: UpdatePlaylistInput & { au
     visibility: input.visibility,
     trackIds: input.trackIds,
     tracksById: input.tracksById,
-    description: existingMetadata?.description,
+    description: input.description ?? existingMetadata?.description,
     cover: existingMetadata?.cover,
     hearts: existingMetadata?.hearts,
     listenCount: existingMetadata?.listenCount,
-    collaborators: existingMetadata?.collaborators
+    collaborators: input.collaborators ?? existingMetadata?.collaborators
   });
 }
 
@@ -535,16 +535,6 @@ export async function incrementPlaylistListenCount(playlistId: string): Promise<
     listenCount: metadata.listenCount + 1
   }));
   return updated.listenCount;
-}
-
-export async function updatePlaylistDescription(
-  playlistId: string,
-  description: string
-): Promise<void> {
-  await patchPlaylistMetadataFile(playlistId, (metadata) => ({
-    ...metadata,
-    description
-  }));
 }
 
 export async function updatePlaylistCover(

--- a/backend/src/services/playlists/playlistStore.ts
+++ b/backend/src/services/playlists/playlistStore.ts
@@ -194,6 +194,12 @@ export function canManagePlaylist(playlist: Playlist, user: AuthUser): boolean {
   return playlist.authorId === user.id || user.role === "admin";
 }
 
+export function canEditPlaylist(playlist: Playlist, user: AuthUser): boolean {
+  return canManagePlaylist(playlist, user)
+    || playlist.collaborators.includes(user.id)
+    || playlist.collaborators.includes("everyone");
+}
+
 export function filterPlayablePlaylists(playlists: Playlist[], user: AuthUser): Playlist[] {
   return playlists.filter((playlist) => canViewPlaylist(playlist, user));
 }

--- a/backend/src/types/library.ts
+++ b/backend/src/types/library.ts
@@ -57,6 +57,10 @@ export type Playlist = {
   hearts: string[];
   heartCount: number;
   listenCount: number;
+  /** 
+   * Collaborators - array of user IDs who can collaborate on this playlist
+   * Special value "everyone" indicates all authenticated users can collaborate
+   */
   collaborators: string[];
 };
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,9 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "music-metadata": "^10.9.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -185,7 +185,6 @@ export function AuthenticatedApp({
     return availablePlaylists.filter(
       (pl) =>
         pl.authorId === user.id ||
-        user.role === "admin" ||
         (pl.collaborators ?? []).includes(user.id) ||
         (pl.collaborators ?? []).includes("everyone")
     );

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -20,6 +20,7 @@ import { usePlaybackCommands } from "./hooks/usePlaybackCommands";
 import { usePlaybackState } from "./hooks/usePlaybackState";
 import { useRecentlyUploaded } from "./hooks/useRecentlyUploaded";
 import { useAutoPlaylists } from "./hooks/useAutoPlaylists";
+import { useForYouPlaylists } from "./hooks/useForYouPlaylists";
 import { useRadioStation } from "./hooks/useRadioStation";
 
 type AuthenticatedAppProps = {
@@ -94,6 +95,7 @@ export function AuthenticatedApp({
   } = useInfiniteLibrary({ user, filters, pageSize: 30 });
 
   const { autoPlaylists, loading: loadingAutoPlaylists, refresh: refreshAutoPlaylists } = useAutoPlaylists();
+  const { forYouPlaylists, loading: loadingForYouPlaylists, dismiss: dismissForYouPlaylist } = useForYouPlaylists();
 
   const allTracksById = useMemo(
     () => new Map(allTracksLibrary.tracks.map((track) => [track.id, track])),
@@ -308,6 +310,9 @@ export function AuthenticatedApp({
         onReportPlaylistListen: handleReportPlaylistListen,
         autoPlaylists,
         loadingAutoPlaylists,
+        forYouPlaylists,
+        loadingForYouPlaylists,
+        onDismissForYouPlaylist: dismissForYouPlaylist,
         allTracksById,
         libraryMetadataError,
         loadingLibraryArtists,

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -301,7 +301,10 @@ export function AuthenticatedApp({
       loadingLibrary={loadingLibrary}
       libraryWorkspaceProps={{
         activeLibrarySection,
-        onSectionChange: setActiveLibrarySection,
+        onSectionChange: (section: LibrarySection) => {
+          setActiveLibrarySection(section);
+          setPlaylistDetailId(null);
+        },
         availablePlaylists,
         ownerNameById,
         user,

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -264,6 +264,10 @@ export function AuthenticatedApp({
       return;
     }
     setActiveView(nextView);
+    setPlaylistDetailId(null);
+    clearSelectedArtist();
+    clearSelectedArtistAlbum();
+    clearSelectedAlbum();
   }
 
   function handleCollapsePlayer(): void {
@@ -304,6 +308,9 @@ export function AuthenticatedApp({
         onSectionChange: (section: LibrarySection) => {
           setActiveLibrarySection(section);
           setPlaylistDetailId(null);
+          clearSelectedArtist();
+          clearSelectedArtistAlbum();
+          clearSelectedAlbum();
         },
         availablePlaylists,
         ownerNameById,

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -186,15 +186,18 @@ export function AuthenticatedApp({
   }, [availablePlaylists, user]);
 
   const ownerNameById = useMemo<Record<string, string>>(() => {
-    const entries: Array<[string, string]> = [];
+    const map: Record<string, string> = {};
+    if (library.ownerNamesById) {
+      Object.assign(map, library.ownerNamesById);
+    }
     if (user) {
-      entries.push([user.id, user.username]);
+      map[user.id] = user.username;
     }
     for (const adminUser of adminUsers) {
-      entries.push([adminUser.id, adminUser.username]);
+      map[adminUser.id] = adminUser.username;
     }
-    return Object.fromEntries(entries);
-  }, [user, adminUsers]);
+    return map;
+  }, [user, adminUsers, library.ownerNamesById]);
 
   const avatarUrl = useMemo(
     () => myProfilePhotoUrl({ version: avatarVersion, userId: user?.id }),

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -19,6 +19,7 @@ import { useLibraryData } from "./hooks/useLibraryData";
 import { usePlaybackCommands } from "./hooks/usePlaybackCommands";
 import { usePlaybackState } from "./hooks/usePlaybackState";
 import { useRecentlyUploaded } from "./hooks/useRecentlyUploaded";
+import { useAutoPlaylists } from "./hooks/useAutoPlaylists";
 import { useRadioStation } from "./hooks/useRadioStation";
 
 type AuthenticatedAppProps = {
@@ -91,6 +92,8 @@ export function AuthenticatedApp({
     sentinelRef: paginatedSentinelRef,
     refresh: refreshPaginatedLibrary
   } = useInfiniteLibrary({ user, filters, pageSize: 30 });
+
+  const { autoPlaylists, loading: loadingAutoPlaylists, refresh: refreshAutoPlaylists } = useAutoPlaylists();
 
   const allTracksById = useMemo(
     () => new Map(allTracksLibrary.tracks.map((track) => [track.id, track])),
@@ -303,6 +306,8 @@ export function AuthenticatedApp({
         onDeletePlaylist: handleDeletePlaylist,
         onHeartPlaylist: handleHeartPlaylist,
         onReportPlaylistListen: handleReportPlaylistListen,
+        autoPlaylists,
+        loadingAutoPlaylists,
         allTracksById,
         libraryMetadataError,
         loadingLibraryArtists,

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -182,7 +182,13 @@ export function AuthenticatedApp({
     if (!user) {
       return [];
     }
-    return availablePlaylists.filter((pl) => pl.authorId === user.id || user.role === "admin");
+    return availablePlaylists.filter(
+      (pl) =>
+        pl.authorId === user.id ||
+        user.role === "admin" ||
+        (pl.collaborators ?? []).includes(user.id) ||
+        (pl.collaborators ?? []).includes("everyone")
+    );
   }, [availablePlaylists, user]);
 
   const ownerNameById = useMemo<Record<string, string>>(() => {

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -442,6 +442,7 @@ export function AuthenticatedApp({
       accountViewProps={{
         user,
         avatarUrl,
+        allTracksById,
         onUpdatePhoto: handleUpdateProfilePhoto,
         onUpdateEmail: handleUpdateEmail,
         onChangePassword: handleUpdateOwnPassword,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,6 +3,8 @@ import type {
   ArtistEntry,
   AutoPlaylistDetail,
   AutoPlaylistSummary,
+  ForYouPlaylistDetail,
+  ForYouPlaylistSummary,
   LibraryResponse,
   Playlist,
   RadioCreateResponse,
@@ -723,6 +725,30 @@ export async function getAutoPlaylistDetail(id: string): Promise<{ playlist: Aut
 
 export async function regenerateAutoPlaylists(): Promise<{ regenerated: number }> {
   return requestJson<{ regenerated: number }>("/api/playlists/automatic/regenerate", {
+    method: "POST"
+  });
+}
+
+export async function getForYouPlaylists(): Promise<ForYouPlaylistSummary[]> {
+  const payload = await requestJson<{ playlists: ForYouPlaylistSummary[] }>("/api/playlists/for-you");
+  return payload.playlists;
+}
+
+export async function getForYouPlaylistDetail(id: string): Promise<{ playlist: ForYouPlaylistDetail; tracks: Track[] }> {
+  return requestJson<{ playlist: ForYouPlaylistDetail; tracks: Track[] }>(
+    `/api/playlists/for-you/${encodeURIComponent(id)}`
+  );
+}
+
+export async function dismissForYouPlaylist(playlistId: string): Promise<void> {
+  await requestJson<void>(
+    `/api/playlists/for-you/${encodeURIComponent(playlistId)}/dismiss`,
+    { method: "POST", skipJson: true }
+  );
+}
+
+export async function regenerateForYouPlaylists(): Promise<{ regenerated: number }> {
+  return requestJson<{ regenerated: number }>("/api/playlists/for-you/regenerate", {
     method: "POST"
   });
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,8 @@
 import type {
   AlbumEntry,
   ArtistEntry,
+  AutoPlaylistDetail,
+  AutoPlaylistSummary,
   LibraryResponse,
   Playlist,
   RadioCreateResponse,
@@ -706,6 +708,23 @@ export async function reportPlaylistListen(playlistId: string): Promise<void> {
 
 export function playlistCoverUrl(playlistId: string): string {
   return withApiBase(`/api/playlists/${encodeURIComponent(playlistId)}/cover`);
+}
+
+export async function getAutoPlaylists(): Promise<AutoPlaylistSummary[]> {
+  const payload = await requestJson<{ playlists: AutoPlaylistSummary[] }>("/api/playlists/automatic");
+  return payload.playlists;
+}
+
+export async function getAutoPlaylistDetail(id: string): Promise<{ playlist: AutoPlaylistDetail; tracks: Track[] }> {
+  return requestJson<{ playlist: AutoPlaylistDetail; tracks: Track[] }>(
+    `/api/playlists/automatic/${encodeURIComponent(id)}`
+  );
+}
+
+export async function regenerateAutoPlaylists(): Promise<{ regenerated: number }> {
+  return requestJson<{ regenerated: number }>("/api/playlists/automatic/regenerate", {
+    method: "POST"
+  });
 }
 
 export async function getUsers(): Promise<User[]> {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -657,6 +657,7 @@ export async function rebuildIndex(): Promise<{ generatedAt: string; totalTracks
 export async function createPlaylist(input: {
   name: string;
   visibility: PlaylistVisibility;
+  description?: string;
 }): Promise<Playlist> {
   const payload = await requestJson<{ playlist: Playlist }>("/api/playlists", {
     method: "POST",
@@ -675,6 +676,8 @@ export async function patchPlaylist(
     name?: string;
     visibility?: PlaylistVisibility;
     trackIds?: string[];
+    description?: string;
+    collaborators?: string[];
   }
 ): Promise<Playlist> {
   const payload = await requestJson<{ playlist: Playlist }>(`/api/playlists/${encodeURIComponent(playlistId)}`, {
@@ -710,6 +713,21 @@ export async function reportPlaylistListen(playlistId: string): Promise<void> {
 
 export function playlistCoverUrl(playlistId: string): string {
   return withApiBase(`/api/playlists/${encodeURIComponent(playlistId)}/cover`);
+}
+
+export async function uploadPlaylistCover(playlistId: string, file: File): Promise<void> {
+  const formData = new FormData();
+  formData.append("cover", file);
+  await requestJson<{ ok: boolean }>(`/api/playlists/${encodeURIComponent(playlistId)}/cover`, {
+    method: "POST",
+    body: formData
+  });
+}
+
+export async function deletePlaylistCover(playlistId: string): Promise<void> {
+  await requestJson<{ ok: boolean }>(`/api/playlists/${encodeURIComponent(playlistId)}/cover`, {
+    method: "DELETE"
+  });
 }
 
 export async function getAutoPlaylists(): Promise<AutoPlaylistSummary[]> {
@@ -964,6 +982,86 @@ export type PlayStatsResponse = {
 
 export async function getMyPlayStats(): Promise<PlayStatsResponse> {
   return requestJson<PlayStatsResponse>("/api/me/play-stats");
+}
+
+// ── Admin: Genre Management ───────────────────────────────────────────
+
+export type GenreSynonyms = Record<string, string>;
+
+export async function getGenreSynonyms(): Promise<GenreSynonyms> {
+  const payload = await requestJson<{ synonyms: GenreSynonyms }>("/api/genre/synonyms");
+  return payload.synonyms;
+}
+
+export async function putGenreSynonym(key: string, value: string): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/synonyms", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, value })
+  });
+}
+
+export async function deleteGenreSynonym(key: string): Promise<void> {
+  await requestJson<void>(`/api/genre/synonyms/${encodeURIComponent(key)}`, {
+    method: "DELETE",
+    skipJson: true
+  });
+}
+
+export async function resetGenreSynonyms(): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/synonyms/reset", { method: "POST" });
+}
+
+export type EnrichmentStatus = {
+  running: boolean;
+  processed?: number;
+  total?: number;
+  startedAt?: string;
+};
+
+export async function getEnrichmentStatus(): Promise<EnrichmentStatus> {
+  return requestJson<EnrichmentStatus>("/api/genre/enrichment/status");
+}
+
+export async function startEnrichment(): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/enrichment/start", { method: "POST" });
+}
+
+export async function stopEnrichment(): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/enrichment/stop", { method: "POST" });
+}
+
+export type GenreCacheStats = {
+  entries: number;
+  sizeBytes: number;
+};
+
+export async function getGenreCacheStats(): Promise<GenreCacheStats> {
+  return requestJson<GenreCacheStats>("/api/genre/cache/stats");
+}
+
+export async function clearGenreCache(): Promise<void> {
+  await requestJson<{ ok: boolean }>("/api/genre/cache/clear", { method: "POST" });
+}
+
+// ── Admin: Auto-Playlist Config ──────────────────────────────────────
+
+export type AutoPlaylistConfig = {
+  maxPlaylists: number;
+  minTracksPerPlaylist: number;
+  tracksPerPlaylist: number;
+};
+
+export async function getAutoPlaylistConfig(): Promise<AutoPlaylistConfig> {
+  return requestJson<AutoPlaylistConfig>("/api/config/auto-playlists");
+}
+
+export async function patchAutoPlaylistConfig(patch: Partial<AutoPlaylistConfig>): Promise<AutoPlaylistConfig> {
+  return requestJson<AutoPlaylistConfig>("/api/config/auto-playlists", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch)
+  });
 }
 
 // ── Admin: Server Logs ────────────────────────────────────────────────

--- a/frontend/src/components/AccountView.test.tsx
+++ b/frontend/src/components/AccountView.test.tsx
@@ -55,6 +55,7 @@ describe("AccountView", () => {
       <AccountView
         user={createUser()}
         avatarUrl="/api/users/me/photo"
+        allTracksById={new Map()}
         onUpdatePhoto={vi.fn().mockResolvedValue(undefined)}
         onUpdateEmail={vi.fn().mockResolvedValue(undefined)}
         onChangePassword={vi.fn().mockResolvedValue(undefined)}
@@ -93,6 +94,7 @@ describe("AccountView", () => {
       <AccountView
         user={createUser()}
         avatarUrl="/api/users/me/photo"
+        allTracksById={new Map()}
         onUpdatePhoto={vi.fn().mockResolvedValue(undefined)}
         onUpdateEmail={vi.fn().mockResolvedValue(undefined)}
         onChangePassword={vi.fn().mockResolvedValue(undefined)}
@@ -127,6 +129,7 @@ describe("AccountView", () => {
       <AccountView
         user={createUser()}
         avatarUrl="/api/users/me/photo"
+        allTracksById={new Map()}
         onUpdatePhoto={vi.fn().mockResolvedValue(undefined)}
         onUpdateEmail={vi.fn().mockResolvedValue(undefined)}
         onChangePassword={vi.fn().mockResolvedValue(undefined)}

--- a/frontend/src/components/AccountView.tsx
+++ b/frontend/src/components/AccountView.tsx
@@ -1,10 +1,12 @@
 import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { User, UserSession } from "../types";
+import { coverUrl, getMyPlayStats, type PlayStatsResponse } from "../api";
+import type { Track, User, UserSession } from "../types";
 
 type AccountViewProps = {
   user: User;
   avatarUrl: string;
+  allTracksById: Map<string, Track>;
   onUpdatePhoto: (file: File) => Promise<void>;
   onUpdateEmail: (email: string) => Promise<void>;
   onChangePassword: (input: { currentPassword: string; newPassword: string }) => Promise<void>;
@@ -50,6 +52,7 @@ function getSessionTitle(session: UserSession): string {
 export function AccountView({
   user,
   avatarUrl,
+  allTracksById,
   onUpdatePhoto,
   onUpdateEmail,
   onChangePassword,
@@ -80,6 +83,17 @@ export function AccountView({
   const [sessionsMessage, setSessionsMessage] = useState<string | null>(null);
   const [revokingSessionId, setRevokingSessionId] = useState<string | null>(null);
   const [loggingOutOtherSessions, setLoggingOutOtherSessions] = useState(false);
+
+  const [playStats, setPlayStats] = useState<PlayStatsResponse | null>(null);
+  const [loadingStats, setLoadingStats] = useState(true);
+
+  useEffect(() => {
+    setLoadingStats(true);
+    void getMyPlayStats()
+      .then(setPlayStats)
+      .catch(() => {})
+      .finally(() => setLoadingStats(false));
+  }, []);
 
   const initial = useMemo(() => getUserInitial(user), [user]);
   const displayedAvatarUrl = selectedPhotoPreviewUrl ?? avatarUrl;
@@ -458,6 +472,74 @@ export function AccountView({
             {passwordMessage.text}
           </p>
         ) : null}
+      </section>
+
+      <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <h3 className="font-display text-xl text-flaque-ink">Listening Stats</h3>
+
+        {loadingStats ? (
+          <p className="mt-3 text-sm text-flaque-steel">Loading stats...</p>
+        ) : !playStats || playStats.totalPlays === 0 ? (
+          <p className="mt-3 text-sm text-flaque-steel">No listening history yet. Start playing some music!</p>
+        ) : (
+          <div className="mt-3 space-y-4">
+            <div className="flex flex-wrap gap-4">
+              <div className="rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-4 py-3">
+                <p className="font-display text-2xl text-flaque-ink">{playStats.totalPlays}</p>
+                <p className="text-xs text-flaque-steel">Total plays</p>
+              </div>
+              <div className="rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-4 py-3">
+                <p className="font-display text-2xl text-flaque-ink">{playStats.uniqueTracksPlayed}</p>
+                <p className="text-xs text-flaque-steel">Unique tracks</p>
+              </div>
+              <div className="rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-4 py-3">
+                <p className="font-display text-2xl text-flaque-ink">{playStats.topArtists.length}</p>
+                <p className="text-xs text-flaque-steel">Artists</p>
+              </div>
+            </div>
+
+            {playStats.topArtists.length > 0 ? (
+              <div>
+                <h4 className="text-sm font-medium text-flaque-ink">Top Artists</h4>
+                <div className="mt-2 space-y-1">
+                  {playStats.topArtists.slice(0, 10).map((entry, i) => (
+                    <div key={entry.artist} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-3 py-1.5">
+                      <span className="w-5 shrink-0 text-right text-xs text-flaque-steel/60">{i + 1}</span>
+                      <span className="min-w-0 flex-1 truncate text-sm text-flaque-ink">{entry.artist}</span>
+                      <span className="shrink-0 text-xs text-flaque-steel">{entry.playCount} play{entry.playCount !== 1 ? "s" : ""}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {playStats.topTracks.length > 0 ? (
+              <div>
+                <h4 className="text-sm font-medium text-flaque-ink">Top Tracks</h4>
+                <div className="mt-2 space-y-1">
+                  {playStats.topTracks.slice(0, 10).map((entry, i) => {
+                    const track = allTracksById.get(entry.trackId);
+                    return (
+                      <div key={entry.trackId} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-2 py-1.5">
+                        <span className="w-5 shrink-0 text-right text-xs text-flaque-steel/60">{i + 1}</span>
+                        {track ? (
+                          <img src={coverUrl(track.id)} alt="" className="h-8 w-8 shrink-0 rounded-md object-cover" loading="lazy" />
+                        ) : (
+                          <div className="h-8 w-8 shrink-0 rounded-md bg-flaque-clay/30" />
+                        )}
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm text-flaque-ink">{track?.tags.title ?? entry.trackId}</p>
+                          <p className="truncate text-xs text-flaque-steel">{track?.tags.artist ?? "Unknown"}</p>
+                        </div>
+                        <span className="shrink-0 text-xs text-flaque-steel">{entry.count}x</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        )}
       </section>
 
       <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">

--- a/frontend/src/components/AdminLibraryView.tsx
+++ b/frontend/src/components/AdminLibraryView.tsx
@@ -1,0 +1,380 @@
+import { FormEvent, useEffect, useState } from "react";
+
+import {
+  clearGenreCache,
+  deleteGenreSynonym,
+  getAutoPlaylistConfig,
+  getEnrichmentStatus,
+  getGenreCacheStats,
+  getGenreSynonyms,
+  patchAutoPlaylistConfig,
+  putGenreSynonym,
+  regenerateAutoPlaylists,
+  resetGenreSynonyms,
+  startEnrichment,
+  stopEnrichment,
+  type AutoPlaylistConfig,
+  type EnrichmentStatus,
+  type GenreCacheStats,
+  type GenreSynonyms
+} from "../api";
+
+export function AdminLibraryView(): JSX.Element {
+  // ── Genre synonyms ─────────────────────────────────────────────
+  const [synonyms, setSynonyms] = useState<GenreSynonyms>({});
+  const [loadingSynonyms, setLoadingSynonyms] = useState(true);
+  const [synonymKey, setSynonymKey] = useState("");
+  const [synonymValue, setSynonymValue] = useState("");
+  const [synonymMessage, setSynonymMessage] = useState<string | null>(null);
+
+  // ── Enrichment ─────────────────────────────────────────────────
+  const [enrichStatus, setEnrichStatus] = useState<EnrichmentStatus | null>(null);
+  const [enrichLoading, setEnrichLoading] = useState(false);
+
+  // ── Cache ──────────────────────────────────────────────────────
+  const [cacheStats, setCacheStats] = useState<GenreCacheStats | null>(null);
+
+  // ── Auto-playlist config ───────────────────────────────────────
+  const [config, setConfig] = useState<AutoPlaylistConfig | null>(null);
+  const [loadingConfig, setLoadingConfig] = useState(true);
+  const [configMax, setConfigMax] = useState("");
+  const [configMin, setConfigMin] = useState("");
+  const [configTracks, setConfigTracks] = useState("");
+  const [configMessage, setConfigMessage] = useState<string | null>(null);
+  const [savingConfig, setSavingConfig] = useState(false);
+  const [regenerating, setRegenerating] = useState(false);
+  const [regenMessage, setRegenMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    void loadSynonyms();
+    void loadEnrichStatus();
+    void loadCacheStats();
+    void loadConfig();
+  }, []);
+
+  async function loadSynonyms(): Promise<void> {
+    setLoadingSynonyms(true);
+    try {
+      const data = await getGenreSynonyms();
+      setSynonyms(data);
+    } catch {
+      setSynonymMessage("Failed to load synonyms.");
+    } finally {
+      setLoadingSynonyms(false);
+    }
+  }
+
+  async function loadEnrichStatus(): Promise<void> {
+    try {
+      const status = await getEnrichmentStatus();
+      setEnrichStatus(status);
+    } catch {}
+  }
+
+  async function loadCacheStats(): Promise<void> {
+    try {
+      const stats = await getGenreCacheStats();
+      setCacheStats(stats);
+    } catch {}
+  }
+
+  async function loadConfig(): Promise<void> {
+    setLoadingConfig(true);
+    try {
+      const cfg = await getAutoPlaylistConfig();
+      setConfig(cfg);
+      setConfigMax(String(cfg.maxPlaylists));
+      setConfigMin(String(cfg.minTracksPerPlaylist));
+      setConfigTracks(String(cfg.tracksPerPlaylist));
+    } catch {} finally {
+      setLoadingConfig(false);
+    }
+  }
+
+  async function handleAddSynonym(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    const k = synonymKey.trim().toLowerCase();
+    const v = synonymValue.trim();
+    if (!k || !v) return;
+    try {
+      await putGenreSynonym(k, v);
+      setSynonymKey("");
+      setSynonymValue("");
+      await loadSynonyms();
+    } catch (err) {
+      setSynonymMessage(err instanceof Error ? err.message : "Failed to save synonym.");
+    }
+  }
+
+  async function handleDeleteSynonym(key: string): Promise<void> {
+    try {
+      await deleteGenreSynonym(key);
+      await loadSynonyms();
+    } catch {}
+  }
+
+  async function handleResetSynonyms(): Promise<void> {
+    try {
+      await resetGenreSynonyms();
+      await loadSynonyms();
+      setSynonymMessage("Synonyms reset to defaults.");
+    } catch {}
+  }
+
+  async function handleToggleEnrichment(): Promise<void> {
+    setEnrichLoading(true);
+    try {
+      if (enrichStatus?.running) {
+        await stopEnrichment();
+      } else {
+        await startEnrichment();
+      }
+      await loadEnrichStatus();
+    } catch {} finally {
+      setEnrichLoading(false);
+    }
+  }
+
+  async function handleClearCache(): Promise<void> {
+    try {
+      await clearGenreCache();
+      await loadCacheStats();
+    } catch {}
+  }
+
+  async function handleSaveConfig(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    setSavingConfig(true);
+    setConfigMessage(null);
+    try {
+      const patch: Partial<AutoPlaylistConfig> = {};
+      const maxVal = parseInt(configMax);
+      const minVal = parseInt(configMin);
+      const tracksVal = parseInt(configTracks);
+      if (!isNaN(maxVal)) patch.maxPlaylists = maxVal;
+      if (!isNaN(minVal)) patch.minTracksPerPlaylist = minVal;
+      if (!isNaN(tracksVal)) patch.tracksPerPlaylist = tracksVal;
+      const updated = await patchAutoPlaylistConfig(patch);
+      setConfig(updated);
+      setConfigMessage("Configuration saved.");
+    } catch (err) {
+      setConfigMessage(err instanceof Error ? err.message : "Failed to save config.");
+    } finally {
+      setSavingConfig(false);
+    }
+  }
+
+  async function handleRegenerate(): Promise<void> {
+    setRegenerating(true);
+    setRegenMessage(null);
+    try {
+      const result = await regenerateAutoPlaylists();
+      setRegenMessage(`Regenerated ${result.regenerated} playlist${result.regenerated !== 1 ? "s" : ""}.`);
+    } catch (err) {
+      setRegenMessage(err instanceof Error ? err.message : "Failed to regenerate.");
+    } finally {
+      setRegenerating(false);
+    }
+  }
+
+  const synonymEntries = Object.entries(synonyms).sort(([a], [b]) => a.localeCompare(b));
+
+  return (
+    <div className="m-4 space-y-4">
+      {/* ── Genre Synonyms ──────────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="font-display text-xl text-flaque-ink">Genre Synonyms</h3>
+          <button
+            type="button"
+            className="rounded-xl border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+            onClick={() => { void handleResetSynonyms(); }}
+          >
+            Reset to defaults
+          </button>
+        </div>
+
+        <form className="mt-3 flex flex-wrap items-end gap-2" onSubmit={(e) => { void handleAddSynonym(e); }}>
+          <label className="text-sm text-flaque-ink">
+            From
+            <input
+              className="mt-1 block w-40 rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              value={synonymKey}
+              onChange={(e) => setSynonymKey(e.target.value)}
+              placeholder="e.g. hiphop"
+            />
+          </label>
+          <label className="text-sm text-flaque-ink">
+            To
+            <input
+              className="mt-1 block w-40 rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              value={synonymValue}
+              onChange={(e) => setSynonymValue(e.target.value)}
+              placeholder="e.g. hip-hop"
+            />
+          </label>
+          <button
+            type="submit"
+            className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:opacity-60"
+            disabled={!synonymKey.trim() || !synonymValue.trim()}
+          >
+            Add
+          </button>
+        </form>
+
+        {synonymMessage ? <p className="mt-2 text-xs text-flaque-steel">{synonymMessage}</p> : null}
+
+        {loadingSynonyms ? (
+          <p className="mt-3 text-sm text-flaque-steel">Loading...</p>
+        ) : synonymEntries.length === 0 ? (
+          <p className="mt-3 text-sm text-flaque-steel">No synonyms configured.</p>
+        ) : (
+          <div className="mt-3 max-h-60 overflow-y-auto rounded-xl border border-flaque-clay/40">
+            <table className="w-full text-left text-sm">
+              <thead className="sticky top-0 bg-flaque-cream/95 text-flaque-ink">
+                <tr>
+                  <th className="px-3 py-2 font-medium">From</th>
+                  <th className="px-3 py-2 font-medium">To</th>
+                  <th className="w-16 px-3 py-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {synonymEntries.map(([key, value]) => (
+                  <tr key={key} className="border-t border-flaque-clay/30">
+                    <td className="px-3 py-1.5 text-flaque-ink">{key}</td>
+                    <td className="px-3 py-1.5 text-flaque-steel">{value}</td>
+                    <td className="px-3 py-1.5">
+                      <button
+                        type="button"
+                        className="text-xs text-red-500 hover:text-red-700"
+                        onClick={() => { void handleDeleteSynonym(key); }}
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* ── Genre Enrichment ────────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <h3 className="font-display text-xl text-flaque-ink">MusicBrainz Enrichment</h3>
+        <p className="mt-1 text-sm text-flaque-steel">
+          Enrich tracks missing genre data by looking them up on MusicBrainz.
+        </p>
+
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            className={`rounded-xl px-4 py-2 text-sm font-medium transition ${
+              enrichStatus?.running
+                ? "border border-red-300 bg-red-50 text-red-700 hover:bg-red-100"
+                : "bg-flaque-ink text-flaque-cream hover:bg-black"
+            }`}
+            onClick={() => { void handleToggleEnrichment(); }}
+            disabled={enrichLoading}
+          >
+            {enrichLoading
+              ? "..."
+              : enrichStatus?.running
+                ? "Stop enrichment"
+                : "Start enrichment"}
+          </button>
+
+          {enrichStatus?.running && enrichStatus.processed !== undefined ? (
+            <span className="text-sm text-flaque-steel">
+              {enrichStatus.processed}{enrichStatus.total !== undefined ? ` / ${enrichStatus.total}` : ""} tracks processed
+            </span>
+          ) : null}
+        </div>
+
+        {cacheStats ? (
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <span className="text-sm text-flaque-steel">
+              Cache: {cacheStats.entries} entries ({(cacheStats.sizeBytes / 1024).toFixed(1)} KB)
+            </span>
+            <button
+              type="button"
+              className="rounded-lg border border-flaque-clay px-3 py-1 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+              onClick={() => { void handleClearCache(); }}
+            >
+              Clear cache
+            </button>
+          </div>
+        ) : null}
+      </section>
+
+      {/* ── Auto-Playlist Config ────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <h3 className="font-display text-xl text-flaque-ink">Automatic Playlists</h3>
+        <p className="mt-1 text-sm text-flaque-steel">
+          Configure how genre/decade playlists are generated.
+        </p>
+
+        {loadingConfig ? (
+          <p className="mt-3 text-sm text-flaque-steel">Loading...</p>
+        ) : (
+          <form className="mt-3 space-y-3" onSubmit={(e) => { void handleSaveConfig(e); }}>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <label className="text-sm text-flaque-ink">
+                Max playlists
+                <input
+                  className="mt-1 block w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                  type="number"
+                  min={0}
+                  value={configMax}
+                  onChange={(e) => setConfigMax(e.target.value)}
+                />
+              </label>
+              <label className="text-sm text-flaque-ink">
+                Min tracks per playlist
+                <input
+                  className="mt-1 block w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                  type="number"
+                  min={1}
+                  value={configMin}
+                  onChange={(e) => setConfigMin(e.target.value)}
+                />
+              </label>
+              <label className="text-sm text-flaque-ink">
+                Tracks per playlist
+                <input
+                  className="mt-1 block w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                  type="number"
+                  min={1}
+                  value={configTracks}
+                  onChange={(e) => setConfigTracks(e.target.value)}
+                />
+              </label>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="submit"
+                className="rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-flaque-cream transition hover:bg-black disabled:opacity-60"
+                disabled={savingConfig}
+              >
+                {savingConfig ? "Saving..." : "Save configuration"}
+              </button>
+              <button
+                type="button"
+                className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:opacity-60"
+                onClick={() => { void handleRegenerate(); }}
+                disabled={regenerating}
+              >
+                {regenerating ? "Regenerating..." : "Regenerate now"}
+              </button>
+            </div>
+
+            {configMessage ? <p className="text-sm text-flaque-steel">{configMessage}</p> : null}
+            {regenMessage ? <p className="text-sm text-flaque-steel">{regenMessage}</p> : null}
+          </form>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -2,6 +2,7 @@ import type { User } from "../types";
 import { navigateTo, type ViewName } from "../utils/appUtils";
 import { AccountView } from "./AccountView";
 import { AdminBackupView } from "./AdminBackupView";
+import { AdminLibraryView } from "./AdminLibraryView";
 import { AdminServerView } from "./AdminServerView";
 import { AdminUsersView } from "./AdminUsersView";
 import { AudioPlayer } from "./AudioPlayer";
@@ -75,7 +76,7 @@ export function AppShell({
     }`;
 
   const configSections: Array<[ConfigSection, string]> = [
-    ["index", "Index"], ["files", "Files"], ["users", "Users"], ["server", "Server"], ["backup", "Backup"]
+    ["index", "Index"], ["files", "Files"], ["users", "Users"], ["library", "Library"], ["server", "Server"], ["backup", "Backup"]
   ];
 
   const sectionSwitcher = activeView === "config" && user.role === "admin" ? (
@@ -145,6 +146,10 @@ export function AppShell({
 
             {configViewProps.activeSection === "backup" ? (
               <AdminBackupView {...backupViewProps} />
+            ) : null}
+
+            {configViewProps.activeSection === "library" ? (
+              <AdminLibraryView />
             ) : null}
           </div>
         ) : null}

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -19,7 +19,7 @@ const LIBRARY_ITEMS: Array<{ key: LibrarySection; label: string }> = [
   { key: "music", label: "Library" },
   { key: "artists", label: "Artists" },
   { key: "albums", label: "Albums" },
-  { key: "playlists", label: "Playlist" }
+  { key: "playlists", label: "Playlists" }
 ];
 
 const THEME_STORAGE_KEY = "flaque_theme_v1";

--- a/frontend/src/components/AutoPlaylistDetailView.tsx
+++ b/frontend/src/components/AutoPlaylistDetailView.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { coverUrl, getAutoPlaylistDetail } from "../api";
+import type { AutoPlaylistDetail, Playlist, Track } from "../types";
+import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+
+type AutoPlaylistDetailViewProps = {
+  playlistId: string;
+  allTracksById: Map<string, Track>;
+  onBack: () => void;
+  onPlayTrack: (playlist: Playlist) => void;
+};
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+export function AutoPlaylistDetailView({
+  playlistId,
+  allTracksById,
+  onBack,
+  onPlayTrack
+}: AutoPlaylistDetailViewProps): JSX.Element {
+  const [detail, setDetail] = useState<AutoPlaylistDetail | null>(null);
+  const [detailTracks, setDetailTracks] = useState<Track[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    getAutoPlaylistDetail(playlistId)
+      .then((result) => {
+        setDetail(result.playlist);
+        setDetailTracks(result.tracks);
+      })
+      .catch(() => {
+        setDetail(null);
+        setDetailTracks([]);
+      })
+      .finally(() => setLoading(false));
+  }, [playlistId]);
+
+  const tracks = useMemo(() => {
+    if (!detail) return detailTracks;
+    return detail.trackIds
+      .map((id) => detailTracks.find((t) => t.id === id) ?? allTracksById.get(id))
+      .filter((t): t is Track => t !== undefined);
+  }, [detail, detailTracks, allTracksById]);
+
+  const totalDuration = useMemo(() => tracks.reduce((sum, t) => sum + t.duration, 0), [tracks]);
+
+  function handlePlayAll(): void {
+    if (!detail || tracks.length === 0) return;
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: tracks.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
+  function handleShufflePlay(): void {
+    if (!detail || tracks.length === 0) return;
+    const shuffled = [...tracks].sort(() => Math.random() - 0.5);
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: shuffled.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
+  if (loading) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <button
+          type="button"
+          className="mb-4 flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+          onClick={onBack}
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to playlists
+        </button>
+        <p className="text-sm text-flaque-steel">Loading...</p>
+      </section>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <button
+          type="button"
+          className="mb-4 flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+          onClick={onBack}
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to playlists
+        </button>
+        <p className="text-sm text-flaque-steel">Auto playlist not found.</p>
+      </section>
+    );
+  }
+
+  const decadeLabel = detail.decade % 100 === 0 ? `${detail.decade}` : `${detail.decade % 100}s`;
+
+  return (
+    <section className="m-4 space-y-4">
+      {/* Back button */}
+      <button
+        type="button"
+        className="flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+        onClick={onBack}
+      >
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        Back to playlists
+      </button>
+
+      {/* Header card */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-white/85 to-flaque-cream/40 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-col gap-5 sm:flex-row">
+          {/* Genre/decade visual */}
+          <div className="flex h-48 w-48 shrink-0 items-center justify-center self-center overflow-hidden rounded-2xl bg-gradient-to-br from-flaque-sand/50 to-flaque-clay/30 sm:self-start">
+            <div className="text-center">
+              <p className="font-display text-5xl font-bold text-flaque-ink/60">{decadeLabel}</p>
+              <p className="mt-1 text-sm font-medium text-flaque-steel">{detail.genre}</p>
+            </div>
+          </div>
+
+          {/* Info */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <h2 className="font-display text-2xl text-flaque-ink">{detail.name}</h2>
+
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-flaque-steel">
+              <span className="rounded-full bg-flaque-sand/50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-flaque-ink/70">
+                Auto-generated
+              </span>
+              <span>{detail.trackCount} track{detail.trackCount !== 1 ? "s" : ""}</span>
+              {totalDuration > 0 ? <span>{formatDuration(totalDuration)}</span> : null}
+              <span>Generated {new Date(detail.generatedAt).toLocaleDateString()}</span>
+            </div>
+
+            {/* Action buttons */}
+            <div className="mt-auto flex flex-wrap items-center gap-2 pt-4">
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black"
+                onClick={handlePlayAll}
+              >
+                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+                Play all
+              </button>
+
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
+                onClick={handleShufflePlay}
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4" />
+                </svg>
+                Shuffle
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Track list */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
+        {tracks.length === 0 ? (
+          <p className="px-5 py-4 text-sm text-flaque-steel">No playable tracks.</p>
+        ) : (
+          <ul>
+            {tracks.map((track, index) => (
+              <li
+                key={track.id}
+                className="flex items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+              >
+                <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
+                <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
+                  <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
+                    {track.tags.extra?.lyrics ? (
+                      <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
+                        L
+                      </span>
+                    ) : null}
+                    <span className="truncate">{getTrackDisplayTitle(track)}</span>
+                  </p>
+                  <p className="truncate text-xs text-flaque-steel">
+                    {getTrackDisplayArtist(track) ?? "Unknown artist"}
+                    {track.tags.album ? ` \u00b7 ${track.tags.album}` : ""}
+                  </p>
+                </div>
+                <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
+                  {formatDuration(track.duration)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/AutoPlaylistDetailView.tsx
+++ b/frontend/src/components/AutoPlaylistDetailView.tsx
@@ -145,13 +145,25 @@ export function AutoPlaylistDetailView({
       {/* Header card */}
       <div className="rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-white/85 to-flaque-cream/40 p-5 shadow-panel backdrop-blur-sm">
         <div className="flex flex-col gap-5 sm:flex-row">
-          {/* Genre/decade visual */}
-          <div className="flex h-48 w-48 shrink-0 items-center justify-center self-center overflow-hidden rounded-2xl bg-gradient-to-br from-flaque-sand/50 to-flaque-clay/30 sm:self-start">
-            <div className="text-center">
-              <p className="font-display text-5xl font-bold text-flaque-ink/60">{decadeLabel}</p>
-              <p className="mt-1 text-sm font-medium text-flaque-steel">{detail.genre}</p>
-            </div>
-          </div>
+           {/* Genre/decade visual */}
+           <div className="relative h-48 w-48 shrink-0 items-center justify-center self-center overflow-hidden rounded-2xl bg-gradient-to-br from-flaque-sand/50 to-flaque-clay/30 sm:self-start">
+             <div className="text-center">
+               <p className="font-display text-5xl font-bold text-flaque-ink/60">{decadeLabel}</p>
+               <p className="mt-1 text-sm font-medium text-flaque-steel">{detail.genre}</p>
+             </div>
+             
+             {/* Play button overlay */}
+             <button
+               type="button"
+               className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100"
+               onClick={handlePlayAll}
+               aria-label={`Play ${detail.name}`}
+             >
+               <svg className="h-10 w-10 text-[#ffffff] drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                 <path d="M8 6v12l10-6-10-6z" />
+               </svg>
+             </button>
+           </div>
 
           {/* Info */}
           <div className="flex min-w-0 flex-1 flex-col">

--- a/frontend/src/components/ConfigView.tsx
+++ b/frontend/src/components/ConfigView.tsx
@@ -27,7 +27,7 @@ export type ConfigViewProps = {
   onSectionChange: (section: ConfigSection) => void;
 };
 
-export type ConfigSection = "index" | "files" | "users" | "server" | "backup";
+export type ConfigSection = "index" | "files" | "users" | "server" | "backup" | "library";
 
 function normalizeSearch(value: string): string {
   return value.trim().toLowerCase();

--- a/frontend/src/components/ForYouPlaylistDetailView.tsx
+++ b/frontend/src/components/ForYouPlaylistDetailView.tsx
@@ -142,16 +142,28 @@ export function ForYouPlaylistDetailView({
       {/* Header card */}
       <div className="rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/80 to-purple-50/60 p-5 shadow-panel backdrop-blur-sm">
         <div className="flex flex-col gap-5 sm:flex-row">
-          {/* Seed artist visual */}
-          <div className="flex h-48 w-48 shrink-0 items-center justify-center self-center overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-100/80 to-purple-100/60 sm:self-start">
-            <div className="text-center px-3">
-              <svg className="mx-auto h-8 w-8 text-indigo-400/70" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-                  d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-              </svg>
-              <p className="mt-2 font-display text-lg font-bold text-flaque-ink/70 leading-tight">{detail.seedArtist}</p>
-            </div>
-          </div>
+           {/* Seed artist visual */}
+           <div className="relative h-48 w-48 shrink-0 items-center justify-center self-center overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-100/80 to-purple-100/60 sm:self-start">
+             <div className="text-center px-3">
+               <svg className="mx-auto h-8 w-8 text-indigo-400/70" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                   d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+               </svg>
+               <p className="mt-2 font-display text-lg font-bold text-flaque-ink/70 leading-tight">{detail.seedArtist}</p>
+             </div>
+             
+             {/* Play button overlay */}
+             <button
+               type="button"
+               className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100"
+               onClick={handlePlayAll}
+               aria-label={`Play ${detail.name}`}
+             >
+               <svg className="h-10 w-10 text-[#ffffff] drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                 <path d="M8 6v12l10-6-10-6z" />
+               </svg>
+             </button>
+           </div>
 
           {/* Info */}
           <div className="flex min-w-0 flex-1 flex-col">

--- a/frontend/src/components/ForYouPlaylistDetailView.tsx
+++ b/frontend/src/components/ForYouPlaylistDetailView.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { coverUrl, getForYouPlaylistDetail } from "../api";
+import type { ForYouPlaylistDetail, Playlist, Track } from "../types";
+import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+
+type ForYouPlaylistDetailViewProps = {
+  playlistId: string;
+  allTracksById: Map<string, Track>;
+  onBack: () => void;
+  onPlayTrack: (playlist: Playlist) => void;
+  onDismiss: (playlistId: string) => Promise<void>;
+};
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+export function ForYouPlaylistDetailView({
+  playlistId,
+  allTracksById,
+  onBack,
+  onPlayTrack,
+  onDismiss
+}: ForYouPlaylistDetailViewProps): JSX.Element {
+  const [detail, setDetail] = useState<ForYouPlaylistDetail | null>(null);
+  const [detailTracks, setDetailTracks] = useState<Track[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dismissing, setDismissing] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    getForYouPlaylistDetail(playlistId)
+      .then((result) => {
+        setDetail(result.playlist);
+        setDetailTracks(result.tracks);
+      })
+      .catch(() => {
+        setDetail(null);
+        setDetailTracks([]);
+      })
+      .finally(() => setLoading(false));
+  }, [playlistId]);
+
+  const tracks = useMemo(() => {
+    if (!detail) return detailTracks;
+    return detail.trackIds
+      .map((id) => detailTracks.find((t) => t.id === id) ?? allTracksById.get(id))
+      .filter((t): t is Track => t !== undefined);
+  }, [detail, detailTracks, allTracksById]);
+
+  const totalDuration = useMemo(() => tracks.reduce((sum, t) => sum + t.duration, 0), [tracks]);
+
+  function handlePlayAll(): void {
+    if (!detail || tracks.length === 0) return;
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: tracks.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
+  function handleShufflePlay(): void {
+    if (!detail || tracks.length === 0) return;
+    const shuffled = [...tracks].sort(() => Math.random() - 0.5);
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: shuffled.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
+  async function handleDismiss(): Promise<void> {
+    if (!detail || dismissing) return;
+    setDismissing(true);
+    try {
+      await onDismiss(detail.id);
+      onBack();
+    } finally {
+      setDismissing(false);
+    }
+  }
+
+  const backButton = (
+    <button
+      type="button"
+      className="flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+      onClick={onBack}
+    >
+      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+      </svg>
+      Back to playlists
+    </button>
+  );
+
+  if (loading) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        {backButton}
+        <p className="mt-4 text-sm text-flaque-steel">Loading...</p>
+      </section>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        {backButton}
+        <p className="mt-4 text-sm text-flaque-steel">For-you playlist not found.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="m-4 space-y-4">
+      {backButton}
+
+      {/* Header card */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/80 to-purple-50/60 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-col gap-5 sm:flex-row">
+          {/* Seed artist visual */}
+          <div className="flex h-48 w-48 shrink-0 items-center justify-center self-center overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-100/80 to-purple-100/60 sm:self-start">
+            <div className="text-center px-3">
+              <svg className="mx-auto h-8 w-8 text-indigo-400/70" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                  d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+              </svg>
+              <p className="mt-2 font-display text-lg font-bold text-flaque-ink/70 leading-tight">{detail.seedArtist}</p>
+            </div>
+          </div>
+
+          {/* Info */}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <h2 className="font-display text-2xl text-flaque-ink">{detail.name}</h2>
+
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-flaque-steel">
+              <span className="rounded-full bg-indigo-100/70 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-indigo-600/80">
+                Made for you
+              </span>
+              <span>{detail.trackCount} track{detail.trackCount !== 1 ? "s" : ""}</span>
+              {totalDuration > 0 ? <span>{formatDuration(totalDuration)}</span> : null}
+              <span>Generated {new Date(detail.generatedAt).toLocaleDateString()}</span>
+            </div>
+
+            {/* Action buttons */}
+            <div className="mt-auto flex flex-wrap items-center gap-2 pt-4">
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black"
+                onClick={handlePlayAll}
+              >
+                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+                Play all
+              </button>
+
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
+                onClick={handleShufflePlay}
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4" />
+                </svg>
+                Shuffle
+              </button>
+
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl border border-red-200 px-4 py-2 text-sm text-red-500 transition hover:bg-red-50"
+                onClick={() => { void handleDismiss(); }}
+                disabled={dismissing}
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                {dismissing ? "Hiding..." : "Not interested"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Track list */}
+      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
+        {tracks.length === 0 ? (
+          <p className="px-5 py-4 text-sm text-flaque-steel">No playable tracks.</p>
+        ) : (
+          <ul>
+            {tracks.map((track, index) => (
+              <li
+                key={track.id}
+                className="flex items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+              >
+                <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
+                <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
+                  <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
+                    {track.tags.extra?.lyrics ? (
+                      <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
+                        L
+                      </span>
+                    ) : null}
+                    <span className="truncate">{getTrackDisplayTitle(track)}</span>
+                  </p>
+                  <p className="truncate text-xs text-flaque-steel">
+                    {getTrackDisplayArtist(track) ?? "Unknown artist"}
+                    {track.tags.album ? ` \u00b7 ${track.tags.album}` : ""}
+                  </p>
+                </div>
+                <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
+                  {formatDuration(track.duration)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -35,7 +35,9 @@ const defaultProps = {
   onPatchPlaylist: vi.fn().mockResolvedValue(undefined),
   onDeletePlaylist: vi.fn().mockResolvedValue(undefined),
   onNavigateToPlaylist: vi.fn(),
-  onReportPlaylistListen: vi.fn().mockResolvedValue(undefined)
+  onReportPlaylistListen: vi.fn().mockResolvedValue(undefined),
+  autoPlaylists: [],
+  loadingAutoPlaylists: false
 };
 
 describe("LibraryPlaylistSection", () => {

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -3,7 +3,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { Playlist } from "../types";
+import type { AutoPlaylistSummary, ForYouPlaylistSummary, Playlist } from "../types";
 import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
 
 function createPlaylist(input: {
@@ -12,6 +12,11 @@ function createPlaylist(input: {
   authorId: string;
   visibility?: "private" | "public";
   trackIds?: string[];
+  description?: string;
+  hearts?: string[];
+  heartCount?: number;
+  listenCount?: number;
+  collaborators?: string[];
 }): Playlist {
   return {
     id: input.id,
@@ -19,12 +24,12 @@ function createPlaylist(input: {
     authorId: input.authorId,
     visibility: input.visibility ?? "private",
     trackIds: input.trackIds ?? [],
-    description: "",
+    description: input.description ?? "",
     cover: null,
-    hearts: [],
-    heartCount: 0,
-    listenCount: 0,
-    collaborators: []
+    hearts: input.hearts ?? [],
+    heartCount: input.heartCount ?? 0,
+    listenCount: input.listenCount ?? 0,
+    collaborators: input.collaborators ?? []
   };
 }
 
@@ -36,17 +41,21 @@ const defaultProps = {
   onDeletePlaylist: vi.fn().mockResolvedValue(undefined),
   onNavigateToPlaylist: vi.fn(),
   onReportPlaylistListen: vi.fn().mockResolvedValue(undefined),
-  autoPlaylists: [],
+  autoPlaylists: [] as AutoPlaylistSummary[],
   loadingAutoPlaylists: false,
-  forYouPlaylists: [],
+  forYouPlaylists: [] as ForYouPlaylistSummary[],
   loadingForYouPlaylists: false,
-  onDismissForYouPlaylist: vi.fn().mockResolvedValue(undefined)
+  onDismissForYouPlaylist: vi.fn().mockResolvedValue(undefined),
+  onHeartPlaylist: vi.fn().mockResolvedValue(undefined)
 };
 
 describe("LibraryPlaylistSection", () => {
   afterEach(() => {
     cleanup();
+    vi.clearAllMocks();
   });
+
+  // ── Basic CRUD ───────────────────────────────────────────────
 
   it("shows empty state when no playlists exist", () => {
     render(
@@ -139,5 +148,429 @@ describe("LibraryPlaylistSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "Play Night Drive" }));
 
     expect(onPlayPlaylist).toHaveBeenCalledWith(playlist);
+  });
+
+  // ── Description field in create form ─────────────────────────
+
+  it("shows description field when name is filled", () => {
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    // No description field initially
+    expect(screen.queryByPlaceholderText("Description (optional)")).toBeNull();
+
+    // Type a name — description field should appear
+    fireEvent.change(screen.getByPlaceholderText("New playlist name"), { target: { value: "Test" } });
+    expect(screen.getByPlaceholderText("Description (optional)")).toBeTruthy();
+  });
+
+  it("submits description along with create", async () => {
+    const onCreatePlaylist = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={onCreatePlaylist}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("New playlist name"), { target: { value: "Described" } });
+    fireEvent.change(screen.getByPlaceholderText("Description (optional)"), { target: { value: "My description" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(onCreatePlaylist).toHaveBeenCalledWith({
+        name: "Described",
+        visibility: "private",
+        description: "My description"
+      });
+    });
+  });
+
+  it("omits description when empty", async () => {
+    const onCreatePlaylist = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={onCreatePlaylist}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("New playlist name"), { target: { value: "NoDesc" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(onCreatePlaylist).toHaveBeenCalledWith({
+        name: "NoDesc",
+        visibility: "private"
+      });
+    });
+  });
+
+  // ── Popular Playlists section ────────────────────────────────
+
+  it("renders Popular Playlists section for public playlists from other users", () => {
+    const publicPlaylist = createPlaylist({
+      id: "playlist-pub",
+      name: "Top Hits",
+      authorId: "user-2",
+      visibility: "public",
+      heartCount: 5,
+      listenCount: 20
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[publicPlaylist]}
+        ownerNameById={{ "user-2": "Bob" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Popular Playlists")).toBeTruthy();
+    expect(screen.getByText("Top Hits")).toBeTruthy();
+  });
+
+  it("shows heart button on popular playlist cards", () => {
+    const publicPlaylist = createPlaylist({
+      id: "playlist-pub",
+      name: "Hearted Mix",
+      authorId: "user-2",
+      visibility: "public",
+      heartCount: 3
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[publicPlaylist]}
+        ownerNameById={{ "user-2": "Bob" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText("Heart playlist")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+  });
+
+  it("calls onHeartPlaylist when heart is clicked", () => {
+    const onHeartPlaylist = vi.fn().mockResolvedValue(undefined);
+    const publicPlaylist = createPlaylist({
+      id: "playlist-pub",
+      name: "Heart Me",
+      authorId: "user-2",
+      visibility: "public"
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[publicPlaylist]}
+        ownerNameById={{ "user-2": "Bob" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        onHeartPlaylist={onHeartPlaylist}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Heart playlist"));
+    expect(onHeartPlaylist).toHaveBeenCalledWith("playlist-pub");
+  });
+
+  it("does not show Popular Playlists when no public playlists from others exist", () => {
+    const myPlaylist = createPlaylist({
+      id: "playlist-mine",
+      name: "Mine",
+      authorId: "user-1",
+      visibility: "public"
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[myPlaylist]}
+        ownerNameById={{ "user-1": "Alice" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("Popular Playlists")).toBeNull();
+  });
+
+  // ── Playlist card info ───────────────────────────────────────
+
+  it("shows description on playlist card when set", () => {
+    const playlist = createPlaylist({
+      id: "playlist-desc",
+      name: "With Desc",
+      authorId: "user-1",
+      description: "A cool playlist"
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        ownerNameById={{ "user-1": "Alice" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("A cool playlist")).toBeTruthy();
+  });
+
+  it("navigates to playlist detail on card click", () => {
+    const onNavigateToPlaylist = vi.fn();
+    const playlist = createPlaylist({
+      id: "playlist-nav",
+      name: "Navigable",
+      authorId: "user-1"
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        ownerNameById={{ "user-1": "Alice" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        onNavigateToPlaylist={onNavigateToPlaylist}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Navigable"));
+    expect(onNavigateToPlaylist).toHaveBeenCalledWith("playlist-nav");
+  });
+
+  // ── Automatic Playlists section ──────────────────────────────
+
+  it("renders Automatic Playlists section with cards", () => {
+    const autoPlaylists: AutoPlaylistSummary[] = [
+      {
+        id: "auto:rock-1970",
+        name: "70s Rock",
+        genre: "Rock",
+        decade: 1970,
+        trackCount: 25,
+        generatedAt: "2026-04-01T00:00:00Z"
+      }
+    ];
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        autoPlaylists={autoPlaylists}
+      />
+    );
+
+    expect(screen.getByText("Automatic Playlists")).toBeTruthy();
+    expect(screen.getByText("70s Rock")).toBeTruthy();
+    expect(screen.getByText("Rock")).toBeTruthy();
+    expect(screen.getByText(/25 tracks/)).toBeTruthy();
+  });
+
+  it("shows loading state for auto playlists", () => {
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        loadingAutoPlaylists={true}
+      />
+    );
+
+    expect(screen.getByText("Loading...")).toBeTruthy();
+  });
+
+  it("shows empty message when no auto playlists", () => {
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        autoPlaylists={[]}
+      />
+    );
+
+    expect(screen.getByText("Automatic playlists will appear here once generated.")).toBeTruthy();
+  });
+
+  it("navigates to auto playlist on click", () => {
+    const onNavigateToPlaylist = vi.fn();
+    const autoPlaylists: AutoPlaylistSummary[] = [
+      {
+        id: "auto:jazz-1960",
+        name: "60s Jazz",
+        genre: "Jazz",
+        decade: 1960,
+        trackCount: 15,
+        generatedAt: "2026-04-01T00:00:00Z"
+      }
+    ];
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        autoPlaylists={autoPlaylists}
+        onNavigateToPlaylist={onNavigateToPlaylist}
+      />
+    );
+
+    fireEvent.click(screen.getByText("60s Jazz"));
+    expect(onNavigateToPlaylist).toHaveBeenCalledWith("auto:jazz-1960");
+  });
+
+  // ── Made for you section ─────────────────────────────────────
+
+  it("renders Made for you section", () => {
+    const forYouPlaylists: ForYouPlaylistSummary[] = [
+      {
+        id: "for-you:pink-floyd",
+        name: "Because you listen to Pink Floyd",
+        seedArtist: "Pink Floyd",
+        trackCount: 20,
+        generatedAt: "2026-04-01T00:00:00Z"
+      }
+    ];
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        forYouPlaylists={forYouPlaylists}
+      />
+    );
+
+    expect(screen.getByText("Made for you")).toBeTruthy();
+    expect(screen.getByText("Because you listen to Pink Floyd")).toBeTruthy();
+    expect(screen.getByText("Pink Floyd")).toBeTruthy();
+    expect(screen.getByText(/20 tracks/)).toBeTruthy();
+  });
+
+  it("hides Made for you section when empty", () => {
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        forYouPlaylists={[]}
+      />
+    );
+
+    expect(screen.queryByText("Made for you")).toBeNull();
+  });
+
+  it("calls dismiss on for-you playlist", () => {
+    const onDismissForYouPlaylist = vi.fn().mockResolvedValue(undefined);
+    const forYouPlaylists: ForYouPlaylistSummary[] = [
+      {
+        id: "for-you:artist",
+        name: "Because you listen to Artist",
+        seedArtist: "Artist",
+        trackCount: 10,
+        generatedAt: "2026-04-01T00:00:00Z"
+      }
+    ];
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[]}
+        ownerNameById={{}}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        forYouPlaylists={forYouPlaylists}
+        onDismissForYouPlaylist={onDismissForYouPlaylist}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Hide Because you listen to Artist"));
+    expect(onDismissForYouPlaylist).toHaveBeenCalledWith("for-you:artist");
+  });
+
+  // ── Listen count badges ──────────────────────────────────────
+
+  it("shows listen count badge on popular playlist cards", () => {
+    const publicPlaylist = createPlaylist({
+      id: "playlist-listened",
+      name: "Listened Mix",
+      authorId: "user-2",
+      visibility: "public",
+      listenCount: 42
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[publicPlaylist]}
+        ownerNameById={{ "user-2": "Bob" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("42")).toBeTruthy();
+  });
+
+  // ── Reports listen on play ───────────────────────────────────
+
+  it("reports listen when playing a playlist", () => {
+    const onReportPlaylistListen = vi.fn().mockResolvedValue(undefined);
+    const playlist = createPlaylist({
+      id: "playlist-report",
+      name: "Report Me",
+      authorId: "user-1",
+      trackIds: ["t1"]
+    });
+
+    render(
+      <LibraryPlaylistSection
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        ownerNameById={{ "user-1": "Alice" }}
+        onCreatePlaylist={vi.fn().mockResolvedValue(undefined)}
+        onPlayPlaylist={vi.fn()}
+        onReportPlaylistListen={onReportPlaylistListen}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Play Report Me" }));
+    expect(onReportPlaylistListen).toHaveBeenCalledWith("playlist-report");
   });
 });

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -37,7 +37,10 @@ const defaultProps = {
   onNavigateToPlaylist: vi.fn(),
   onReportPlaylistListen: vi.fn().mockResolvedValue(undefined),
   autoPlaylists: [],
-  loadingAutoPlaylists: false
+  loadingAutoPlaylists: false,
+  forYouPlaylists: [],
+  loadingForYouPlaylists: false,
+  onDismissForYouPlaylist: vi.fn().mockResolvedValue(undefined)
 };
 
 describe("LibraryPlaylistSection", () => {

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useState } from "react";
 
 import { coverUrl, playlistCoverUrl } from "../api";
-import type { Playlist, PlaylistVisibility, Track, User } from "../types";
+import type { AutoPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
 
 type LibraryPlaylistSectionProps = {
   availablePlaylists: Playlist[];
@@ -15,6 +15,8 @@ type LibraryPlaylistSectionProps = {
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onNavigateToPlaylist: (playlistId: string) => void;
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
+  autoPlaylists: AutoPlaylistSummary[];
+  loadingAutoPlaylists: boolean;
 };
 
 // ── Mosaic cover (compact) ─────────────────────────────────────────
@@ -168,7 +170,9 @@ export function LibraryPlaylistSection({
   onPatchPlaylist: _onPatchPlaylist,
   onDeletePlaylist: _onDeletePlaylist,
   onNavigateToPlaylist,
-  onReportPlaylistListen
+  onReportPlaylistListen,
+  autoPlaylists,
+  loadingAutoPlaylists
 }: LibraryPlaylistSectionProps): JSX.Element {
   const [playlistName, setPlaylistName] = useState("");
   const [playlistVisibility, setPlaylistVisibility] = useState<PlaylistVisibility>("private");
@@ -275,12 +279,43 @@ export function LibraryPlaylistSection({
         </section>
       ) : null}
 
-      {/* ── Automatic Playlists (placeholder) ─────────────────────── */}
-      <section className="rounded-xl border border-dashed border-flaque-clay/60 bg-white/60 p-5 backdrop-blur-sm">
+      {/* ── Automatic Playlists ────────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-gradient-to-br from-white/85 to-flaque-cream/40 p-5 shadow-panel backdrop-blur-sm">
         <SectionHeader title="Automatic Playlists" />
-        <p className="mt-2 text-sm text-flaque-steel">
-          Automatic playlists will appear here once generated.
-        </p>
+        {loadingAutoPlaylists ? (
+          <p className="mt-2 text-sm text-flaque-steel">Loading...</p>
+        ) : autoPlaylists.length === 0 ? (
+          <p className="mt-2 text-sm text-flaque-steel">
+            Automatic playlists will appear here once generated.
+          </p>
+        ) : (
+          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            {autoPlaylists.map((ap) => (
+              <div
+                key={ap.id}
+                className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-flaque-ink/5 to-flaque-sand/30 shadow-sm transition hover:shadow-md"
+                onClick={() => onNavigateToPlaylist(ap.id)}
+                role="link"
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === "Enter") onNavigateToPlaylist(ap.id); }}
+              >
+                <div className="flex aspect-square w-full items-center justify-center bg-gradient-to-br from-flaque-sand/40 to-flaque-clay/20">
+                  <div className="text-center">
+                    <p className="font-display text-2xl font-bold text-flaque-ink/70">{ap.decade % 100 === 0 ? ap.decade : `${ap.decade % 100}s`}</p>
+                    <p className="mt-0.5 text-xs font-medium text-flaque-steel">{ap.genre}</p>
+                  </div>
+                </div>
+                <div className="p-3">
+                  <p className="truncate text-sm font-semibold text-flaque-ink">{ap.name}</p>
+                  <p className="mt-0.5 text-xs text-flaque-steel">
+                    {ap.trackCount} track{ap.trackCount !== 1 ? "s" : ""}
+                    {" \u00b7 "}Generated {new Date(ap.generatedAt).toLocaleDateString()}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </section>
     </div>
   );

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useState } from "react";
 
 import { coverUrl, playlistCoverUrl } from "../api";
-import type { AutoPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
+import type { AutoPlaylistSummary, ForYouPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
 
 type LibraryPlaylistSectionProps = {
   availablePlaylists: Playlist[];
@@ -17,6 +17,9 @@ type LibraryPlaylistSectionProps = {
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
   autoPlaylists: AutoPlaylistSummary[];
   loadingAutoPlaylists: boolean;
+  forYouPlaylists: ForYouPlaylistSummary[];
+  loadingForYouPlaylists: boolean;
+  onDismissForYouPlaylist: (playlistId: string) => Promise<void>;
 };
 
 // ── Mosaic cover (compact) ─────────────────────────────────────────
@@ -172,7 +175,10 @@ export function LibraryPlaylistSection({
   onNavigateToPlaylist,
   onReportPlaylistListen,
   autoPlaylists,
-  loadingAutoPlaylists
+  loadingAutoPlaylists,
+  forYouPlaylists,
+  loadingForYouPlaylists,
+  onDismissForYouPlaylist
 }: LibraryPlaylistSectionProps): JSX.Element {
   const [playlistName, setPlaylistName] = useState("");
   const [playlistVisibility, setPlaylistVisibility] = useState<PlaylistVisibility>("private");
@@ -258,6 +264,56 @@ export function LibraryPlaylistSection({
           </div>
         )}
       </section>
+
+      {/* ── Made For You ────────────────────────────────────────── */}
+      {!loadingForYouPlaylists && forYouPlaylists.length > 0 ? (
+        <section className="rounded-xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/60 to-purple-50/40 p-5 shadow-panel backdrop-blur-sm">
+          <SectionHeader title="Made for you" />
+          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            {forYouPlaylists.map((fy) => (
+              <div
+                key={fy.id}
+                className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/80 to-purple-50/60 shadow-sm transition hover:shadow-md"
+                onClick={() => onNavigateToPlaylist(fy.id)}
+                role="link"
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === "Enter") onNavigateToPlaylist(fy.id); }}
+              >
+                <div className="flex aspect-square w-full items-center justify-center bg-gradient-to-br from-indigo-100/60 to-purple-100/40">
+                  <div className="text-center px-3">
+                    <svg className="mx-auto h-8 w-8 text-indigo-400/60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                        d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                    </svg>
+                    <p className="mt-1 font-display text-sm font-bold text-flaque-ink/70 leading-tight">{fy.seedArtist}</p>
+                  </div>
+                </div>
+                <div className="p-3">
+                  <p className="truncate text-sm font-semibold text-flaque-ink">{fy.name}</p>
+                  <p className="mt-0.5 text-xs text-flaque-steel">
+                    {fy.trackCount} track{fy.trackCount !== 1 ? "s" : ""}
+                  </p>
+                </div>
+
+                {/* Dismiss button */}
+                <button
+                  type="button"
+                  className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-flaque-steel opacity-0 shadow-sm transition hover:bg-white hover:text-red-500 group-hover:opacity-100"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void onDismissForYouPlaylist(fy.id);
+                  }}
+                  aria-label={`Hide ${fy.name}`}
+                >
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       {/* ── Popular Playlists ─────────────────────────────────────── */}
       {popularPlaylists.length > 0 ? (

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -145,18 +145,60 @@ function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPl
                 aria-label={hasHearted ? "Remove heart" : "Heart playlist"}
               >
                 <svg className="h-3 w-3" fill={hasHearted ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
                 </svg>
                 {playlist.heartCount > 0 ? playlist.heartCount : ""}
               </button>
             ) : playlist.heartCount > 0 ? (
               <span className="flex items-center gap-0.5 text-[10px] text-red-400">
                 <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                  <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
                 </svg>
                 {playlist.heartCount}
               </span>
             ) : null}
+            {playlist.listenCount > 0 ? (
+              <span className="flex items-center gap-0.5 text-[10px] text-flaque-steel">
+                <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                </svg>
+                {playlist.listenCount}
+              </span>
+            ) : null}
+            {/* Collaborators badge */}
+            {playlist.collaborators.length > 0 ? (
+              <>
+                {playlist.collaborators.includes("everyone") ? (
+                  <span className="flex items-center gap-0.5 text-[10px] text-yellow-600">
+                    <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
+                      <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 2a8 8 0 110 16 8 8 0 010-16zM12 11a2 2 0 100 4 2 2 0 000-4z"/>
+                    </svg>
+                    Everyone
+                  </span>
+                ) : (
+                  playlist.collaborators.map((collabId) => {
+                    const collabName = ownerNameById[collabId] ?? collabId;
+                    return (
+                      <span key={collabId} className="inline-flex items-center gap-1 rounded-full bg-flaque-cream px-2 py-0.5 text-[10px] font-medium text-flaque-ink">
+                        {collabName}
+                        <button
+                          type="button"
+                          className="text-flaque-steel hover:text-red-500"
+                          onClick={() => { /* Remove collaborator functionality would go here */ }}
+                          aria-label={`Remove ${collabName}`}
+                        >
+                          <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                          </svg>
+                        </button>
+                      </span>
+                    );
+                  })
+                )}
+              </>
+            ) : null}
+          </div>
+        ) : null}
             {playlist.listenCount > 0 ? (
               <span className="flex items-center gap-0.5 text-[10px] text-flaque-steel">
                 <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -115,7 +115,7 @@ function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPl
             onClick={(e) => { e.stopPropagation(); onPlay(); }}
             aria-label={`Play ${playlist.name}`}
           >
-            <svg className="h-10 w-10 text-white drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <svg className="h-10 w-10 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
               <path d="M8 6v12l10-6-10-6z" />
             </svg>
           </button>

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useState } from "react";
 
+import defaultCoverImage from "../assets/default-cover.png";
 import { coverUrl, playlistCoverUrl } from "../api";
 import type { AutoPlaylistSummary, ForYouPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
 
@@ -27,23 +28,17 @@ type LibraryPlaylistSectionProps = {
 
 function getPlaylistMosaicTracks(trackIds: string[], allTracksById: Map<string, Track>): Track[] {
   const seen = new Set<string>();
-  const withCover: Track[] = [];
-  const withoutCover: Track[] = [];
+  const result: Track[] = [];
   for (const id of trackIds) {
-    if (withCover.length >= 4) break;
+    if (result.length >= 4) break;
     const track = allTracksById.get(id);
     if (!track) continue;
     const albumKey = track.tags.album ?? track.id;
     if (!seen.has(albumKey)) {
       seen.add(albumKey);
-      if (track.cover) {
-        withCover.push(track);
-      } else if (withoutCover.length < 4) {
-        withoutCover.push(track);
-      }
+      result.push(track);
     }
   }
-  const result = [...withCover, ...withoutCover].slice(0, 4);
   return result;
 }
 
@@ -52,25 +47,19 @@ function PlaylistMosaic({ tracks }: { tracks: Track[] }): JSX.Element {
 
   if (tracks.length === 0) {
     return (
-      <div className="flex h-full w-full items-center justify-center bg-flaque-clay/20">
-        <svg className="h-8 w-8 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-            d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
-        </svg>
-      </div>
+      <img src={defaultCoverImage} alt="" className="h-full w-full object-cover" />
     );
   }
 
   if (tracks.length === 1) {
-    return tracks[0]!.cover ? (
-      <img src={coverUrl(tracks[0]!.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-    ) : (
-      <div className="flex h-full w-full items-center justify-center bg-flaque-clay/20">
-        <svg className="h-8 w-8 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-            d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
-        </svg>
-      </div>
+    return (
+      <img
+        src={coverUrl(tracks[0]!.id)}
+        alt=""
+        className="h-full w-full object-cover"
+        loading="lazy"
+        onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
+      />
     );
   }
 
@@ -78,18 +67,16 @@ function PlaylistMosaic({ tracks }: { tracks: Track[] }): JSX.Element {
     <div className="grid h-full w-full grid-cols-2 grid-rows-2">
       {slots.map((track, i) =>
         track ? (
-          track.cover ? (
-            <img key={i} src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-          ) : (
-            <div key={i} className="flex items-center justify-center bg-flaque-clay/20">
-              <svg className="h-4 w-4 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-                  d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
-              </svg>
-            </div>
-          )
+          <img
+            key={i}
+            src={coverUrl(track.id)}
+            alt=""
+            className="h-full w-full object-cover"
+            loading="lazy"
+            onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
+          />
         ) : (
-          <div key={i} className="bg-flaque-clay/20" />
+          <img key={i} src={defaultCoverImage} alt="" className="h-full w-full object-cover" />
         )
       )}
     </div>

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -27,17 +27,23 @@ type LibraryPlaylistSectionProps = {
 
 function getPlaylistMosaicTracks(trackIds: string[], allTracksById: Map<string, Track>): Track[] {
   const seen = new Set<string>();
-  const result: Track[] = [];
+  const withCover: Track[] = [];
+  const withoutCover: Track[] = [];
   for (const id of trackIds) {
-    if (result.length >= 4) break;
+    if (withCover.length >= 4) break;
     const track = allTracksById.get(id);
     if (!track) continue;
     const albumKey = track.tags.album ?? track.id;
     if (!seen.has(albumKey)) {
       seen.add(albumKey);
-      result.push(track);
+      if (track.cover) {
+        withCover.push(track);
+      } else if (withoutCover.length < 4) {
+        withoutCover.push(track);
+      }
     }
   }
+  const result = [...withCover, ...withoutCover].slice(0, 4);
   return result;
 }
 
@@ -56,8 +62,15 @@ function PlaylistMosaic({ tracks }: { tracks: Track[] }): JSX.Element {
   }
 
   if (tracks.length === 1) {
-    return (
+    return tracks[0]!.cover ? (
       <img src={coverUrl(tracks[0]!.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+    ) : (
+      <div className="flex h-full w-full items-center justify-center bg-flaque-clay/20">
+        <svg className="h-8 w-8 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+            d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+        </svg>
+      </div>
     );
   }
 
@@ -65,7 +78,16 @@ function PlaylistMosaic({ tracks }: { tracks: Track[] }): JSX.Element {
     <div className="grid h-full w-full grid-cols-2 grid-rows-2">
       {slots.map((track, i) =>
         track ? (
-          <img key={i} src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+          track.cover ? (
+            <img key={i} src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+          ) : (
+            <div key={i} className="flex items-center justify-center bg-flaque-clay/20">
+              <svg className="h-4 w-4 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                  d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+              </svg>
+            </div>
+          )
         ) : (
           <div key={i} className="bg-flaque-clay/20" />
         )

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -167,8 +167,8 @@ function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPl
               </span>
             ) : null}
             {/* Collaborators badge */}
-            {playlist.collaborators.length > 0 ? (
-              playlist.collaborators.includes("everyone") ? (
+            {(playlist.collaborators ?? []).length > 0 ? (
+              (playlist.collaborators ?? []).includes("everyone") ? (
                 <span className="flex items-center gap-0.5 text-[10px] text-yellow-600">
                   <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 2a8 8 0 110 16 8 8 0 010-16zM12 11a2 2 0 100 4 2 2 0 000-4z"/>
@@ -177,7 +177,7 @@ function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPl
                 </span>
               ) : (
                 <>
-                  {playlist.collaborators.map((collabId) => {
+                  {(playlist.collaborators ?? []).map((collabId) => {
                     const collabName = ownerNameById[collabId] ?? collabId;
                     return (
                       <span key={collabId} className="inline-flex items-center gap-1 rounded-full bg-flaque-cream px-2 py-0.5 text-[10px] font-medium text-flaque-ink">
@@ -389,7 +389,7 @@ export function LibraryPlaylistSection({
                 onPlay={() => handlePlay(playlist)}
                 showBadges
                 onHeart={() => { void onHeartPlaylist(playlist.id); }}
-                hasHearted={playlist.hearts.includes(user.id)}
+                hasHearted={(playlist.hearts ?? []).includes(user.id)}
               />
             ))}
           </div>

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -12,7 +12,7 @@ type LibraryPlaylistSectionProps = {
   user: User;
   onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
-  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
+  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<Playlist>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onNavigateToPlaylist: (playlistId: string) => void;
   onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -99,28 +99,28 @@ function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPl
       tabIndex={0}
       onKeyDown={(e) => { if (e.key === "Enter") onNavigate(); }}
     >
-        {/* Cover */}
-        <div className="relative aspect-square w-full overflow-hidden">
-          {playlist.cover ? (
-            <img src={playlistCoverUrl(playlist.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-          ) : (
-            <PlaylistMosaic tracks={mosaicTracks} />
-          )}
+      {/* Cover */}
+      <div className="relative aspect-square w-full overflow-hidden">
+        {playlist.cover ? (
+          <img src={playlistCoverUrl(playlist.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+        ) : (
+          <PlaylistMosaic tracks={mosaicTracks} />
+        )}
 
-          {/* Play button overlay */}
-          {onPlay ? (
-            <button
-              type="button"
-              className="absolute inset-0 flex items-center justify-center rounded-lg bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100"
-              onClick={(e) => { e.stopPropagation(); onPlay(); }}
-              aria-label={`Play ${playlist.name}`}
-            >
-              <svg className="h-10 w-10 text-[#ffffff] drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M8 6v12l10-6-10-6z" />
-              </svg>
-            </button>
-          ) : null}
-        </div>
+        {/* Play button overlay */}
+        {onPlay ? (
+          <button
+            type="button"
+            className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100"
+            onClick={(e) => { e.stopPropagation(); onPlay(); }}
+            aria-label={`Play ${playlist.name}`}
+          >
+            <svg className="h-10 w-10 text-white drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M8 6v12l10-6-10-6z" />
+            </svg>
+          </button>
+        ) : null}
+      </div>
 
       {/* Info */}
       <div className="flex flex-1 flex-col p-2">
@@ -134,7 +134,7 @@ function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPl
 
         {/* Badges */}
         {showBadges ? (
-          <div className="mt-1.5 flex items-center gap-2">
+          <div className="mt-1 flex flex-wrap items-center gap-1.5">
             {onHeart ? (
               <button
                 type="button"
@@ -145,14 +145,14 @@ function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPl
                 aria-label={hasHearted ? "Remove heart" : "Heart playlist"}
               >
                 <svg className="h-3 w-3" fill={hasHearted ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
                 </svg>
                 {playlist.heartCount > 0 ? playlist.heartCount : ""}
               </button>
             ) : playlist.heartCount > 0 ? (
               <span className="flex items-center gap-0.5 text-[10px] text-red-400">
                 <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                  <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
                 </svg>
                 {playlist.heartCount}
               </span>
@@ -161,52 +161,32 @@ function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPl
               <span className="flex items-center gap-0.5 text-[10px] text-flaque-steel">
                 <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 {playlist.listenCount}
               </span>
             ) : null}
             {/* Collaborators badge */}
             {playlist.collaborators.length > 0 ? (
-              <>
-                {playlist.collaborators.includes("everyone") ? (
-                  <span className="flex items-center gap-0.5 text-[10px] text-yellow-600">
-                    <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 2a8 8 0 110 16 8 8 0 010-16zM12 11a2 2 0 100 4 2 2 0 000-4z"/>
-                    </svg>
-                    Everyone
-                  </span>
-                ) : (
-                  playlist.collaborators.map((collabId) => {
+              playlist.collaborators.includes("everyone") ? (
+                <span className="flex items-center gap-0.5 text-[10px] text-yellow-600">
+                  <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 2a8 8 0 110 16 8 8 0 010-16zM12 11a2 2 0 100 4 2 2 0 000-4z"/>
+                  </svg>
+                  Everyone
+                </span>
+              ) : (
+                <>
+                  {playlist.collaborators.map((collabId) => {
                     const collabName = ownerNameById[collabId] ?? collabId;
                     return (
                       <span key={collabId} className="inline-flex items-center gap-1 rounded-full bg-flaque-cream px-2 py-0.5 text-[10px] font-medium text-flaque-ink">
                         {collabName}
-                        <button
-                          type="button"
-                          className="text-flaque-steel hover:text-red-500"
-                          onClick={() => { /* Remove collaborator functionality would go here */ }}
-                          aria-label={`Remove ${collabName}`}
-                        >
-                          <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
-                          </svg>
-                        </button>
                       </span>
                     );
-                  })
-                )}
-              </>
-            ) : null}
-          </div>
-        ) : null}
-            {playlist.listenCount > 0 ? (
-              <span className="flex items-center gap-0.5 text-[10px] text-flaque-steel">
-                <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                {playlist.listenCount}
-              </span>
+                  })}
+                </>
+              )
             ) : null}
           </div>
         ) : null}

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -240,7 +240,7 @@ export function LibraryPlaylistSection({
   const myPlaylists = availablePlaylists.filter((p) => p.authorId === user.id);
   const popularPlaylists = availablePlaylists
     .filter((p) => p.visibility === "public" && p.authorId !== user.id)
-    .sort((a, b) => (b.heartCount * 3 + b.listenCount) - (a.heartCount * 3 + a.listenCount));
+    .sort((a, b) => b.heartCount - a.heartCount || b.listenCount - a.listenCount);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -99,34 +99,36 @@ function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPl
       tabIndex={0}
       onKeyDown={(e) => { if (e.key === "Enter") onNavigate(); }}
     >
-      {/* Cover */}
-      <div className="relative aspect-square w-full overflow-hidden">
-        {playlist.cover ? (
-          <img src={playlistCoverUrl(playlist.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-        ) : (
-          <PlaylistMosaic tracks={mosaicTracks} />
-        )}
+        {/* Cover */}
+        <div className="relative aspect-square w-full overflow-hidden">
+          {playlist.cover ? (
+            <img src={playlistCoverUrl(playlist.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+          ) : (
+            <PlaylistMosaic tracks={mosaicTracks} />
+          )}
 
-        {/* Play button overlay */}
-        <button
-          type="button"
-          className="absolute bottom-2 right-2 flex h-10 w-10 items-center justify-center rounded-full bg-flaque-ink text-white opacity-0 shadow-lg transition group-hover:opacity-100"
-          onClick={(e) => { e.stopPropagation(); onPlay(); }}
-          aria-label={`Play ${playlist.name}`}
-        >
-          <svg className="h-5 w-5 translate-x-px" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M8 5v14l11-7z" />
-          </svg>
-        </button>
-      </div>
+          {/* Play button overlay */}
+          {onPlay ? (
+            <button
+              type="button"
+              className="absolute inset-0 flex items-center justify-center rounded-lg bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100"
+              onClick={(e) => { e.stopPropagation(); onPlay(); }}
+              aria-label={`Play ${playlist.name}`}
+            >
+              <svg className="h-10 w-10 text-[#ffffff] drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M8 6v12l10-6-10-6z" />
+              </svg>
+            </button>
+          ) : null}
+        </div>
 
       {/* Info */}
-      <div className="flex flex-1 flex-col p-3">
-        <p className="truncate text-sm font-semibold text-flaque-ink">{playlist.name}</p>
+      <div className="flex flex-1 flex-col p-2">
+        <p className="truncate text-xs font-semibold text-flaque-ink">{playlist.name}</p>
         {playlist.description ? (
-          <p className="mt-0.5 line-clamp-1 text-xs text-flaque-steel">{playlist.description}</p>
+          <p className="mt-0.5 line-clamp-1 text-[10px] text-flaque-steel">{playlist.description}</p>
         ) : null}
-        <p className="mt-1 truncate text-xs text-flaque-steel">
+        <p className="mt-0.5 truncate text-[10px] text-flaque-steel">
           {owner} &middot; {playlist.trackIds.length} track{playlist.trackIds.length !== 1 ? "s" : ""}
         </p>
 
@@ -285,7 +287,7 @@ export function LibraryPlaylistSection({
         {myPlaylists.length === 0 ? (
           <p className="mt-4 text-sm text-flaque-steel">No playlists yet.</p>
         ) : (
-          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <div className="mt-4 grid grid-cols-3 gap-2.5 sm:grid-cols-4 lg:grid-cols-6">
             {myPlaylists.map((playlist) => (
               <PlaylistCard
                 key={playlist.id}
@@ -304,7 +306,7 @@ export function LibraryPlaylistSection({
       {!loadingForYouPlaylists && forYouPlaylists.length > 0 ? (
         <section className="rounded-xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/60 to-purple-50/40 p-5 shadow-panel backdrop-blur-sm">
           <SectionHeader title="Made for you" />
-          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <div className="mt-4 grid grid-cols-3 gap-2.5 sm:grid-cols-4 lg:grid-cols-6">
             {forYouPlaylists.map((fy) => (
               <div
                 key={fy.id}
@@ -354,7 +356,7 @@ export function LibraryPlaylistSection({
       {popularPlaylists.length > 0 ? (
         <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
           <SectionHeader title="Popular Playlists" />
-          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <div className="mt-4 grid grid-cols-3 gap-2.5 sm:grid-cols-4 lg:grid-cols-6">
             {popularPlaylists.map((playlist) => (
               <PlaylistCard
                 key={playlist.id}
@@ -382,7 +384,7 @@ export function LibraryPlaylistSection({
             Automatic playlists will appear here once generated.
           </p>
         ) : (
-          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <div className="mt-4 grid grid-cols-3 gap-2.5 sm:grid-cols-4 lg:grid-cols-6">
             {autoPlaylists.map((ap) => (
               <div
                 key={ap.id}

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -9,11 +9,12 @@ type LibraryPlaylistSectionProps = {
   ownerNameById: Record<string, string>;
   allTracksById: Map<string, Track>;
   user: User;
-  onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility }) => Promise<void>;
+  onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
-  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
+  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onNavigateToPlaylist: (playlistId: string) => void;
+  onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
   autoPlaylists: AutoPlaylistSummary[];
   loadingAutoPlaylists: boolean;
@@ -82,9 +83,11 @@ type PlaylistCardProps = {
   onNavigate: () => void;
   onPlay: () => void;
   showBadges?: boolean;
+  onHeart?: () => void;
+  hasHearted?: boolean;
 };
 
-function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPlay, showBadges }: PlaylistCardProps): JSX.Element {
+function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPlay, showBadges, onHeart, hasHearted }: PlaylistCardProps): JSX.Element {
   const mosaicTracks = getPlaylistMosaicTracks(playlist.trackIds, allTracksById);
   const owner = ownerNameById[playlist.authorId] ?? playlist.authorId;
 
@@ -130,7 +133,21 @@ function PlaylistCard({ playlist, allTracksById, ownerNameById, onNavigate, onPl
         {/* Badges */}
         {showBadges ? (
           <div className="mt-1.5 flex items-center gap-2">
-            {playlist.heartCount > 0 ? (
+            {onHeart ? (
+              <button
+                type="button"
+                className={`flex items-center gap-0.5 text-[10px] transition ${
+                  hasHearted ? "text-red-500 hover:text-red-600" : "text-flaque-steel hover:text-red-400"
+                }`}
+                onClick={(e) => { e.stopPropagation(); onHeart(); }}
+                aria-label={hasHearted ? "Remove heart" : "Heart playlist"}
+              >
+                <svg className="h-3 w-3" fill={hasHearted ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                </svg>
+                {playlist.heartCount > 0 ? playlist.heartCount : ""}
+              </button>
+            ) : playlist.heartCount > 0 ? (
               <span className="flex items-center gap-0.5 text-[10px] text-red-400">
                 <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
@@ -173,6 +190,7 @@ export function LibraryPlaylistSection({
   onPatchPlaylist: _onPatchPlaylist,
   onDeletePlaylist: _onDeletePlaylist,
   onNavigateToPlaylist,
+  onHeartPlaylist,
   onReportPlaylistListen,
   autoPlaylists,
   loadingAutoPlaylists,
@@ -181,6 +199,7 @@ export function LibraryPlaylistSection({
   onDismissForYouPlaylist
 }: LibraryPlaylistSectionProps): JSX.Element {
   const [playlistName, setPlaylistName] = useState("");
+  const [playlistDescription, setPlaylistDescription] = useState("");
   const [playlistVisibility, setPlaylistVisibility] = useState<PlaylistVisibility>("private");
   const [submitting, setSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -196,8 +215,13 @@ export function LibraryPlaylistSection({
     setSubmitting(true);
     setStatusMessage(null);
     try {
-      await onCreatePlaylist({ name: playlistName, visibility: playlistVisibility });
+      await onCreatePlaylist({
+        name: playlistName,
+        visibility: playlistVisibility,
+        description: playlistDescription.trim() || undefined
+      });
       setPlaylistName("");
+      setPlaylistDescription("");
       setStatusMessage("Playlist created.");
     } catch (error) {
       setStatusMessage(error instanceof Error ? error.message : "Unable to create playlist");
@@ -218,31 +242,42 @@ export function LibraryPlaylistSection({
         <SectionHeader title="My Playlists" />
 
         <form
-          className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]"
+          className="mt-4 space-y-3"
           onSubmit={(event) => { void handleSubmit(event); }}
         >
-          <input
-            className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-            type="text"
-            placeholder="New playlist name"
-            value={playlistName}
-            onChange={(event) => setPlaylistName(event.target.value)}
-          />
-          <select
-            className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-            value={playlistVisibility}
-            onChange={(event) => setPlaylistVisibility(event.target.value as PlaylistVisibility)}
-          >
-            <option value="private">Private</option>
-            <option value="public">Public</option>
-          </select>
-          <button
-            className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
-            type="submit"
-            disabled={submitting || !playlistName.trim()}
-          >
-            {submitting ? "Creating..." : "Create"}
-          </button>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]">
+            <input
+              className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              type="text"
+              placeholder="New playlist name"
+              value={playlistName}
+              onChange={(event) => setPlaylistName(event.target.value)}
+            />
+            <select
+              className="rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              value={playlistVisibility}
+              onChange={(event) => setPlaylistVisibility(event.target.value as PlaylistVisibility)}
+            >
+              <option value="private">Private</option>
+              <option value="public">Public</option>
+            </select>
+            <button
+              className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+              type="submit"
+              disabled={submitting || !playlistName.trim()}
+            >
+              {submitting ? "Creating..." : "Create"}
+            </button>
+          </div>
+          {playlistName.trim() ? (
+            <textarea
+              className="w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              rows={2}
+              placeholder="Description (optional)"
+              value={playlistDescription}
+              onChange={(event) => setPlaylistDescription(event.target.value)}
+            />
+          ) : null}
         </form>
 
         {statusMessage ? <p className="mt-2 text-sm text-flaque-steel">{statusMessage}</p> : null}
@@ -329,6 +364,8 @@ export function LibraryPlaylistSection({
                 onNavigate={() => onNavigateToPlaylist(playlist.id)}
                 onPlay={() => handlePlay(playlist)}
                 showBadges
+                onHeart={() => { void onHeartPlaylist(playlist.id); }}
+                hasHearted={playlist.hearts.includes(user.id)}
               />
             ))}
           </div>

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -3,9 +3,10 @@ import { LibraryAlbumsSection } from "./LibraryAlbumsSection";
 import { LibraryArtistsSection } from "./LibraryArtistsSection";
 import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
 import { AutoPlaylistDetailView } from "./AutoPlaylistDetailView";
+import { ForYouPlaylistDetailView } from "./ForYouPlaylistDetailView";
 import { PlaylistDetailView } from "./PlaylistDetailView";
 import { PaginatedLibrary } from "./PaginatedLibrary";
-import type { AlbumEntry, ArtistEntry, AutoPlaylistSummary, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
+import type { AlbumEntry, ArtistEntry, AutoPlaylistSummary, ForYouPlaylistSummary, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
 import type { LibraryFilters, LibrarySection } from "../types/library";
 import { navigateTo } from "../utils/appUtils";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
@@ -26,6 +27,9 @@ type LibraryWorkspaceProps = {
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
   autoPlaylists: AutoPlaylistSummary[];
   loadingAutoPlaylists: boolean;
+  forYouPlaylists: ForYouPlaylistSummary[];
+  loadingForYouPlaylists: boolean;
+  onDismissForYouPlaylist: (playlistId: string) => Promise<void>;
   allTracksById: Map<string, Track>;
   libraryMetadataError: string | null;
   loadingLibraryArtists: boolean;
@@ -99,6 +103,9 @@ export function LibraryWorkspace({
   onReportPlaylistListen,
   autoPlaylists,
   loadingAutoPlaylists,
+  forYouPlaylists,
+  loadingForYouPlaylists,
+  onDismissForYouPlaylist,
   allTracksById,
   libraryMetadataError,
   loadingLibraryArtists,
@@ -153,7 +160,15 @@ export function LibraryWorkspace({
   return (
     <div className="h-full min-h-0 space-y-4 overflow-y-auto">
       {activeLibrarySection === "playlists" ? (
-        playlistDetailId && playlistDetailId.startsWith("auto:") ? (
+        playlistDetailId && playlistDetailId.startsWith("for-you:") ? (
+          <ForYouPlaylistDetailView
+            playlistId={playlistDetailId}
+            allTracksById={allTracksById}
+            onBack={() => onPlaylistDetailNavigate(null)}
+            onPlayTrack={onPlayPlaylist}
+            onDismiss={onDismissForYouPlaylist}
+          />
+        ) : playlistDetailId && playlistDetailId.startsWith("auto:") ? (
           <AutoPlaylistDetailView
             playlistId={playlistDetailId}
             allTracksById={allTracksById}
@@ -190,6 +205,9 @@ export function LibraryWorkspace({
             onReportPlaylistListen={onReportPlaylistListen}
             autoPlaylists={autoPlaylists}
             loadingAutoPlaylists={loadingAutoPlaylists}
+            forYouPlaylists={forYouPlaylists}
+            loadingForYouPlaylists={loadingForYouPlaylists}
+            onDismissForYouPlaylist={onDismissForYouPlaylist}
           />
         )
       ) : null}

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -21,7 +21,7 @@ type LibraryWorkspaceProps = {
   onPlaylistDetailNavigate: (id: string | null) => void;
   onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
-  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
+  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<Playlist>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
@@ -186,6 +186,7 @@ export function LibraryWorkspace({
             onBack={() => onPlaylistDetailNavigate(null)}
             onPlay={onPlayPlaylist}
             onPatch={onPatchPlaylist}
+            onNavigate={onPlaylistDetailNavigate}
             onDelete={onDeletePlaylist}
             onHeart={onHeartPlaylist}
             onReportListen={onReportPlaylistListen}

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -19,9 +19,9 @@ type LibraryWorkspaceProps = {
   user: User;
   playlistDetailId: string | null;
   onPlaylistDetailNavigate: (id: string | null) => void;
-  onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility }) => Promise<void>;
+  onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
-  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
+  onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
@@ -202,6 +202,7 @@ export function LibraryWorkspace({
             onPatchPlaylist={onPatchPlaylist}
             onDeletePlaylist={onDeletePlaylist}
             onNavigateToPlaylist={onPlaylistDetailNavigate}
+            onHeartPlaylist={onHeartPlaylist}
             onReportPlaylistListen={onReportPlaylistListen}
             autoPlaylists={autoPlaylists}
             loadingAutoPlaylists={loadingAutoPlaylists}

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -2,9 +2,10 @@ import { HomePanels } from "./HomePanels";
 import { LibraryAlbumsSection } from "./LibraryAlbumsSection";
 import { LibraryArtistsSection } from "./LibraryArtistsSection";
 import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
+import { AutoPlaylistDetailView } from "./AutoPlaylistDetailView";
 import { PlaylistDetailView } from "./PlaylistDetailView";
 import { PaginatedLibrary } from "./PaginatedLibrary";
-import type { AlbumEntry, ArtistEntry, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
+import type { AlbumEntry, ArtistEntry, AutoPlaylistSummary, LibraryResponse, Playlist, PlaylistVisibility, RadioTrack, Track, User } from "../types";
 import type { LibraryFilters, LibrarySection } from "../types/library";
 import { navigateTo } from "../utils/appUtils";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
@@ -23,6 +24,8 @@ type LibraryWorkspaceProps = {
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportPlaylistListen: (playlistId: string) => Promise<void>;
+  autoPlaylists: AutoPlaylistSummary[];
+  loadingAutoPlaylists: boolean;
   allTracksById: Map<string, Track>;
   libraryMetadataError: string | null;
   loadingLibraryArtists: boolean;
@@ -94,6 +97,8 @@ export function LibraryWorkspace({
   onDeletePlaylist,
   onHeartPlaylist,
   onReportPlaylistListen,
+  autoPlaylists,
+  loadingAutoPlaylists,
   allTracksById,
   libraryMetadataError,
   loadingLibraryArtists,
@@ -148,7 +153,14 @@ export function LibraryWorkspace({
   return (
     <div className="h-full min-h-0 space-y-4 overflow-y-auto">
       {activeLibrarySection === "playlists" ? (
-        playlistDetailId ? (
+        playlistDetailId && playlistDetailId.startsWith("auto:") ? (
+          <AutoPlaylistDetailView
+            playlistId={playlistDetailId}
+            allTracksById={allTracksById}
+            onBack={() => onPlaylistDetailNavigate(null)}
+            onPlayTrack={onPlayPlaylist}
+          />
+        ) : playlistDetailId ? (
           <PlaylistDetailView
             playlistId={playlistDetailId}
             availablePlaylists={availablePlaylists}
@@ -176,6 +188,8 @@ export function LibraryWorkspace({
             onDeletePlaylist={onDeletePlaylist}
             onNavigateToPlaylist={onPlaylistDetailNavigate}
             onReportPlaylistListen={onReportPlaylistListen}
+            autoPlaylists={autoPlaylists}
+            loadingAutoPlaylists={loadingAutoPlaylists}
           />
         )
       ) : null}

--- a/frontend/src/components/PlaylistDetailView.test.tsx
+++ b/frontend/src/components/PlaylistDetailView.test.tsx
@@ -1,0 +1,416 @@
+/* @vitest-environment happy-dom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Playlist, Track, User } from "../types";
+
+const { getUsersMock } = vi.hoisted(() => ({
+  getUsersMock: vi.fn<() => Promise<User[]>>().mockResolvedValue([])
+}));
+
+vi.mock("../api", () => ({
+  coverUrl: (id: string) => `/api/covers/${id}`,
+  playlistCoverUrl: (id: string) => `/api/playlists/${id}/cover`,
+  getUsers: getUsersMock,
+  uploadPlaylistCover: vi.fn().mockResolvedValue(undefined),
+  deletePlaylistCover: vi.fn().mockResolvedValue(undefined)
+}));
+
+import { PlaylistDetailView } from "./PlaylistDetailView";
+
+function makeTrack(id: string, title?: string, artist?: string): Track {
+  return {
+    id,
+    owner: "user-1",
+    path: `/uploads/${id}.mp3`,
+    duration: 200,
+    mimeType: "audio/mpeg",
+    codec: "mp3",
+    tags: {
+      title: title ?? id,
+      artist: artist ?? "Test Artist"
+    }
+  };
+}
+
+function makePlaylist(overrides: Partial<Playlist> = {}): Playlist {
+  return {
+    id: "user-1:my-playlist",
+    name: "My Playlist",
+    authorId: "user-1",
+    visibility: "public",
+    trackIds: ["t1", "t2"],
+    description: "A test playlist",
+    cover: null,
+    hearts: [],
+    heartCount: 0,
+    listenCount: 5,
+    collaborators: [],
+    ...overrides
+  };
+}
+
+const defaultUser: User = { id: "user-1", username: "alice", email: "alice@test.local", role: "user" };
+const otherUser: User = { id: "user-2", username: "bob", email: "bob@test.local", role: "user" };
+
+function createTracksMap(tracks: Track[]): Map<string, Track> {
+  return new Map(tracks.map((t) => [t.id, t]));
+}
+
+const defaultTracks = [makeTrack("t1", "Song One", "Artist A"), makeTrack("t2", "Song Two", "Artist B")];
+const defaultTracksById = createTracksMap(defaultTracks);
+
+const defaultProps = {
+  playlistId: "user-1:my-playlist",
+  availablePlaylists: [makePlaylist()],
+  manageablePlaylists: [makePlaylist()],
+  allTracksById: defaultTracksById,
+  ownerNameById: { "user-1": "alice", "user-2": "bob" } as Record<string, string>,
+  user: defaultUser,
+  onBack: vi.fn(),
+  onPlay: vi.fn(),
+  onPatch: vi.fn().mockResolvedValue(undefined),
+  onDelete: vi.fn().mockResolvedValue(undefined),
+  onHeart: vi.fn().mockResolvedValue({ hearted: true, heartCount: 1 }),
+  onReportListen: vi.fn().mockResolvedValue(undefined)
+};
+
+describe("PlaylistDetailView", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders playlist info, tracks, and stats", () => {
+    render(<PlaylistDetailView {...defaultProps} />);
+
+    expect(screen.getByText("My Playlist")).toBeTruthy();
+    expect(screen.getByText("A test playlist")).toBeTruthy();
+    expect(screen.getByText("by alice")).toBeTruthy();
+    expect(screen.getByText(/2 tracks/)).toBeTruthy();
+    expect(screen.getByText("Song One")).toBeTruthy();
+    expect(screen.getByText("Song Two")).toBeTruthy();
+  });
+
+  it("shows not found when playlist doesn't exist", () => {
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        playlistId="nonexistent:id"
+      />
+    );
+
+    expect(screen.getByText("Playlist not found.")).toBeTruthy();
+  });
+
+  it("shows back button and navigates on click", () => {
+    const onBack = vi.fn();
+    render(<PlaylistDetailView {...defaultProps} onBack={onBack} />);
+
+    fireEvent.click(screen.getByText("Back to playlists"));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("plays all tracks on Play all click", () => {
+    const onPlay = vi.fn();
+    const onReportListen = vi.fn().mockResolvedValue(undefined);
+    render(<PlaylistDetailView {...defaultProps} onPlay={onPlay} onReportListen={onReportListen} />);
+
+    fireEvent.click(screen.getByText("Play all"));
+    expect(onPlay).toHaveBeenCalledTimes(1);
+    expect(onReportListen).toHaveBeenCalledWith("user-1:my-playlist");
+  });
+
+  it("shuffles tracks on Shuffle click", () => {
+    const onPlay = vi.fn();
+    render(<PlaylistDetailView {...defaultProps} onPlay={onPlay} />);
+
+    fireEvent.click(screen.getByText("Shuffle"));
+    expect(onPlay).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Heart button ─────────────────────────────────────────────
+
+  it("shows heart button for public playlist from other user", () => {
+    const playlist = makePlaylist({ id: "user-2:other-playlist", authorId: "user-2", visibility: "public" });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        playlistId="user-2:other-playlist"
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[]}
+        user={defaultUser}
+      />
+    );
+
+    expect(screen.getByLabelText("Heart playlist")).toBeTruthy();
+  });
+
+  it("does not show heart button for own playlist", () => {
+    render(<PlaylistDetailView {...defaultProps} />);
+
+    expect(screen.queryByLabelText("Heart playlist")).toBeNull();
+    expect(screen.queryByLabelText("Remove heart")).toBeNull();
+  });
+
+  it("toggles heart on click", async () => {
+    const onHeart = vi.fn().mockResolvedValue({ hearted: true, heartCount: 1 });
+    const playlist = makePlaylist({ id: "user-2:heartable", authorId: "user-2", visibility: "public" });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        playlistId="user-2:heartable"
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[]}
+        user={defaultUser}
+        onHeart={onHeart}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Heart playlist"));
+
+    await waitFor(() => {
+      expect(onHeart).toHaveBeenCalledWith("user-2:heartable");
+    });
+  });
+
+  it("shows filled heart when already hearted", () => {
+    const playlist = makePlaylist({
+      id: "user-2:hearted",
+      authorId: "user-2",
+      visibility: "public",
+      hearts: ["user-1"],
+      heartCount: 1
+    });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        playlistId="user-2:hearted"
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[]}
+        user={defaultUser}
+      />
+    );
+
+    expect(screen.getByLabelText("Remove heart")).toBeTruthy();
+  });
+
+  // ── Visibility badge ─────────────────────────────────────────
+
+  it("shows visibility badge", () => {
+    render(<PlaylistDetailView {...defaultProps} />);
+    expect(screen.getByText("public")).toBeTruthy();
+  });
+
+  it("shows private badge for private playlist", () => {
+    const playlist = makePlaylist({ visibility: "private" });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[playlist]}
+      />
+    );
+    expect(screen.getByText("private")).toBeTruthy();
+  });
+
+  // ── Listen count ─────────────────────────────────────────────
+
+  it("shows listen count when > 0", () => {
+    const playlist = makePlaylist({ listenCount: 42 });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[playlist]}
+      />
+    );
+    expect(screen.getByText("42")).toBeTruthy();
+  });
+
+  // ── Collaborators ────────────────────────────────────────────
+
+  it("displays collaborators", () => {
+    const playlist = makePlaylist({ collaborators: ["user-2"] });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[playlist]}
+      />
+    );
+
+    expect(screen.getByText("Collaborators:")).toBeTruthy();
+    expect(screen.getByText("bob")).toBeTruthy();
+  });
+
+  // ── Edit button visibility ───────────────────────────────────
+
+  it("shows Edit button for manageable playlist", () => {
+    render(<PlaylistDetailView {...defaultProps} />);
+    expect(screen.getByText("Edit")).toBeTruthy();
+  });
+
+  it("shows Edit button for collaborator", () => {
+    const playlist = makePlaylist({ id: "user-2:collab", authorId: "user-2", collaborators: ["user-1"] });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        playlistId="user-2:collab"
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[]}
+      />
+    );
+    expect(screen.getByText("Edit")).toBeTruthy();
+  });
+
+  it("hides Edit and Delete for non-owner non-collaborator", () => {
+    const playlist = makePlaylist({ id: "user-2:foreign", authorId: "user-2" });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        playlistId="user-2:foreign"
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[]}
+      />
+    );
+    expect(screen.queryByText("Edit")).toBeNull();
+    expect(screen.queryByText("Delete")).toBeNull();
+  });
+
+  // ── Delete ───────────────────────────────────────────────────
+
+  it("deletes playlist and navigates back", async () => {
+    const onDelete = vi.fn().mockResolvedValue(undefined);
+    const onBack = vi.fn();
+    render(<PlaylistDetailView {...defaultProps} onDelete={onDelete} onBack={onBack} />);
+
+    fireEvent.click(screen.getByText("Delete"));
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith("user-1:my-playlist");
+      expect(onBack).toHaveBeenCalled();
+    });
+  });
+
+  // ── Edit modal ───────────────────────────────────────────────
+
+  it("opens edit modal and saves changes", async () => {
+    const onPatch = vi.fn().mockResolvedValue(undefined);
+    render(<PlaylistDetailView {...defaultProps} onPatch={onPatch} />);
+
+    fireEvent.click(screen.getByText("Edit"));
+    expect(screen.getByText("Edit playlist")).toBeTruthy();
+
+    // Change name
+    const nameInput = screen.getByDisplayValue("My Playlist") as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "Renamed" } });
+
+    // Change description
+    const descTextarea = screen.getByDisplayValue("A test playlist") as HTMLTextAreaElement;
+    fireEvent.change(descTextarea, { target: { value: "New desc" } });
+
+    // Submit
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(onPatch).toHaveBeenCalledWith(
+        "user-1:my-playlist",
+        expect.objectContaining({
+          name: "Renamed",
+          description: "New desc"
+        })
+      );
+    });
+  });
+
+  it("edit modal shows visibility selector", async () => {
+    render(<PlaylistDetailView {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    const selects = screen.getAllByRole("combobox");
+    const visibilitySelect = selects.find(
+      (s) => (s as HTMLSelectElement).value === "public"
+    ) as HTMLSelectElement;
+    expect(visibilitySelect).toBeTruthy();
+  });
+
+  it("edit modal shows track list with drag handles", () => {
+    render(<PlaylistDetailView {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    // Should show track names in the modal
+    const songOnes = screen.getAllByText("Song One");
+    expect(songOnes.length).toBeGreaterThanOrEqual(2); // one in list, one in modal
+
+    // Drag handles
+    const dragHandles = screen.getAllByLabelText("Drag to reorder");
+    expect(dragHandles.length).toBe(2);
+  });
+
+  it("edit modal allows removing tracks", async () => {
+    const onPatch = vi.fn().mockResolvedValue(undefined);
+    render(<PlaylistDetailView {...defaultProps} onPatch={onPatch} />);
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    // Remove first track
+    const removeButtons = screen.getAllByLabelText("Remove track");
+    fireEvent.click(removeButtons[0]!);
+
+    // Save
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(onPatch).toHaveBeenCalledWith(
+        "user-1:my-playlist",
+        expect.objectContaining({
+          trackIds: ["t2"]
+        })
+      );
+    });
+  });
+
+  it("edit modal cancel closes without saving", () => {
+    const onPatch = vi.fn();
+    render(<PlaylistDetailView {...defaultProps} onPatch={onPatch} />);
+
+    fireEvent.click(screen.getByText("Edit"));
+    expect(screen.getByText("Edit playlist")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(screen.queryByText("Edit playlist")).toBeNull();
+    expect(onPatch).not.toHaveBeenCalled();
+  });
+
+  // ── Description display ──────────────────────────────────────
+
+  it("hides description when empty", () => {
+    const playlist = makePlaylist({ description: "" });
+    render(
+      <PlaylistDetailView
+        {...defaultProps}
+        availablePlaylists={[playlist]}
+        manageablePlaylists={[playlist]}
+      />
+    );
+
+    // The description paragraph should not be rendered
+    expect(screen.queryByText("A test playlist")).toBeNull();
+  });
+
+  // ── Reports listen only once ─────────────────────────────────
+
+  it("reports listen only once per playlist view", () => {
+    const onReportListen = vi.fn().mockResolvedValue(undefined);
+    render(<PlaylistDetailView {...defaultProps} onReportListen={onReportListen} />);
+
+    fireEvent.click(screen.getByText("Play all"));
+    fireEvent.click(screen.getByText("Shuffle"));
+
+    expect(onReportListen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/PlaylistDetailView.test.tsx
+++ b/frontend/src/components/PlaylistDetailView.test.tsx
@@ -70,7 +70,8 @@ const defaultProps = {
   user: defaultUser,
   onBack: vi.fn(),
   onPlay: vi.fn(),
-  onPatch: vi.fn().mockResolvedValue(undefined),
+  onPatch: vi.fn().mockResolvedValue(makePlaylist()),
+  onNavigate: vi.fn(),
   onDelete: vi.fn().mockResolvedValue(undefined),
   onHeart: vi.fn().mockResolvedValue({ hearted: true, heartCount: 1 }),
   onReportListen: vi.fn().mockResolvedValue(undefined)
@@ -297,7 +298,7 @@ describe("PlaylistDetailView", () => {
   // ── Inline editing ───────────────────────────────────────────
 
   it("enters inline edit mode and saves changes", async () => {
-    const onPatch = vi.fn().mockResolvedValue(undefined);
+    const onPatch = vi.fn().mockResolvedValue(makePlaylist());
     render(<PlaylistDetailView {...defaultProps} onPatch={onPatch} />);
 
     fireEvent.click(screen.getByText("Edit"));
@@ -347,7 +348,7 @@ describe("PlaylistDetailView", () => {
   });
 
   it("inline edit allows removing tracks", async () => {
-    const onPatch = vi.fn().mockResolvedValue(undefined);
+    const onPatch = vi.fn().mockResolvedValue(makePlaylist());
     render(<PlaylistDetailView {...defaultProps} onPatch={onPatch} />);
 
     fireEvent.click(screen.getByText("Edit"));

--- a/frontend/src/components/PlaylistDetailView.test.tsx
+++ b/frontend/src/components/PlaylistDetailView.test.tsx
@@ -294,20 +294,19 @@ describe("PlaylistDetailView", () => {
     });
   });
 
-  // ── Edit modal ───────────────────────────────────────────────
+  // ── Inline editing ───────────────────────────────────────────
 
-  it("opens edit modal and saves changes", async () => {
+  it("enters inline edit mode and saves changes", async () => {
     const onPatch = vi.fn().mockResolvedValue(undefined);
     render(<PlaylistDetailView {...defaultProps} onPatch={onPatch} />);
 
     fireEvent.click(screen.getByText("Edit"));
-    expect(screen.getByText("Edit playlist")).toBeTruthy();
 
-    // Change name
+    // Title becomes an input
     const nameInput = screen.getByDisplayValue("My Playlist") as HTMLInputElement;
     fireEvent.change(nameInput, { target: { value: "Renamed" } });
 
-    // Change description
+    // Description becomes a textarea
     const descTextarea = screen.getByDisplayValue("A test playlist") as HTMLTextAreaElement;
     fireEvent.change(descTextarea, { target: { value: "New desc" } });
 
@@ -325,7 +324,7 @@ describe("PlaylistDetailView", () => {
     });
   });
 
-  it("edit modal shows visibility selector", async () => {
+  it("inline edit shows visibility selector", async () => {
     render(<PlaylistDetailView {...defaultProps} />);
 
     fireEvent.click(screen.getByText("Edit"));
@@ -337,21 +336,17 @@ describe("PlaylistDetailView", () => {
     expect(visibilitySelect).toBeTruthy();
   });
 
-  it("edit modal shows track list with drag handles", () => {
+  it("inline edit shows track list with drag handles", () => {
     render(<PlaylistDetailView {...defaultProps} />);
 
     fireEvent.click(screen.getByText("Edit"));
 
-    // Should show track names in the modal
-    const songOnes = screen.getAllByText("Song One");
-    expect(songOnes.length).toBeGreaterThanOrEqual(2); // one in list, one in modal
-
-    // Drag handles
+    // Drag handles appear in edit mode
     const dragHandles = screen.getAllByLabelText("Drag to reorder");
     expect(dragHandles.length).toBe(2);
   });
 
-  it("edit modal allows removing tracks", async () => {
+  it("inline edit allows removing tracks", async () => {
     const onPatch = vi.fn().mockResolvedValue(undefined);
     render(<PlaylistDetailView {...defaultProps} onPatch={onPatch} />);
 
@@ -374,15 +369,19 @@ describe("PlaylistDetailView", () => {
     });
   });
 
-  it("edit modal cancel closes without saving", () => {
+  it("inline edit cancel exits without saving", () => {
     const onPatch = vi.fn();
     render(<PlaylistDetailView {...defaultProps} onPatch={onPatch} />);
 
     fireEvent.click(screen.getByText("Edit"));
-    expect(screen.getByText("Edit playlist")).toBeTruthy();
+    // Save and Cancel buttons should be visible
+    expect(screen.getByText("Save")).toBeTruthy();
+    expect(screen.getByText("Cancel")).toBeTruthy();
 
     fireEvent.click(screen.getByText("Cancel"));
-    expect(screen.queryByText("Edit playlist")).toBeNull();
+    // Edit button reappears, Save/Cancel disappear
+    expect(screen.getByText("Edit")).toBeTruthy();
+    expect(screen.queryByText("Save")).toBeNull();
     expect(onPatch).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -689,9 +689,9 @@ export function PlaylistDetailView({
 
           {/* Info */}
           <div className="flex min-w-0 flex-1 flex-col">
-            <div className="flex items-start gap-2">
+            <div className="flex items-center gap-2">
               <h2 className="font-display text-2xl text-flaque-ink">{playlist.name}</h2>
-              <span className={`mt-1 shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+              <span className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
                 playlist.visibility === "public"
                   ? "bg-green-100 text-green-700"
                   : "bg-flaque-clay/30 text-flaque-steel"

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -671,7 +671,7 @@ export function PlaylistDetailView({
                onClick={handlePlayAll}
                aria-label={`Play ${playlist.name}`}
              >
-               <svg className="h-10 w-10 text-[#ffffff] drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+               <svg className="h-10 w-10 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
                  <path d="M8 6v12l10-6-10-6z" />
                </svg>
              </button>

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -50,17 +50,23 @@ function formatDuration(seconds: number): string {
 
 function getPlaylistMosaicTracks(trackIds: string[], allTracksById: Map<string, Track>): Track[] {
   const seen = new Set<string>();
-  const result: Track[] = [];
+  const withCover: Track[] = [];
+  const withoutCover: Track[] = [];
   for (const id of trackIds) {
-    if (result.length >= 4) break;
+    if (withCover.length >= 4) break;
     const track = allTracksById.get(id);
     if (!track) continue;
     const albumKey = track.tags.album ?? track.id;
     if (!seen.has(albumKey)) {
       seen.add(albumKey);
-      result.push(track);
+      if (track.cover) {
+        withCover.push(track);
+      } else if (withoutCover.length < 4) {
+        withoutCover.push(track);
+      }
     }
   }
+  const result = [...withCover, ...withoutCover].slice(0, 4);
   return result;
 }
 
@@ -91,12 +97,19 @@ function PlaylistCover({ playlist, mosaicTracks }: { playlist: Playlist; mosaicT
   }
 
   if (mosaicTracks.length === 1) {
-    return (
+    return mosaicTracks[0]!.cover ? (
       <img
         src={coverUrl(mosaicTracks[0]!.id)}
         alt=""
         className="h-full w-full rounded-2xl object-cover"
       />
+    ) : (
+      <div className="flex h-full w-full items-center justify-center rounded-2xl bg-flaque-clay/20">
+        <svg className="h-16 w-16 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+            d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+        </svg>
+      </div>
     );
   }
 
@@ -104,7 +117,16 @@ function PlaylistCover({ playlist, mosaicTracks }: { playlist: Playlist; mosaicT
     <div className="grid h-full w-full grid-cols-2 grid-rows-2 overflow-hidden rounded-2xl">
       {slots.map((track, i) =>
         track ? (
-          <img key={i} src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+          track.cover ? (
+            <img key={i} src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+          ) : (
+            <div key={i} className="flex items-center justify-center bg-flaque-clay/20">
+              <svg className="h-8 w-8 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                  d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+              </svg>
+            </div>
+          )
         ) : (
           <div key={i} className="bg-flaque-clay/20" />
         )
@@ -176,7 +198,16 @@ function SortableTrackItem({
 
       <div className="h-8 w-8 shrink-0 overflow-hidden rounded-md">
         {track ? (
-          <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+          track.cover ? (
+            <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center bg-flaque-clay/20">
+              <svg className="h-4 w-4 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                  d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+              </svg>
+            </div>
+          )
         ) : (
           <div className="h-full w-full bg-flaque-clay/30" />
         )}
@@ -826,7 +857,16 @@ export function PlaylistDetailView({
               >
                 <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
                 <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
-                  <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+                  {track.cover ? (
+                    <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center bg-flaque-clay/20">
+                      <svg className="h-4 w-4 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                          d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+                      </svg>
+                    </div>
+                  )}
                 </div>
                 <div className="min-w-0 flex-1">
                   <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -17,6 +17,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
+import defaultCoverImage from "../assets/default-cover.png";
 import { coverUrl, deletePlaylistCover, getUsers, playlistCoverUrl, uploadPlaylistCover } from "../api";
 import type { Playlist, PlaylistVisibility, Track, User } from "../types";
 import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
@@ -50,23 +51,17 @@ function formatDuration(seconds: number): string {
 
 function getPlaylistMosaicTracks(trackIds: string[], allTracksById: Map<string, Track>): Track[] {
   const seen = new Set<string>();
-  const withCover: Track[] = [];
-  const withoutCover: Track[] = [];
+  const result: Track[] = [];
   for (const id of trackIds) {
-    if (withCover.length >= 4) break;
+    if (result.length >= 4) break;
     const track = allTracksById.get(id);
     if (!track) continue;
     const albumKey = track.tags.album ?? track.id;
     if (!seen.has(albumKey)) {
       seen.add(albumKey);
-      if (track.cover) {
-        withCover.push(track);
-      } else if (withoutCover.length < 4) {
-        withoutCover.push(track);
-      }
+      result.push(track);
     }
   }
-  const result = [...withCover, ...withoutCover].slice(0, 4);
   return result;
 }
 
@@ -87,29 +82,18 @@ function PlaylistCover({ playlist, mosaicTracks }: { playlist: Playlist; mosaicT
 
   if (mosaicTracks.length === 0) {
     return (
-      <div className="flex h-full w-full items-center justify-center rounded-2xl bg-flaque-clay/20">
-        <svg className="h-16 w-16 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-            d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
-        </svg>
-      </div>
+      <img src={defaultCoverImage} alt="" className="h-full w-full rounded-2xl object-cover" />
     );
   }
 
   if (mosaicTracks.length === 1) {
-    return mosaicTracks[0]!.cover ? (
+    return (
       <img
         src={coverUrl(mosaicTracks[0]!.id)}
         alt=""
         className="h-full w-full rounded-2xl object-cover"
+        onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
       />
-    ) : (
-      <div className="flex h-full w-full items-center justify-center rounded-2xl bg-flaque-clay/20">
-        <svg className="h-16 w-16 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-            d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
-        </svg>
-      </div>
     );
   }
 
@@ -117,18 +101,16 @@ function PlaylistCover({ playlist, mosaicTracks }: { playlist: Playlist; mosaicT
     <div className="grid h-full w-full grid-cols-2 grid-rows-2 overflow-hidden rounded-2xl">
       {slots.map((track, i) =>
         track ? (
-          track.cover ? (
-            <img key={i} src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-          ) : (
-            <div key={i} className="flex items-center justify-center bg-flaque-clay/20">
-              <svg className="h-8 w-8 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-                  d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
-              </svg>
-            </div>
-          )
+          <img
+            key={i}
+            src={coverUrl(track.id)}
+            alt=""
+            className="h-full w-full object-cover"
+            loading="lazy"
+            onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
+          />
         ) : (
-          <div key={i} className="bg-flaque-clay/20" />
+          <img key={i} src={defaultCoverImage} alt="" className="h-full w-full object-cover" />
         )
       )}
     </div>
@@ -198,18 +180,15 @@ function SortableTrackItem({
 
       <div className="h-8 w-8 shrink-0 overflow-hidden rounded-md">
         {track ? (
-          track.cover ? (
-            <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-          ) : (
-            <div className="flex h-full w-full items-center justify-center bg-flaque-clay/20">
-              <svg className="h-4 w-4 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-                  d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
-              </svg>
-            </div>
-          )
+          <img
+            src={coverUrl(track.id)}
+            alt=""
+            className="h-full w-full object-cover"
+            loading="lazy"
+            onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
+          />
         ) : (
-          <div className="h-full w-full bg-flaque-clay/30" />
+          <img src={defaultCoverImage} alt="" className="h-full w-full object-cover" />
         )}
       </div>
       <div className="min-w-0 flex-1">
@@ -857,16 +836,13 @@ export function PlaylistDetailView({
               >
                 <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
                 <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
-                  {track.cover ? (
-                    <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-                  ) : (
-                    <div className="flex h-full w-full items-center justify-center bg-flaque-clay/20">
-                      <svg className="h-4 w-4 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-                          d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
-                      </svg>
-                    </div>
-                  )}
+                  <img
+                    src={coverUrl(track.id)}
+                    alt=""
+                    className="h-full w-full object-cover"
+                    loading="lazy"
+                    onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
+                  />
                 </div>
                 <div className="min-w-0 flex-1">
                   <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -32,7 +32,8 @@ type PlaylistDetailViewProps = {
   onBack: () => void;
   onPlay: (playlist: Playlist) => void;
   onPlayTrack?: (track: Track, queueSource: Track[]) => void;
-  onPatch: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
+  onPatch: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<Playlist>;
+  onNavigate: (playlistId: string) => void;
   onDelete: (playlistId: string) => Promise<void>;
   onHeart: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportListen: (playlistId: string) => Promise<void>;
@@ -220,6 +221,7 @@ export function PlaylistDetailView({
   onPlay,
   onPlayTrack,
   onPatch,
+  onNavigate,
   onDelete,
   onHeart,
   onReportListen
@@ -444,7 +446,7 @@ export function PlaylistDetailView({
         }
         setCoverUploading(false);
       }
-      await onPatch(playlist!.id, {
+      const updated = await onPatch(playlist!.id, {
         name: editName.trim() || playlist!.name,
         visibility: editVisibility,
         description: editDescription.trim(),
@@ -452,6 +454,9 @@ export function PlaylistDetailView({
         collaborators: isOwner ? editCollaboratorIds : undefined
       });
       setEditing(false);
+      if (updated.id !== playlist!.id) {
+        onNavigate(updated.id);
+      }
     } finally {
       setSaving(false);
     }

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -30,6 +30,7 @@ type PlaylistDetailViewProps = {
   user: User;
   onBack: () => void;
   onPlay: (playlist: Playlist) => void;
+  onPlayTrack?: (track: Track, queueSource: Track[]) => void;
   onPatch: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   onDelete: (playlistId: string) => Promise<void>;
   onHeart: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
@@ -502,6 +503,7 @@ export function PlaylistDetailView({
   user,
   onBack,
   onPlay,
+  onPlayTrack,
   onPatch,
   onDelete,
   onHeart,
@@ -579,6 +581,22 @@ export function PlaylistDetailView({
     onPlay(playlist);
   }
 
+  function handlePlayTrack(track: Track): void {
+    if (!playlist) return;
+    if (!listenReportedRef.current) {
+      listenReportedRef.current = true;
+      void onReportListen(playlist.id);
+    }
+    if (onPlayTrack) {
+      onPlayTrack(track, tracks);
+    } else {
+      const idx = tracks.indexOf(track);
+      const reordered = [...tracks.slice(idx), ...tracks.slice(0, idx)];
+      const syntheticPlaylist: Playlist = { ...playlist, trackIds: reordered.map((t) => t.id) };
+      onPlay(syntheticPlaylist);
+    }
+  }
+
   function handleShufflePlay(): void {
     if (!playlist || tracks.length === 0) return;
     if (!listenReportedRef.current) {
@@ -632,10 +650,22 @@ export function PlaylistDetailView({
       {/* Header card */}
       <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
         <div className="flex flex-col gap-5 sm:flex-row">
-          {/* Cover */}
-          <div className="h-48 w-48 shrink-0 self-center overflow-hidden sm:self-start">
-            <PlaylistCover playlist={playlist} mosaicTracks={mosaicTracks} />
-          </div>
+           {/* Cover */}
+           <div className="relative h-48 w-48 shrink-0 self-center overflow-hidden sm:self-start">
+             <PlaylistCover playlist={playlist} mosaicTracks={mosaicTracks} />
+             
+             {/* Play button overlay */}
+             <button
+               type="button"
+               className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100"
+               onClick={handlePlayAll}
+               aria-label={`Play ${playlist.name}`}
+             >
+               <svg className="h-10 w-10 text-[#ffffff] drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                 <path d="M8 6v12l10-6-10-6z" />
+               </svg>
+             </button>
+           </div>
 
           {/* Info */}
           <div className="flex min-w-0 flex-1 flex-col">
@@ -654,8 +684,9 @@ export function PlaylistDetailView({
               <p className="mt-1 text-sm text-flaque-steel">{playlist.description}</p>
             ) : null}
 
-            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-flaque-steel">
-              <span>by {owner}</span>
+            <p className="mt-2 text-sm text-flaque-steel">by {owner}</p>
+
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-flaque-steel">
               <span>{playlist.trackIds.length} track{playlist.trackIds.length !== 1 ? "s" : ""}</span>
               {totalDuration > 0 ? <span>{formatDuration(totalDuration)}</span> : null}
               {playlist.listenCount > 0 ? (
@@ -665,6 +696,31 @@ export function PlaylistDetailView({
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                   {playlist.listenCount}
+                </span>
+              ) : null}
+              {canHeart ? (
+                <button
+                  type="button"
+                  className={`flex items-center gap-0.5 transition ${
+                    hasHearted
+                      ? "text-red-500 hover:text-red-600"
+                      : "text-flaque-steel hover:text-red-400"
+                  }`}
+                  onClick={() => { void handleHeart(); }}
+                  disabled={hearting}
+                  aria-label={hasHearted ? "Remove heart" : "Heart playlist"}
+                >
+                  <svg className="h-3.5 w-3.5" fill={hasHearted ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                  </svg>
+                  {playlist.heartCount > 0 ? playlist.heartCount : ""}
+                </button>
+              ) : playlist.heartCount > 0 ? (
+                <span className="flex items-center gap-0.5 text-red-400">
+                  <svg className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                  </svg>
+                  {playlist.heartCount}
                 </span>
               ) : null}
             </div>
@@ -703,32 +759,6 @@ export function PlaylistDetailView({
                 </svg>
                 Shuffle
               </button>
-
-              {canHeart ? (
-                <button
-                  type="button"
-                  className={`flex items-center gap-1 rounded-xl border px-3 py-2 text-sm transition ${
-                    hasHearted
-                      ? "border-red-200 bg-red-50 text-red-600 hover:bg-red-100"
-                      : "border-flaque-clay text-flaque-steel hover:bg-flaque-cream hover:text-flaque-ink"
-                  }`}
-                  onClick={() => { void handleHeart(); }}
-                  disabled={hearting}
-                  aria-label={hasHearted ? "Remove heart" : "Heart playlist"}
-                >
-                  <svg className="h-4 w-4" fill={hasHearted ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-                  </svg>
-                  {playlist.heartCount > 0 ? playlist.heartCount : ""}
-                </button>
-              ) : playlist.heartCount > 0 ? (
-                <span className="flex items-center gap-1 text-xs text-flaque-steel">
-                  <svg className="h-3.5 w-3.5 text-red-400" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-                  </svg>
-                  {playlist.heartCount}
-                </span>
-              ) : null}
 
               {canEdit ? (
                 <button
@@ -769,7 +799,11 @@ export function PlaylistDetailView({
             {tracks.map((track, index) => (
               <li
                 key={track.id}
-                className="flex items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+                className="flex cursor-pointer items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+                onClick={() => handlePlayTrack(track)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === "Enter") handlePlayTrack(track); }}
               >
                 <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
                 <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -211,7 +211,7 @@ function EditModal({ playlist, allTracksById, isOwner, saving, onSave, onClose }
   const [description, setDescription] = useState(playlist.description);
   const [visibility, setVisibility] = useState<PlaylistVisibility>(playlist.visibility);
   const [trackIds, setTrackIds] = useState<string[]>([...playlist.trackIds]);
-  const [collaboratorIds, setCollaboratorIds] = useState<string[]>([...playlist.collaborators]);
+  const [collaboratorIds, setCollaboratorIds] = useState<string[]>([...(playlist.collaborators ?? [])]);
   const [allUsers, setAllUsers] = useState<User[]>([]);
   const [coverPreview, setCoverPreview] = useState<string | null>(null);
   const [coverFile, setCoverFile] = useState<File | null>(null);
@@ -532,7 +532,7 @@ export function PlaylistDetailView({
 
   const canEdit = useMemo(() => {
     if (!playlist) return false;
-    return canManage || playlist.collaborators.includes(user.id);
+    return canManage || (playlist.collaborators ?? []).includes(user.id) || (playlist.collaborators ?? []).includes("everyone");
   }, [playlist, canManage, user.id]);
 
   const canHeart = useMemo(() => {
@@ -542,7 +542,7 @@ export function PlaylistDetailView({
 
   const hasHearted = useMemo(() => {
     if (!playlist) return false;
-    return playlist.hearts.includes(user.id);
+    return (playlist.hearts ?? []).includes(user.id);
   }, [playlist, user.id]);
 
   const tracks = useMemo(() => {
@@ -735,10 +735,10 @@ export function PlaylistDetailView({
               ) : null}
             </div>
 
-            {playlist.collaborators.length > 0 ? (
+            {(playlist.collaborators ?? []).length > 0 ? (
               <div className="mt-2 flex flex-wrap gap-1">
                 <span className="text-xs text-flaque-steel">Collaborators:</span>
-                {playlist.collaborators.includes("everyone") ? (
+                {(playlist.collaborators ?? []).includes("everyone") ? (
                   <span className="flex items-center gap-0.5 text-[10px] text-yellow-600">
                     <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M12 2a10 10 0 100 20 10 10 10 0 000-20zm0 2a8 8 0 110 16 8 8 0 010-16zM12 11a2 2 0 1000 4 2 2 0 000-4z"/>
@@ -746,7 +746,7 @@ export function PlaylistDetailView({
                     Everyone
                   </span>
                 ) : (
-                  playlist.collaborators.map((collab) => (
+                  (playlist.collaborators ?? []).map((collab) => (
                     <span key={collab} className="rounded-full bg-flaque-cream px-2 py-0.5 text-[10px] font-medium text-flaque-ink">
                       {ownerNameById[collab] ?? collab}
                     </span>

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { type ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -117,16 +117,7 @@ function PlaylistCover({ playlist, mosaicTracks }: { playlist: Playlist; mosaicT
   );
 }
 
-// ── Edit modal ─────────────────────────────────────────────────────
-
-type EditModalProps = {
-  playlist: Playlist;
-  allTracksById: Map<string, Track>;
-  isOwner: boolean;
-  saving: boolean;
-  onSave: (patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
-  onClose: () => void;
-};
+// ── Sortable track item (reused for inline edit) ──────────────────
 
 function SortableTrackItem({
   id,
@@ -216,302 +207,6 @@ function SortableTrackItem({
   );
 }
 
-function EditModal({ playlist, allTracksById, isOwner, saving, onSave, onClose }: EditModalProps): JSX.Element {
-  const [name, setName] = useState(playlist.name);
-  const [description, setDescription] = useState(playlist.description);
-  const [visibility, setVisibility] = useState<PlaylistVisibility>(playlist.visibility);
-  const [trackIds, setTrackIds] = useState<string[]>([...playlist.trackIds]);
-  const [collaboratorIds, setCollaboratorIds] = useState<string[]>([...(playlist.collaborators ?? [])]);
-  const [allUsers, setAllUsers] = useState<User[]>([]);
-  const [coverPreview, setCoverPreview] = useState<string | null>(null);
-  const [coverFile, setCoverFile] = useState<File | null>(null);
-  const [coverRemoved, setCoverRemoved] = useState(false);
-  const [coverUploading, setCoverUploading] = useState(false);
-  const coverInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (isOwner) {
-      void getUsers().then(setAllUsers).catch(() => {});
-    }
-  }, [isOwner]);
-
-  const availableCollaborators = useMemo(() =>
-    allUsers.filter((u) => u.id !== playlist.authorId && !collaboratorIds.includes(u.id)),
-    [allUsers, playlist.authorId, collaboratorIds]
-  );
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-  );
-
-  function handleCoverSelect(e: ChangeEvent<HTMLInputElement>): void {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setCoverFile(file);
-    setCoverRemoved(false);
-    const url = URL.createObjectURL(file);
-    setCoverPreview(url);
-  }
-
-  function handleCoverRemove(): void {
-    setCoverFile(null);
-    if (coverPreview) URL.revokeObjectURL(coverPreview);
-    setCoverPreview(null);
-    setCoverRemoved(true);
-    if (coverInputRef.current) coverInputRef.current.value = "";
-  }
-
-  function removeTrack(id: string): void {
-    setTrackIds((prev) => prev.filter((t) => t !== id));
-  }
-
-  function handleDragEnd(event: DragEndEvent): void {
-    const { active, over } = event;
-    if (over && active.id !== over.id) {
-      setTrackIds((prev) => {
-        const oldIndex = prev.indexOf(active.id as string);
-        const newIndex = prev.indexOf(over.id as string);
-        return arrayMove(prev, oldIndex, newIndex);
-      });
-    }
-  }
-
-  async function handleSubmit(e: FormEvent): Promise<void> {
-    e.preventDefault();
-    if (coverFile || (coverRemoved && playlist.cover)) {
-      setCoverUploading(true);
-      try {
-        if (coverFile) {
-          await uploadPlaylistCover(playlist.id, coverFile);
-        } else {
-          await deletePlaylistCover(playlist.id);
-        }
-      } catch {
-        setCoverUploading(false);
-        return;
-      }
-      setCoverUploading(false);
-    }
-    await onSave({
-      name: name.trim() || playlist.name,
-      visibility,
-      description: description.trim(),
-      trackIds,
-      collaborators: isOwner ? collaboratorIds : undefined
-    });
-  }
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      <div className="flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-flaque-clay/60 bg-white shadow-xl">
-        <div className="flex items-center justify-between border-b border-flaque-clay/30 px-5 py-4">
-          <h3 className="font-display text-lg text-flaque-ink">Edit playlist</h3>
-          <button
-            type="button"
-            className="rounded-lg p-1 text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-
-        <form className="flex flex-1 flex-col overflow-hidden" onSubmit={(e) => { void handleSubmit(e); }}>
-          <div className="space-y-3 px-5 pt-4">
-            <div>
-              <label className="block text-sm font-medium text-flaque-ink">Name</label>
-              <input
-                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                disabled={saving}
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-flaque-ink">Description</label>
-              <textarea
-                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-                rows={3}
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                disabled={saving}
-                placeholder="Add a description..."
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-flaque-ink">Visibility</label>
-              <select
-                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-                value={visibility}
-                onChange={(e) => setVisibility(e.target.value as PlaylistVisibility)}
-                disabled={saving}
-              >
-                <option value="private">Private</option>
-                <option value="public">Public</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-flaque-ink">Cover image</label>
-              <div className="mt-1 flex items-center gap-3">
-                {(coverPreview ?? (!coverRemoved && playlist.cover)) ? (
-                  <img
-                    src={coverPreview ?? playlistCoverUrl(playlist.id)}
-                    alt="Cover preview"
-                    className="h-14 w-14 shrink-0 rounded-lg object-cover"
-                  />
-                ) : (
-                  <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-lg bg-flaque-clay/20">
-                    <svg className="h-6 w-6 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                    </svg>
-                  </div>
-                )}
-                <div className="flex flex-col gap-1">
-                  <input
-                    ref={coverInputRef}
-                    type="file"
-                    accept="image/*"
-                    className="hidden"
-                    onChange={handleCoverSelect}
-                    disabled={saving || coverUploading}
-                  />
-                  <button
-                    type="button"
-                    className="rounded-lg border border-flaque-clay px-3 py-1 text-xs text-flaque-ink transition hover:bg-flaque-cream"
-                    onClick={() => coverInputRef.current?.click()}
-                    disabled={saving || coverUploading}
-                  >
-                    {coverFile ? "Change" : "Upload"}
-                  </button>
-                  {(coverPreview ?? (!coverRemoved && playlist.cover)) ? (
-                    <button
-                      type="button"
-                      className="rounded-lg px-3 py-1 text-xs text-red-500 transition hover:text-red-700"
-                      onClick={handleCoverRemove}
-                      disabled={saving || coverUploading}
-                    >
-                      Remove
-                    </button>
-                  ) : null}
-                </div>
-              </div>
-            </div>
-            {isOwner ? (
-              <div>
-                <label className="block text-sm font-medium text-flaque-ink">Collaborators</label>
-                {collaboratorIds.length > 0 ? (
-                  <div className="mt-1 flex flex-wrap gap-1">
-                    {collaboratorIds.includes("everyone") ? (
-                      <span className="flex items-center gap-0.5 text-[10px] text-yellow-600">
-                        <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
-                          <path d="M12 2a10 10 0 100 20 10 10 10 0 000-20zm0 2a8 8 0 110 16 8 8 0 010-16zM12 11a2 2 0 1000 4 2 2 0 000-4z"/>
-                        </svg>
-                        Everyone
-                      </span>
-                    ) : (
-                      collaboratorIds.map((collab) => {
-                        const u = allUsers.find((usr) => usr.id === collab);
-                        return (
-                          <span key={collab} className="inline-flex items-center gap-1 rounded-full bg-flaque-cream px-2 py-0.5 text-xs text-flaque-ink">
-                            {u?.username ?? collab}
-                            <button
-                              type="button"
-                              className="text-flaque-steel hover:text-red-500"
-                              onClick={() => setCollaboratorIds((prev) => prev.filter((c) => c !== collab))}
-                              aria-label={`Remove ${u?.username ?? collab}`}
-                            >
-                              <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
-                              </svg>
-                            </button>
-                          </span>
-                        );
-                      })
-                    )}
-                  </div>
-                ) : null}
-                {availableCollaborators.length > 0 ? (
-                  <select
-                    className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-                    value=""
-                    onChange={(e) => {
-                      if (e.target.value) setCollaboratorIds((prev) => [...prev, e.target.value]);
-                    }}
-                    disabled={saving}
-                  >
-                    <option value="">Add a collaborator...</option>
-                    <option value="everyone">Everyone</option>
-                    {availableCollaborators.map((u) => (
-                      <option key={u.id} value={u.id}>{u.username}</option>
-                    ))}
-                  </select>
-                ) : (
-                  <p className="mt-1 text-xs text-flaque-steel">
-                    {collaboratorIds.length > 0 ? "All users added." : "No other users available."}
-                  </p>
-                )}
-              </div>
-            ) : null}
-          </div>
-
-          <div className="mt-4 flex-1 overflow-y-auto px-5">
-            <p className="text-sm font-medium text-flaque-ink">
-              Tracks <span className="text-flaque-steel">({trackIds.length})</span>
-            </p>
-            {trackIds.length === 0 ? (
-              <p className="mt-2 text-sm text-flaque-steel">No tracks in this playlist.</p>
-            ) : (
-              <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragEnd={handleDragEnd}
-              >
-                <SortableContext items={trackIds} strategy={verticalListSortingStrategy}>
-                  <ul className="mt-2 space-y-1">
-                    {trackIds.map((id) => (
-                      <SortableTrackItem
-                        key={id}
-                        id={id}
-                        track={allTracksById.get(id)}
-                        saving={saving}
-                        onRemove={removeTrack}
-                      />
-                    ))}
-                  </ul>
-                </SortableContext>
-              </DndContext>
-            )}
-          </div>
-
-          <div className="flex justify-end gap-2 border-t border-flaque-clay/30 px-5 py-4">
-            <button
-              type="button"
-              className="rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-steel transition hover:bg-flaque-cream"
-              onClick={onClose}
-              disabled={saving}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              className="rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-flaque-cream transition hover:bg-black disabled:opacity-60"
-              disabled={saving || coverUploading}
-            >
-              {coverUploading ? "Uploading cover..." : saving ? "Saving..." : "Save"}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
-
 // ── Main component ─────────────────────────────────────────────────
 
 export function PlaylistDetailView({
@@ -530,11 +225,37 @@ export function PlaylistDetailView({
   onReportListen
 }: PlaylistDetailViewProps): JSX.Element {
   const playlist = availablePlaylists.find((p) => p.id === playlistId);
-  const [editOpen, setEditOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [hearting, setHearting] = useState(false);
   const listenReportedRef = useRef(false);
 
+  // ── Edit state ──────────────────────────────────────────────────
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editVisibility, setEditVisibility] = useState<PlaylistVisibility>("private");
+  const [editTrackIds, setEditTrackIds] = useState<string[]>([]);
+  const [editCollaboratorIds, setEditCollaboratorIds] = useState<string[]>([]);
+  const [allUsers, setAllUsers] = useState<User[]>([]);
+  const [coverPreview, setCoverPreview] = useState<string | null>(null);
+  const [coverFile, setCoverFile] = useState<File | null>(null);
+  const [coverRemoved, setCoverRemoved] = useState(false);
+  const [coverUploading, setCoverUploading] = useState(false);
+  const coverInputRef = useRef<HTMLInputElement>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const isOwner = playlist ? playlist.authorId === user.id : false;
+
+  const availableCollaborators = useMemo(() =>
+    allUsers.filter((u) => u.id !== playlist?.authorId && !editCollaboratorIds.includes(u.id)),
+    [allUsers, playlist?.authorId, editCollaboratorIds]
+  );
+
+  // ── Derived data ────────────────────────────────────────────────
   const canManage = useMemo(() => {
     if (!playlist) return false;
     return manageablePlaylists.some((p) => p.id === playlist.id);
@@ -573,6 +294,73 @@ export function PlaylistDetailView({
   useEffect(() => {
     listenReportedRef.current = false;
   }, [playlistId]);
+
+  // Clean up cover preview URL on unmount
+  useEffect(() => {
+    return () => {
+      if (coverPreview) URL.revokeObjectURL(coverPreview);
+    };
+  }, [coverPreview]);
+
+  // ── Edit mode handlers ──────────────────────────────────────────
+
+  function startEditing(): void {
+    if (!playlist) return;
+    setEditName(playlist.name);
+    setEditDescription(playlist.description);
+    setEditVisibility(playlist.visibility);
+    setEditTrackIds([...playlist.trackIds]);
+    setEditCollaboratorIds([...(playlist.collaborators ?? [])]);
+    setCoverPreview(null);
+    setCoverFile(null);
+    setCoverRemoved(false);
+    setEditing(true);
+    if (isOwner) {
+      void getUsers().then(setAllUsers).catch(() => {});
+    }
+  }
+
+  function cancelEditing(): void {
+    if (coverPreview) URL.revokeObjectURL(coverPreview);
+    setCoverPreview(null);
+    setCoverFile(null);
+    setCoverRemoved(false);
+    setEditing(false);
+  }
+
+  function handleCoverSelect(e: ChangeEvent<HTMLInputElement>): void {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setCoverFile(file);
+    setCoverRemoved(false);
+    const url = URL.createObjectURL(file);
+    setCoverPreview(url);
+  }
+
+  function handleCoverRemove(): void {
+    setCoverFile(null);
+    if (coverPreview) URL.revokeObjectURL(coverPreview);
+    setCoverPreview(null);
+    setCoverRemoved(true);
+    if (coverInputRef.current) coverInputRef.current.value = "";
+  }
+
+  function removeTrack(id: string): void {
+    setEditTrackIds((prev) => prev.filter((t) => t !== id));
+  }
+
+  function handleDragEnd(event: DragEndEvent): void {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      setEditTrackIds((prev) => {
+        const oldIndex = prev.indexOf(active.id as string);
+        const newIndex = prev.indexOf(over.id as string);
+        return arrayMove(prev, oldIndex, newIndex);
+      });
+    }
+  }
+
+  // ── Playback handlers ──────────────────────────────────────────
 
   if (!playlist) {
     return (
@@ -638,11 +426,32 @@ export function PlaylistDetailView({
     }
   }
 
-  async function handleSave(patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }): Promise<void> {
+  async function handleSave(): Promise<void> {
     setSaving(true);
     try {
-      await onPatch(playlist!.id, patch);
-      setEditOpen(false);
+      if (coverFile || (coverRemoved && playlist!.cover)) {
+        setCoverUploading(true);
+        try {
+          if (coverFile) {
+            await uploadPlaylistCover(playlist!.id, coverFile);
+          } else {
+            await deletePlaylistCover(playlist!.id);
+          }
+        } catch {
+          setCoverUploading(false);
+          setSaving(false);
+          return;
+        }
+        setCoverUploading(false);
+      }
+      await onPatch(playlist!.id, {
+        name: editName.trim() || playlist!.name,
+        visibility: editVisibility,
+        description: editDescription.trim(),
+        trackIds: editTrackIds,
+        collaborators: isOwner ? editCollaboratorIds : undefined
+      });
+      setEditing(false);
     } finally {
       setSaving(false);
     }
@@ -653,13 +462,17 @@ export function PlaylistDetailView({
     onBack();
   }
 
+  // ── Cover display logic for edit mode ───────────────────────────
+  const coverSrc = coverPreview
+    ?? (coverRemoved ? null : (playlist.cover ? playlistCoverUrl(playlist.id) : null));
+
   return (
     <section className="m-4 space-y-4">
       {/* Back button */}
       <button
         type="button"
         className="flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
-        onClick={onBack}
+        onClick={() => { if (editing) cancelEditing(); onBack(); }}
       >
         <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
@@ -667,49 +480,131 @@ export function PlaylistDetailView({
         Back to playlists
       </button>
 
-      {/* Header card */}
+      {/* Hidden cover file input */}
+      <input
+        ref={coverInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleCoverSelect}
+        disabled={saving || coverUploading}
+      />
+
+      {/* Header */}
       <div className="rounded-2xl p-5">
         <div className="flex flex-col gap-5 sm:flex-row">
-           {/* Cover */}
-           <div className="relative h-48 w-48 shrink-0 self-center overflow-hidden sm:self-start">
-             <PlaylistCover playlist={playlist} mosaicTracks={mosaicTracks} />
-             
-             {/* Play button overlay */}
-             <button
-               type="button"
-               className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100"
-               onClick={handlePlayAll}
-               aria-label={`Play ${playlist.name}`}
-             >
-               <svg className="h-10 w-10 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
-                 <path d="M8 6v12l10-6-10-6z" />
-               </svg>
-             </button>
-           </div>
+          {/* Cover */}
+          <div className="relative h-48 w-48 shrink-0 self-center overflow-hidden sm:self-start">
+            {editing ? (
+              <>
+                <button
+                  type="button"
+                  className="group/cover relative h-full w-full rounded-2xl overflow-hidden"
+                  onClick={() => coverInputRef.current?.click()}
+                  disabled={saving || coverUploading}
+                >
+                  {coverSrc ? (
+                    <img src={coverSrc} alt="" className="h-full w-full rounded-2xl object-cover" />
+                  ) : (
+                    <PlaylistCover playlist={playlist} mosaicTracks={mosaicTracks} />
+                  )}
+                  <div className="absolute inset-0 flex flex-col items-center justify-center rounded-2xl bg-black/40 opacity-0 transition group-hover/cover:opacity-100">
+                    <svg className="h-8 w-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" />
+                    </svg>
+                    <span className="mt-1 text-xs font-medium text-white">Change cover</span>
+                  </div>
+                </button>
+                {(coverPreview ?? (!coverRemoved && playlist.cover)) ? (
+                  <button
+                    type="button"
+                    className="absolute bottom-1 right-1 rounded-lg bg-black/60 px-2 py-0.5 text-[10px] text-white transition hover:bg-red-600"
+                    onClick={handleCoverRemove}
+                    disabled={saving || coverUploading}
+                  >
+                    Remove
+                  </button>
+                ) : null}
+              </>
+            ) : (
+              <>
+                <PlaylistCover playlist={playlist} mosaicTracks={mosaicTracks} />
+                <button
+                  type="button"
+                  className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100"
+                  onClick={handlePlayAll}
+                  aria-label={`Play ${playlist.name}`}
+                >
+                  <svg className="h-10 w-10 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
+                    <path d="M8 6v12l10-6-10-6z" />
+                  </svg>
+                </button>
+              </>
+            )}
+          </div>
 
           {/* Info */}
           <div className="flex min-w-0 flex-1 flex-col">
+            {/* Title + visibility */}
             <div className="flex items-center gap-2">
-              <h2 className="font-display text-2xl text-flaque-ink">{playlist.name}</h2>
-              <span className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
-                playlist.visibility === "public"
-                  ? "bg-green-100 text-green-700"
-                  : "bg-flaque-clay/30 text-flaque-steel"
-              }`}>
-                {playlist.visibility}
-              </span>
+              {editing ? (
+                <input
+                  className="min-w-0 flex-1 border-b-2 border-flaque-sand bg-transparent font-display text-2xl text-flaque-ink outline-none transition focus:border-flaque-ink"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  disabled={saving}
+                  autoFocus
+                />
+              ) : (
+                <h2 className="font-display text-2xl text-flaque-ink">{playlist.name}</h2>
+              )}
+              {editing ? (
+                <select
+                  className={`shrink-0 cursor-pointer rounded-full border border-flaque-clay/40 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide outline-none transition ${
+                    editVisibility === "public"
+                      ? "bg-green-100 text-green-700"
+                      : "bg-flaque-clay/30 text-flaque-steel"
+                  }`}
+                  value={editVisibility}
+                  onChange={(e) => setEditVisibility(e.target.value as PlaylistVisibility)}
+                  disabled={saving}
+                >
+                  <option value="private">Private</option>
+                  <option value="public">Public</option>
+                </select>
+              ) : (
+                <span className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+                  playlist.visibility === "public"
+                    ? "bg-green-100 text-green-700"
+                    : "bg-flaque-clay/30 text-flaque-steel"
+                }`}>
+                  {playlist.visibility}
+                </span>
+              )}
             </div>
 
-            {playlist.description ? (
+            {/* Description */}
+            {editing ? (
+              <textarea
+                className="mt-1 w-full resize-none rounded-lg border border-flaque-clay/40 bg-transparent px-2 py-1 text-sm text-flaque-steel outline-none transition focus:border-flaque-ink/40"
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+                placeholder="Add a description..."
+                rows={2}
+                disabled={saving}
+              />
+            ) : playlist.description ? (
               <p className="mt-1 text-sm text-flaque-steel">{playlist.description}</p>
             ) : null}
 
             <p className="mt-2 text-sm text-flaque-steel">by {owner}</p>
 
+            {/* Stats line */}
             <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-flaque-steel">
-              <span>{playlist.trackIds.length} track{playlist.trackIds.length !== 1 ? "s" : ""}</span>
-              {totalDuration > 0 ? <span>{formatDuration(totalDuration)}</span> : null}
-              {playlist.listenCount > 0 ? (
+              <span>{(editing ? editTrackIds : playlist.trackIds).length} track{(editing ? editTrackIds : playlist.trackIds).length !== 1 ? "s" : ""}</span>
+              {totalDuration > 0 && !editing ? <span>{formatDuration(totalDuration)}</span> : null}
+              {!editing && playlist.listenCount > 0 ? (
                 <span className="flex items-center gap-0.5">
                   <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
@@ -718,7 +613,7 @@ export function PlaylistDetailView({
                   {playlist.listenCount}
                 </span>
               ) : null}
-              {canHeart ? (
+              {!editing && canHeart ? (
                 <button
                   type="button"
                   className={`flex items-center gap-0.5 transition ${
@@ -735,7 +630,7 @@ export function PlaylistDetailView({
                   </svg>
                   {playlist.heartCount > 0 ? playlist.heartCount : ""}
                 </button>
-              ) : playlist.heartCount > 0 ? (
+              ) : !editing && playlist.heartCount > 0 ? (
                 <span className="flex items-center gap-0.5 text-red-400">
                   <svg className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
@@ -745,7 +640,69 @@ export function PlaylistDetailView({
               ) : null}
             </div>
 
-            {(playlist.collaborators ?? []).length > 0 ? (
+            {/* Collaborators */}
+            {editing && isOwner ? (
+              <div className="mt-2">
+                <div className="flex flex-wrap items-center gap-1">
+                  <span className="text-xs text-flaque-steel">Collaborators:</span>
+                  {editCollaboratorIds.includes("everyone") ? (
+                    <span className="inline-flex items-center gap-0.5 text-[10px] text-yellow-600">
+                      <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 2a10 10 0 100 20 10 10 10 0 000-20zm0 2a8 8 0 110 16 8 8 0 010-16zM12 11a2 2 0 1000 4 2 2 0 000-4z"/>
+                      </svg>
+                      Everyone
+                      <button
+                        type="button"
+                        className="ml-0.5 text-flaque-steel hover:text-red-500"
+                        onClick={() => setEditCollaboratorIds((prev) => prev.filter((c) => c !== "everyone"))}
+                        aria-label="Remove everyone"
+                      >
+                        <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                      </button>
+                    </span>
+                  ) : (
+                    editCollaboratorIds.map((collab) => {
+                      const u = allUsers.find((usr) => usr.id === collab);
+                      return (
+                        <span key={collab} className="inline-flex items-center gap-1 rounded-full bg-flaque-cream px-2 py-0.5 text-[10px] font-medium text-flaque-ink">
+                          {u?.username ?? ownerNameById[collab] ?? collab}
+                          <button
+                            type="button"
+                            className="text-flaque-steel hover:text-red-500"
+                            onClick={() => setEditCollaboratorIds((prev) => prev.filter((c) => c !== collab))}
+                            aria-label={`Remove ${u?.username ?? collab}`}
+                          >
+                            <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                          </button>
+                        </span>
+                      );
+                    })
+                  )}
+                </div>
+                {availableCollaborators.length > 0 || !editCollaboratorIds.includes("everyone") ? (
+                  <select
+                    className="mt-1 rounded-lg border border-flaque-clay/40 bg-transparent px-2 py-1 text-xs text-flaque-ink outline-none transition focus:border-flaque-ink/40"
+                    value=""
+                    onChange={(e) => {
+                      if (e.target.value) setEditCollaboratorIds((prev) => [...prev, e.target.value]);
+                    }}
+                    disabled={saving}
+                  >
+                    <option value="">Add collaborator...</option>
+                    {!editCollaboratorIds.includes("everyone") ? (
+                      <option value="everyone">Everyone</option>
+                    ) : null}
+                    {availableCollaborators.map((u) => (
+                      <option key={u.id} value={u.id}>{u.username}</option>
+                    ))}
+                  </select>
+                ) : null}
+              </div>
+            ) : (playlist.collaborators ?? []).length > 0 ? (
               <div className="mt-2 flex flex-wrap gap-1">
                 <span className="text-xs text-flaque-steel">Collaborators:</span>
                 {(playlist.collaborators ?? []).includes("everyone") ? (
@@ -767,117 +724,164 @@ export function PlaylistDetailView({
 
             {/* Action buttons */}
             <div className="mt-auto flex flex-wrap items-center gap-2 pt-4">
-              <button
-                type="button"
-                className="flex items-center gap-1.5 rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black"
-                onClick={handlePlayAll}
-              >
-                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M8 5v14l11-7z" />
-                </svg>
-                Play all
-              </button>
+              {editing ? (
+                <>
+                  <button
+                    type="button"
+                    className="flex items-center gap-1.5 rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black disabled:opacity-60"
+                    onClick={() => { void handleSave(); }}
+                    disabled={saving || coverUploading}
+                  >
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    {coverUploading ? "Uploading cover..." : saving ? "Saving..." : "Save"}
+                  </button>
+                  <button
+                    type="button"
+                    className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-steel transition hover:bg-flaque-cream"
+                    onClick={cancelEditing}
+                    disabled={saving}
+                  >
+                    Cancel
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    className="flex items-center gap-1.5 rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black"
+                    onClick={handlePlayAll}
+                  >
+                    <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                      <path d="M8 5v14l11-7z" />
+                    </svg>
+                    Play all
+                  </button>
 
-              <button
-                type="button"
-                className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
-                onClick={handleShufflePlay}
-              >
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4" />
-                </svg>
-                Shuffle
-              </button>
+                  <button
+                    type="button"
+                    className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
+                    onClick={handleShufflePlay}
+                  >
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4" />
+                    </svg>
+                    Shuffle
+                  </button>
 
-              {canEdit ? (
-                <button
-                  type="button"
-                  className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-3 py-2 text-sm text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
-                  onClick={() => setEditOpen(true)}
-                >
-                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                  </svg>
-                  Edit
-                </button>
-              ) : null}
+                  {canEdit ? (
+                    <button
+                      type="button"
+                      className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-3 py-2 text-sm text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
+                      onClick={startEditing}
+                    >
+                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                      </svg>
+                      Edit
+                    </button>
+                  ) : null}
 
-              {canManage ? (
-                <button
-                  type="button"
-                  className="flex items-center gap-1.5 rounded-xl border border-red-200 px-3 py-2 text-sm text-red-500 transition hover:bg-red-50 hover:text-red-600"
-                  onClick={() => { void handleDelete(); }}
-                >
-                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-                  Delete
-                </button>
-              ) : null}
+                  {canManage ? (
+                    <button
+                      type="button"
+                      className="flex items-center gap-1.5 rounded-xl border border-red-200 px-3 py-2 text-sm text-red-500 transition hover:bg-red-50 hover:text-red-600"
+                      onClick={() => { void handleDelete(); }}
+                    >
+                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                      </svg>
+                      Delete
+                    </button>
+                  ) : null}
+                </>
+              )}
             </div>
           </div>
         </div>
       </div>
 
       {/* Track list */}
-      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
-        {tracks.length === 0 ? (
-          <p className="px-5 py-4 text-sm text-flaque-steel">No playable tracks.</p>
-        ) : (
-          <ul>
-            {tracks.map((track, index) => (
-              <li
-                key={track.id}
-                className="flex cursor-pointer items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
-                onClick={() => handlePlayTrack(track)}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => { if (e.key === "Enter") handlePlayTrack(track); }}
-              >
-                <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
-                <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
-                  <img
-                    src={coverUrl(track.id)}
-                    alt=""
-                    className="h-full w-full object-cover"
-                    loading="lazy"
-                    onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
-                  />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
-                    {track.tags.extra?.lyrics ? (
-                      <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
-                        L
-                      </span>
-                    ) : null}
-                    <span className="truncate">{getTrackDisplayTitle(track)}</span>
-                  </p>
-                  <p className="truncate text-xs text-flaque-steel">
-                    {getTrackDisplayArtist(track) ?? "Unknown artist"}
-                    {track.tags.album ? ` \u00b7 ${track.tags.album}` : ""}
-                  </p>
-                </div>
-                <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
-                  {formatDuration(track.duration)}
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-
-      {/* Edit modal */}
-      {editOpen ? (
-        <EditModal
-          playlist={playlist}
-          allTracksById={allTracksById}
-          isOwner={playlist.authorId === user.id}
-          saving={saving}
-          onSave={handleSave}
-          onClose={() => setEditOpen(false)}
-        />
-      ) : null}
+      {editing ? (
+        <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
+          <div className="px-4 pt-3 pb-1">
+            <p className="text-sm font-medium text-flaque-ink">
+              Tracks <span className="text-flaque-steel">({editTrackIds.length})</span>
+            </p>
+          </div>
+          {editTrackIds.length === 0 ? (
+            <p className="px-5 py-4 text-sm text-flaque-steel">No tracks in this playlist.</p>
+          ) : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext items={editTrackIds} strategy={verticalListSortingStrategy}>
+                <ul className="space-y-1 p-3">
+                  {editTrackIds.map((id) => (
+                    <SortableTrackItem
+                      key={id}
+                      id={id}
+                      track={allTracksById.get(id)}
+                      saving={saving}
+                      onRemove={removeTrack}
+                    />
+                  ))}
+                </ul>
+              </SortableContext>
+            </DndContext>
+          )}
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
+          {tracks.length === 0 ? (
+            <p className="px-5 py-4 text-sm text-flaque-steel">No playable tracks.</p>
+          ) : (
+            <ul>
+              {tracks.map((track, index) => (
+                <li
+                  key={track.id}
+                  className="flex cursor-pointer items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+                  onClick={() => handlePlayTrack(track)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => { if (e.key === "Enter") handlePlayTrack(track); }}
+                >
+                  <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
+                  <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
+                    <img
+                      src={coverUrl(track.id)}
+                      alt=""
+                      className="h-full w-full object-cover"
+                      loading="lazy"
+                      onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
+                    />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
+                      {track.tags.extra?.lyrics ? (
+                        <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
+                          L
+                        </span>
+                      ) : null}
+                      <span className="truncate">{getTrackDisplayTitle(track)}</span>
+                    </p>
+                    <p className="truncate text-xs text-flaque-steel">
+                      {getTrackDisplayArtist(track) ?? "Unknown artist"}
+                      {track.tags.album ? ` \u00b7 ${track.tags.album}` : ""}
+                    </p>
+                  </div>
+                  <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
+                    {formatDuration(track.duration)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -397,24 +397,33 @@ function EditModal({ playlist, allTracksById, isOwner, saving, onSave, onClose }
                 <label className="block text-sm font-medium text-flaque-ink">Collaborators</label>
                 {collaboratorIds.length > 0 ? (
                   <div className="mt-1 flex flex-wrap gap-1">
-                    {collaboratorIds.map((collab) => {
-                      const u = allUsers.find((usr) => usr.id === collab);
-                      return (
-                        <span key={collab} className="inline-flex items-center gap-1 rounded-full bg-flaque-cream px-2 py-0.5 text-xs text-flaque-ink">
-                          {u?.username ?? collab}
-                          <button
-                            type="button"
-                            className="text-flaque-steel hover:text-red-500"
-                            onClick={() => setCollaboratorIds((prev) => prev.filter((c) => c !== collab))}
-                            aria-label={`Remove ${u?.username ?? collab}`}
-                          >
-                            <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
-                            </svg>
-                          </button>
-                        </span>
-                      );
-                    })}
+                    {collaboratorIds.includes("everyone") ? (
+                      <span className="flex items-center gap-0.5 text-[10px] text-yellow-600">
+                        <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
+                          <path d="M12 2a10 10 0 100 20 10 10 10 0 000-20zm0 2a8 8 0 110 16 8 8 0 010-16zM12 11a2 2 0 1000 4 2 2 0 000-4z"/>
+                        </svg>
+                        Everyone
+                      </span>
+                    ) : (
+                      collaboratorIds.map((collab) => {
+                        const u = allUsers.find((usr) => usr.id === collab);
+                        return (
+                          <span key={collab} className="inline-flex items-center gap-1 rounded-full bg-flaque-cream px-2 py-0.5 text-xs text-flaque-ink">
+                            {u?.username ?? collab}
+                            <button
+                              type="button"
+                              className="text-flaque-steel hover:text-red-500"
+                              onClick={() => setCollaboratorIds((prev) => prev.filter((c) => c !== collab))}
+                              aria-label={`Remove ${u?.username ?? collab}`}
+                            >
+                              <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                              </svg>
+                            </button>
+                          </span>
+                        );
+                      })
+                    )}
                   </div>
                 ) : null}
                 {availableCollaborators.length > 0 ? (
@@ -427,6 +436,7 @@ function EditModal({ playlist, allTracksById, isOwner, saving, onSave, onClose }
                     disabled={saving}
                   >
                     <option value="">Add a collaborator...</option>
+                    <option value="everyone">Everyone</option>
                     {availableCollaborators.map((u) => (
                       <option key={u.id} value={u.id}>{u.username}</option>
                     ))}
@@ -728,11 +738,20 @@ export function PlaylistDetailView({
             {playlist.collaborators.length > 0 ? (
               <div className="mt-2 flex flex-wrap gap-1">
                 <span className="text-xs text-flaque-steel">Collaborators:</span>
-                {playlist.collaborators.map((collab) => (
-                  <span key={collab} className="rounded-full bg-flaque-cream px-2 py-0.5 text-[10px] font-medium text-flaque-ink">
-                    {ownerNameById[collab] ?? collab}
+                {playlist.collaborators.includes("everyone") ? (
+                  <span className="flex items-center gap-0.5 text-[10px] text-yellow-600">
+                    <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 24 24">
+                      <path d="M12 2a10 10 0 100 20 10 10 10 0 000-20zm0 2a8 8 0 110 16 8 8 0 010-16zM12 11a2 2 0 1000 4 2 2 0 000-4z"/>
+                    </svg>
+                    Everyone
                   </span>
-                ))}
+                ) : (
+                  playlist.collaborators.map((collab) => (
+                    <span key={collab} className="rounded-full bg-flaque-cream px-2 py-0.5 text-[10px] font-medium text-flaque-ink">
+                      {ownerNameById[collab] ?? collab}
+                    </span>
+                  ))
+                )}
               </div>
             ) : null}
 

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -1,4 +1,21 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 import { coverUrl, playlistCoverUrl } from "../api";
 import type { Playlist, PlaylistVisibility, Track, User } from "../types";
@@ -105,21 +122,111 @@ type EditModalProps = {
   onClose: () => void;
 };
 
+function SortableTrackItem({
+  id,
+  track,
+  saving,
+  onRemove
+}: {
+  id: string;
+  track: Track | undefined;
+  saving: boolean;
+  onRemove: (id: string) => void;
+}): JSX.Element {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : undefined,
+    position: isDragging ? "relative" as const : undefined
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-2 py-1.5 ${
+        isDragging ? "shadow-lg ring-2 ring-flaque-sand/60" : ""
+      }`}
+    >
+      {/* Drag handle */}
+      <button
+        type="button"
+        className="shrink-0 cursor-grab touch-none rounded p-0.5 text-flaque-steel/50 transition hover:text-flaque-ink active:cursor-grabbing"
+        aria-label="Drag to reorder"
+        {...attributes}
+        {...listeners}
+      >
+        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+          <circle cx="9" cy="6" r="1.5" /><circle cx="15" cy="6" r="1.5" />
+          <circle cx="9" cy="12" r="1.5" /><circle cx="15" cy="12" r="1.5" />
+          <circle cx="9" cy="18" r="1.5" /><circle cx="15" cy="18" r="1.5" />
+        </svg>
+      </button>
+
+      <div className="h-8 w-8 shrink-0 overflow-hidden rounded-md">
+        {track ? (
+          <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
+        ) : (
+          <div className="h-full w-full bg-flaque-clay/30" />
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-medium text-flaque-ink">
+          {track ? getTrackDisplayTitle(track) : id}
+        </p>
+        {track ? (
+          <p className="truncate text-[10px] text-flaque-steel">
+            {getTrackDisplayArtist(track) ?? "Unknown artist"}
+          </p>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        className="shrink-0 rounded p-0.5 text-red-400 transition hover:text-red-600 disabled:opacity-30"
+        onClick={() => onRemove(id)}
+        disabled={saving}
+        aria-label="Remove track"
+      >
+        <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </li>
+  );
+}
+
 function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditModalProps): JSX.Element {
   const [name, setName] = useState(playlist.name);
   const [description, setDescription] = useState(playlist.description);
   const [trackIds, setTrackIds] = useState<string[]>([...playlist.trackIds]);
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
   function removeTrack(id: string): void {
     setTrackIds((prev) => prev.filter((t) => t !== id));
   }
 
-  function moveTrack(index: number, direction: -1 | 1): void {
-    const next = [...trackIds];
-    const target = index + direction;
-    if (target < 0 || target >= next.length) return;
-    [next[index], next[target]] = [next[target]!, next[index]!];
-    setTrackIds(next);
+  function handleDragEnd(event: DragEndEvent): void {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      setTrackIds((prev) => {
+        const oldIndex = prev.indexOf(active.id as string);
+        const newIndex = prev.indexOf(over.id as string);
+        return arrayMove(prev, oldIndex, newIndex);
+      });
+    }
   }
 
   async function handleSubmit(e: FormEvent): Promise<void> {
@@ -182,67 +289,25 @@ function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditMod
             {trackIds.length === 0 ? (
               <p className="mt-2 text-sm text-flaque-steel">No tracks in this playlist.</p>
             ) : (
-              <ul className="mt-2 space-y-1">
-                {trackIds.map((id, index) => {
-                  const track = allTracksById.get(id);
-                  return (
-                    <li key={id} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-2 py-1.5">
-                      <div className="h-8 w-8 shrink-0 overflow-hidden rounded-md">
-                        {track ? (
-                          <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-                        ) : (
-                          <div className="h-full w-full bg-flaque-clay/30" />
-                        )}
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-xs font-medium text-flaque-ink">
-                          {track ? getTrackDisplayTitle(track) : id}
-                        </p>
-                        {track ? (
-                          <p className="truncate text-[10px] text-flaque-steel">
-                            {getTrackDisplayArtist(track) ?? "Unknown artist"}
-                          </p>
-                        ) : null}
-                      </div>
-                      <div className="flex shrink-0 items-center gap-1">
-                        <button
-                          type="button"
-                          className="rounded p-0.5 text-flaque-steel transition hover:text-flaque-ink disabled:opacity-30"
-                          onClick={() => moveTrack(index, -1)}
-                          disabled={index === 0 || saving}
-                          aria-label="Move up"
-                        >
-                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 15l7-7 7 7" />
-                          </svg>
-                        </button>
-                        <button
-                          type="button"
-                          className="rounded p-0.5 text-flaque-steel transition hover:text-flaque-ink disabled:opacity-30"
-                          onClick={() => moveTrack(index, 1)}
-                          disabled={index === trackIds.length - 1 || saving}
-                          aria-label="Move down"
-                        >
-                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" />
-                          </svg>
-                        </button>
-                        <button
-                          type="button"
-                          className="rounded p-0.5 text-red-400 transition hover:text-red-600 disabled:opacity-30"
-                          onClick={() => removeTrack(id)}
-                          disabled={saving}
-                          aria-label="Remove track"
-                        >
-                          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
-                          </svg>
-                        </button>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext items={trackIds} strategy={verticalListSortingStrategy}>
+                  <ul className="mt-2 space-y-1">
+                    {trackIds.map((id) => (
+                      <SortableTrackItem
+                        key={id}
+                        id={id}
+                        track={allTracksById.get(id)}
+                        saving={saving}
+                        onRemove={removeTrack}
+                      />
+                    ))}
+                  </ul>
+                </SortableContext>
+              </DndContext>
             )}
           </div>
 

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { type ChangeEvent, FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -17,7 +17,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
-import { coverUrl, playlistCoverUrl } from "../api";
+import { coverUrl, deletePlaylistCover, getUsers, playlistCoverUrl, uploadPlaylistCover } from "../api";
 import type { Playlist, PlaylistVisibility, Track, User } from "../types";
 import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
 
@@ -30,7 +30,7 @@ type PlaylistDetailViewProps = {
   user: User;
   onBack: () => void;
   onPlay: (playlist: Playlist) => void;
-  onPatch: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string }) => Promise<void>;
+  onPatch: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   onDelete: (playlistId: string) => Promise<void>;
   onHeart: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;
   onReportListen: (playlistId: string) => Promise<void>;
@@ -117,8 +117,9 @@ function PlaylistCover({ playlist, mosaicTracks }: { playlist: Playlist; mosaicT
 type EditModalProps = {
   playlist: Playlist;
   allTracksById: Map<string, Track>;
+  isOwner: boolean;
   saving: boolean;
-  onSave: (patch: { name?: string; trackIds?: string[]; description?: string }) => Promise<void>;
+  onSave: (patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   onClose: () => void;
 };
 
@@ -204,15 +205,51 @@ function SortableTrackItem({
   );
 }
 
-function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditModalProps): JSX.Element {
+function EditModal({ playlist, allTracksById, isOwner, saving, onSave, onClose }: EditModalProps): JSX.Element {
   const [name, setName] = useState(playlist.name);
   const [description, setDescription] = useState(playlist.description);
+  const [visibility, setVisibility] = useState<PlaylistVisibility>(playlist.visibility);
   const [trackIds, setTrackIds] = useState<string[]>([...playlist.trackIds]);
+  const [collaboratorIds, setCollaboratorIds] = useState<string[]>([...playlist.collaborators]);
+  const [allUsers, setAllUsers] = useState<User[]>([]);
+  const [coverPreview, setCoverPreview] = useState<string | null>(null);
+  const [coverFile, setCoverFile] = useState<File | null>(null);
+  const [coverRemoved, setCoverRemoved] = useState(false);
+  const [coverUploading, setCoverUploading] = useState(false);
+  const coverInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOwner) {
+      void getUsers().then(setAllUsers).catch(() => {});
+    }
+  }, [isOwner]);
+
+  const availableCollaborators = useMemo(() =>
+    allUsers.filter((u) => u.id !== playlist.authorId && !collaboratorIds.includes(u.id)),
+    [allUsers, playlist.authorId, collaboratorIds]
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
+
+  function handleCoverSelect(e: ChangeEvent<HTMLInputElement>): void {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setCoverFile(file);
+    setCoverRemoved(false);
+    const url = URL.createObjectURL(file);
+    setCoverPreview(url);
+  }
+
+  function handleCoverRemove(): void {
+    setCoverFile(null);
+    if (coverPreview) URL.revokeObjectURL(coverPreview);
+    setCoverPreview(null);
+    setCoverRemoved(true);
+    if (coverInputRef.current) coverInputRef.current.value = "";
+  }
 
   function removeTrack(id: string): void {
     setTrackIds((prev) => prev.filter((t) => t !== id));
@@ -231,10 +268,26 @@ function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditMod
 
   async function handleSubmit(e: FormEvent): Promise<void> {
     e.preventDefault();
+    if (coverFile || (coverRemoved && playlist.cover)) {
+      setCoverUploading(true);
+      try {
+        if (coverFile) {
+          await uploadPlaylistCover(playlist.id, coverFile);
+        } else {
+          await deletePlaylistCover(playlist.id);
+        }
+      } catch {
+        setCoverUploading(false);
+        return;
+      }
+      setCoverUploading(false);
+    }
     await onSave({
       name: name.trim() || playlist.name,
+      visibility,
       description: description.trim(),
-      trackIds
+      trackIds,
+      collaborators: isOwner ? collaboratorIds : undefined
     });
   }
 
@@ -280,6 +333,110 @@ function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditMod
                 placeholder="Add a description..."
               />
             </div>
+            <div>
+              <label className="block text-sm font-medium text-flaque-ink">Visibility</label>
+              <select
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                value={visibility}
+                onChange={(e) => setVisibility(e.target.value as PlaylistVisibility)}
+                disabled={saving}
+              >
+                <option value="private">Private</option>
+                <option value="public">Public</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-flaque-ink">Cover image</label>
+              <div className="mt-1 flex items-center gap-3">
+                {(coverPreview ?? (!coverRemoved && playlist.cover)) ? (
+                  <img
+                    src={coverPreview ?? playlistCoverUrl(playlist.id)}
+                    alt="Cover preview"
+                    className="h-14 w-14 shrink-0 rounded-lg object-cover"
+                  />
+                ) : (
+                  <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-lg bg-flaque-clay/20">
+                    <svg className="h-6 w-6 text-flaque-steel/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                  </div>
+                )}
+                <div className="flex flex-col gap-1">
+                  <input
+                    ref={coverInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleCoverSelect}
+                    disabled={saving || coverUploading}
+                  />
+                  <button
+                    type="button"
+                    className="rounded-lg border border-flaque-clay px-3 py-1 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+                    onClick={() => coverInputRef.current?.click()}
+                    disabled={saving || coverUploading}
+                  >
+                    {coverFile ? "Change" : "Upload"}
+                  </button>
+                  {(coverPreview ?? (!coverRemoved && playlist.cover)) ? (
+                    <button
+                      type="button"
+                      className="rounded-lg px-3 py-1 text-xs text-red-500 transition hover:text-red-700"
+                      onClick={handleCoverRemove}
+                      disabled={saving || coverUploading}
+                    >
+                      Remove
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+            {isOwner ? (
+              <div>
+                <label className="block text-sm font-medium text-flaque-ink">Collaborators</label>
+                {collaboratorIds.length > 0 ? (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {collaboratorIds.map((collab) => {
+                      const u = allUsers.find((usr) => usr.id === collab);
+                      return (
+                        <span key={collab} className="inline-flex items-center gap-1 rounded-full bg-flaque-cream px-2 py-0.5 text-xs text-flaque-ink">
+                          {u?.username ?? collab}
+                          <button
+                            type="button"
+                            className="text-flaque-steel hover:text-red-500"
+                            onClick={() => setCollaboratorIds((prev) => prev.filter((c) => c !== collab))}
+                            aria-label={`Remove ${u?.username ?? collab}`}
+                          >
+                            <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                          </button>
+                        </span>
+                      );
+                    })}
+                  </div>
+                ) : null}
+                {availableCollaborators.length > 0 ? (
+                  <select
+                    className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                    value=""
+                    onChange={(e) => {
+                      if (e.target.value) setCollaboratorIds((prev) => [...prev, e.target.value]);
+                    }}
+                    disabled={saving}
+                  >
+                    <option value="">Add a collaborator...</option>
+                    {availableCollaborators.map((u) => (
+                      <option key={u.id} value={u.id}>{u.username}</option>
+                    ))}
+                  </select>
+                ) : (
+                  <p className="mt-1 text-xs text-flaque-steel">
+                    {collaboratorIds.length > 0 ? "All users added." : "No other users available."}
+                  </p>
+                )}
+              </div>
+            ) : null}
           </div>
 
           <div className="mt-4 flex-1 overflow-y-auto px-5">
@@ -323,9 +480,9 @@ function EditModal({ playlist, allTracksById, saving, onSave, onClose }: EditMod
             <button
               type="submit"
               className="rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-flaque-cream transition hover:bg-black disabled:opacity-60"
-              disabled={saving}
+              disabled={saving || coverUploading}
             >
-              {saving ? "Saving..." : "Save"}
+              {coverUploading ? "Uploading cover..." : saving ? "Saving..." : "Save"}
             </button>
           </div>
         </form>
@@ -443,7 +600,7 @@ export function PlaylistDetailView({
     }
   }
 
-  async function handleSave(patch: { name?: string; trackIds?: string[]; description?: string }): Promise<void> {
+  async function handleSave(patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }): Promise<void> {
     setSaving(true);
     try {
       await onPatch(playlist!.id, patch);
@@ -557,6 +714,7 @@ export function PlaylistDetailView({
                   }`}
                   onClick={() => { void handleHeart(); }}
                   disabled={hearting}
+                  aria-label={hasHearted ? "Remove heart" : "Heart playlist"}
                 >
                   <svg className="h-4 w-4" fill={hasHearted ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
@@ -645,6 +803,7 @@ export function PlaylistDetailView({
         <EditModal
           playlist={playlist}
           allTracksById={allTracksById}
+          isOwner={playlist.authorId === user.id}
           saving={saving}
           onSave={handleSave}
           onClose={() => setEditOpen(false)}

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -668,7 +668,7 @@ export function PlaylistDetailView({
       </button>
 
       {/* Header card */}
-      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+      <div className="rounded-2xl p-5">
         <div className="flex flex-col gap-5 sm:flex-row">
            {/* Cover */}
            <div className="relative h-48 w-48 shrink-0 self-center overflow-hidden sm:self-start">

--- a/frontend/src/hooks/useAutoPlaylists.ts
+++ b/frontend/src/hooks/useAutoPlaylists.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { getAutoPlaylists } from "../api";
+import type { AutoPlaylistSummary } from "../types";
+
+type UseAutoPlaylistsResult = {
+  autoPlaylists: AutoPlaylistSummary[];
+  loading: boolean;
+  refresh: () => void;
+};
+
+export function useAutoPlaylists(): UseAutoPlaylistsResult {
+  const [autoPlaylists, setAutoPlaylists] = useState<AutoPlaylistSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetch = useCallback(() => {
+    setLoading(true);
+    getAutoPlaylists()
+      .then(setAutoPlaylists)
+      .catch(() => setAutoPlaylists([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { autoPlaylists, loading, refresh: fetch };
+}

--- a/frontend/src/hooks/useForYouPlaylists.ts
+++ b/frontend/src/hooks/useForYouPlaylists.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { getForYouPlaylists, dismissForYouPlaylist as apiDismiss } from "../api";
+import type { ForYouPlaylistSummary } from "../types";
+
+type UseForYouPlaylistsResult = {
+  forYouPlaylists: ForYouPlaylistSummary[];
+  loading: boolean;
+  refresh: () => void;
+  dismiss: (playlistId: string) => Promise<void>;
+};
+
+export function useForYouPlaylists(): UseForYouPlaylistsResult {
+  const [forYouPlaylists, setForYouPlaylists] = useState<ForYouPlaylistSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetch = useCallback(() => {
+    setLoading(true);
+    getForYouPlaylists()
+      .then(setForYouPlaylists)
+      .catch(() => setForYouPlaylists([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  const dismiss = useCallback(async (playlistId: string) => {
+    await apiDismiss(playlistId);
+    setForYouPlaylists((prev) => prev.filter((p) => p.id !== playlistId));
+  }, []);
+
+  return { forYouPlaylists, loading, refresh: fetch, dismiss };
+}

--- a/frontend/src/hooks/useLibraryCommands.ts
+++ b/frontend/src/hooks/useLibraryCommands.ts
@@ -50,9 +50,9 @@ type UseLibraryCommandsResult = {
   handleRebuildIndex: () => Promise<void>;
   handleDeleteTrack: (trackId: string) => Promise<void>;
   handleUpdateTrackMetadata: (trackId: string, patch: TrackMetadataPatch) => Promise<void>;
-  handleCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility }) => Promise<void>;
+  handleCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   handleAddTrackToPlaylist: (input: { trackId: string; playlistId: string }) => Promise<void>;
-  handlePatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }) => Promise<void>;
+  handlePatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
   handleDeletePlaylist: (playlistId: string) => Promise<void>;
   handleBulkDeleteTracks: (trackIds: string[]) => Promise<void>;
   handleBulkUpdateTrackMetadata: (trackIds: string[], patch: TrackMetadataPatch) => Promise<void>;
@@ -160,6 +160,7 @@ export function useLibraryCommands({
   async function handleCreatePlaylist(input: {
     name: string;
     visibility: PlaylistVisibility;
+    description?: string;
   }): Promise<void> {
     await createPlaylist(input);
     setAppNotice({
@@ -201,7 +202,7 @@ export function useLibraryCommands({
 
   async function handlePatchPlaylist(
     playlistId: string,
-    patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[] }
+    patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }
   ): Promise<void> {
     await patchPlaylist(playlistId, patch);
     await Promise.all([refreshCurrentLibrary(), refreshAllTracks()]);

--- a/frontend/src/hooks/useLibraryCommands.ts
+++ b/frontend/src/hooks/useLibraryCommands.ts
@@ -52,7 +52,7 @@ type UseLibraryCommandsResult = {
   handleUpdateTrackMetadata: (trackId: string, patch: TrackMetadataPatch) => Promise<void>;
   handleCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   handleAddTrackToPlaylist: (input: { trackId: string; playlistId: string }) => Promise<void>;
-  handlePatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<void>;
+  handlePatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<Playlist>;
   handleDeletePlaylist: (playlistId: string) => Promise<void>;
   handleBulkDeleteTracks: (trackIds: string[]) => Promise<void>;
   handleBulkUpdateTrackMetadata: (trackIds: string[], patch: TrackMetadataPatch) => Promise<void>;
@@ -203,11 +203,12 @@ export function useLibraryCommands({
   async function handlePatchPlaylist(
     playlistId: string,
     patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }
-  ): Promise<void> {
-    await patchPlaylist(playlistId, patch);
+  ): Promise<Playlist> {
+    const updated = await patchPlaylist(playlistId, patch);
     await Promise.all([refreshCurrentLibrary(), refreshAllTracks()]);
     refreshRecentlyUploaded();
     refreshPaginatedLibrary();
+    return updated;
   }
 
   async function handleDeletePlaylist(playlistId: string): Promise<void> {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -159,3 +159,16 @@ export type RadioQueueResponse = {
     trackList: RadioTrack[];
   } | null;
 };
+
+export type AutoPlaylistSummary = {
+  id: string;
+  name: string;
+  genre: string;
+  decade: number;
+  trackCount: number;
+  generatedAt: string;
+};
+
+export type AutoPlaylistDetail = AutoPlaylistSummary & {
+  trackIds: string[];
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -172,3 +172,15 @@ export type AutoPlaylistSummary = {
 export type AutoPlaylistDetail = AutoPlaylistSummary & {
   trackIds: string[];
 };
+
+export type ForYouPlaylistSummary = {
+  id: string;
+  name: string;
+  seedArtist: string;
+  trackCount: number;
+  generatedAt: string;
+};
+
+export type ForYouPlaylistDetail = ForYouPlaylistSummary & {
+  trackIds: string[];
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -107,6 +107,7 @@ export type LibraryResponse = {
   totalTracks: number;
   totalPlaylists?: number;
   owners: string[];
+  ownerNamesById?: Record<string, string>;
   artists: ArtistEntry[];
   albums: AlbumEntry[];
   tracks: Track[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,9 @@
       "name": "flaque-frontend",
       "version": "0.2.2",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "music-metadata": "^10.9.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -382,6 +385,59 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -5916,7 +5972,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {


### PR DESCRIPTION
## Summary
- **Visual improvements**: smaller playlist cards (6/row), transparent header, default-cover.png placeholders for tracks without art, visibility badge aligned with title, popular playlists sorted by likes then listens
- **Inline editing**: replaced the edit modal with in-place editing — cover, title, description, visibility, collaborators, and track order are all editable directly in the playlist detail view
- **Bug fixes**: add-to-playlist picker now respects collaborator/everyone permissions, playlist rename navigates to new URL, sidebar navigation resets detail views, dark mode play button, hearts/collaborators undefined crashes, author shows username instead of ID
- **Collaborator support**: "everyone" collaborator type for open playlists, backend `canEditPlaylist` authorization

## Test plan
- [x] Open the Playlists page — cards should be compact (6 per row on desktop)
- [x] Tracks without cover art show the default flaque placeholder in mosaics and tracklists
- [x] Click Edit on a playlist — title, description, visibility, cover, collaborators, and track list become editable inline (no modal)
- [x] Rename a playlist and save — URL updates to match the new name
- [x] Click sidebar menu items — always lands on root page, not a previously opened detail
- [x] Add a track to a playlist via the "+" button — only owned/collaborator/everyone playlists appear
- [x] Set "everyone" as collaborator — other users can edit the playlist
- [x] Popular playlists section is ordered by hearts, then listens

🤖 Generated with [Claude Code](https://claude.com/claude-code)