### PR TITLE
Fix admin library bugs & auto playlist visuals

### DIFF
--- a/backend/src/api/autoPlaylistRoutes.ts
+++ b/backend/src/api/autoPlaylistRoutes.ts
@@ -52,7 +52,8 @@ export function createAutoPlaylistRouter(indexStore: IndexStore): Router {
           decade: p.decade,
           trackCount: p.trackCount,
           generatedAt: p.generatedAt,
-          colors: p.colors
+          colors: p.colors,
+          gradientAngle: p.gradientAngle
         }))
       });
     } catch (error) {

--- a/backend/src/api/autoPlaylistRoutes.ts
+++ b/backend/src/api/autoPlaylistRoutes.ts
@@ -51,7 +51,8 @@ export function createAutoPlaylistRouter(indexStore: IndexStore): Router {
           genre: p.genre,
           decade: p.decade,
           trackCount: p.trackCount,
-          generatedAt: p.generatedAt
+          generatedAt: p.generatedAt,
+          colors: p.colors
         }))
       });
     } catch (error) {

--- a/backend/src/api/router.ts
+++ b/backend/src/api/router.ts
@@ -24,6 +24,8 @@ export function createApiRouter(indexStore: IndexStore): Router {
   router.use("/auth", createAuthRouter());
   router.use(createUploadRouter(indexStore));
   router.use(createLibraryRouter(indexStore));
+  router.use(createAutoPlaylistRouter(indexStore));
+  router.use(createForYouPlaylistRouter(indexStore));
   router.use(createPlaylistRouter(indexStore));
   router.use(createRadioRouter(indexStore));
   router.use(createStreamingRouter(indexStore));
@@ -31,8 +33,6 @@ export function createApiRouter(indexStore: IndexStore): Router {
   router.use(createCoverRouter(indexStore));
   router.use(createIndexRouter(indexStore));
   router.use(createGenreRouter(indexStore));
-  router.use(createAutoPlaylistRouter(indexStore));
-  router.use(createForYouPlaylistRouter(indexStore));
   router.use(createUserRouter());
   router.use(createLogRouter());
   router.use(createServerRouter());

--- a/backend/src/services/playlists/autoPlaylistService.ts
+++ b/backend/src/services/playlists/autoPlaylistService.ts
@@ -26,6 +26,7 @@ export type AutoPlaylist = {
   trackCount: number;
   generatedAt: string;
   colors: [string, string, string];
+  gradientAngle: number;
 };
 
 export type AutoPlaylistConfig = {
@@ -192,7 +193,8 @@ export async function generateAutoPlaylists(tracks: Track[]): Promise<AutoPlayli
       trackIds: selectedTracks.map((t) => t.id),
       trackCount: selectedTracks.length,
       generatedAt,
-      colors: randomGradientColors()
+      colors: randomGradientColors(),
+      gradientAngle: Math.floor(Math.random() * 360)
     });
   }
 
@@ -235,9 +237,8 @@ export async function loadAutoPlaylists(): Promise<AutoPlaylist[]> {
       null as unknown as AutoPlaylist
     );
     if (data && data.id && data.trackIds) {
-      if (!data.colors) {
-        data.colors = randomGradientColors();
-      }
+      if (!data.colors) data.colors = randomGradientColors();
+      if (data.gradientAngle === undefined) data.gradientAngle = Math.floor(Math.random() * 360);
       playlists.push(data);
     }
   }

--- a/backend/src/services/playlists/autoPlaylistService.ts
+++ b/backend/src/services/playlists/autoPlaylistService.ts
@@ -25,6 +25,7 @@ export type AutoPlaylist = {
   trackIds: string[];
   trackCount: number;
   generatedAt: string;
+  colors: [string, string, string];
 };
 
 export type AutoPlaylistConfig = {
@@ -128,6 +129,17 @@ function slugify(text: string): string {
     .replace(/^-|-$/g, "");
 }
 
+function randomGradientColors(): [string, string, string] {
+  const hue = Math.floor(Math.random() * 360);
+  const offsets = [0, 40 + Math.floor(Math.random() * 40), 160 + Math.floor(Math.random() * 80)];
+  return offsets.map((offset) => {
+    const h = (hue + offset) % 360;
+    const s = 55 + Math.floor(Math.random() * 25);
+    const l = 45 + Math.floor(Math.random() * 20);
+    return `hsl(${h}, ${s}%, ${l}%)`;
+  }) as [string, string, string];
+}
+
 export async function generateAutoPlaylists(tracks: Track[]): Promise<AutoPlaylist[]> {
   const config = await getAutoPlaylistConfig();
 
@@ -179,7 +191,8 @@ export async function generateAutoPlaylists(tracks: Track[]): Promise<AutoPlayli
       decade: group.decade,
       trackIds: selectedTracks.map((t) => t.id),
       trackCount: selectedTracks.length,
-      generatedAt
+      generatedAt,
+      colors: randomGradientColors()
     });
   }
 
@@ -222,6 +235,9 @@ export async function loadAutoPlaylists(): Promise<AutoPlaylist[]> {
       null as unknown as AutoPlaylist
     );
     if (data && data.id && data.trackIds) {
+      if (!data.colors) {
+        data.colors = randomGradientColors();
+      }
       playlists.push(data);
     }
   }

--- a/backend/src/services/scanner/scannerService.ts
+++ b/backend/src/services/scanner/scannerService.ts
@@ -221,7 +221,7 @@ function classifyTrackChanges(
 
 function applyTrackMetadataOverride(
   track: Track,
-  metadataOverride?: { title?: string; artist?: string; album?: string; year?: number }
+  metadataOverride?: { title?: string; artist?: string; album?: string; year?: number; genre?: string[] }
 ): Track {
   if (!metadataOverride) {
     return track;
@@ -234,14 +234,15 @@ function applyTrackMetadataOverride(
       title: metadataOverride.title ?? track.tags.title,
       artist: metadataOverride.artist ?? track.tags.artist,
       album: metadataOverride.album ?? track.tags.album,
-      year: metadataOverride.year ?? track.tags.year
+      year: metadataOverride.year ?? track.tags.year,
+      genre: metadataOverride.genre ?? track.tags.genre
     }
   };
 }
 
 async function probeChangedTracks(
   changedTracks: FileSystemTrackState[],
-  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string; year?: number }>,
+  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string; year?: number; genre?: string[] }>,
   albumsByDirectory: Map<string, AlbumAggregate>,
   processedArtists: Set<string>,
   processedAlbums: Set<string>
@@ -256,7 +257,8 @@ async function probeChangedTracks(
       ...metadata.tags,
       title: metadataOverride?.title ?? metadata.tags.title,
       artist: metadataOverride?.artist ?? metadata.tags.artist,
-      album: metadataOverride?.album ?? metadata.tags.album
+      album: metadataOverride?.album ?? metadata.tags.album,
+      genre: metadataOverride?.genre ?? metadata.tags.genre
     };
 
     const track: Track = {
@@ -298,7 +300,7 @@ function compareTrackOrder(a: Track, b: Track): number {
 async function mergeFinalTracks(
   unchangedTracks: ClassifiedTracks["unchanged"],
   changedTracks: Track[],
-  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string; year?: number }>,
+  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string; year?: number; genre?: string[] }>,
   albumsByDirectory: Map<string, AlbumAggregate>,
   processedArtists: Set<string>,
   processedAlbums: Set<string>
@@ -330,7 +332,7 @@ async function mergeFinalTracks(
 async function performScan(
   mode: ScanMode,
   previousIndex: LibraryIndex | undefined,
-  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string; year?: number }>
+  metadataOverrides: Record<string, { title?: string; artist?: string; album?: string; year?: number; genre?: string[] }>
 ): Promise<LibraryIndex> {
   const ownership = await readTrackOwnership();
   const filesystemState = await collectFilesystemState(ownership, metadataOverrides);

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -468,6 +468,7 @@ export function AuthenticatedApp({
         onRevokeSession: handleRevokeMySession,
         onLogoutOtherSessions: handleLogoutOtherSessions
       }}
+      onAutoPlaylistsRegenerated={refreshAutoPlaylists}
       playerStatusMessage={playerStatusMessage}
       audioPlayerProps={{
         track: selectedTrackRefreshed,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -989,15 +989,14 @@ export async function getMyPlayStats(): Promise<PlayStatsResponse> {
 export type GenreSynonyms = Record<string, string>;
 
 export async function getGenreSynonyms(): Promise<GenreSynonyms> {
-  const payload = await requestJson<{ synonyms: GenreSynonyms }>("/api/genre/synonyms");
-  return payload.synonyms;
+  return requestJson<GenreSynonyms>("/api/genre/synonyms");
 }
 
 export async function putGenreSynonym(key: string, value: string): Promise<void> {
   await requestJson<{ ok: boolean }>("/api/genre/synonyms", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ key, value })
+    body: JSON.stringify({ from: key, to: value })
   });
 }
 

--- a/frontend/src/components/AdminLibraryView.tsx
+++ b/frontend/src/components/AdminLibraryView.tsx
@@ -19,7 +19,11 @@ import {
   type GenreSynonyms
 } from "../api";
 
-export function AdminLibraryView(): JSX.Element {
+type AdminLibraryViewProps = {
+  onAutoPlaylistsRegenerated?: () => void;
+};
+
+export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryViewProps): JSX.Element {
   // ── Genre synonyms ─────────────────────────────────────────────
   const [synonyms, setSynonyms] = useState<GenreSynonyms>({});
   const [loadingSynonyms, setLoadingSynonyms] = useState(true);
@@ -218,6 +222,7 @@ export function AdminLibraryView(): JSX.Element {
     try {
       const result = await regenerateAutoPlaylists();
       setRegenMessage(`Regenerated ${result.regenerated} playlist${result.regenerated !== 1 ? "s" : ""}.`);
+      onAutoPlaylistsRegenerated?.();
     } catch (err) {
       setRegenMessage(err instanceof Error ? err.message : "Failed to regenerate.");
     } finally {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -41,6 +41,7 @@ type AppShellProps = {
   accountViewProps: AccountViewProps;
   playerStatusMessage: string | null;
   audioPlayerProps: AudioPlayerBaseProps;
+  onAutoPlaylistsRegenerated?: () => void;
 };
 
 /**
@@ -64,7 +65,8 @@ export function AppShell({
   backupViewProps,
   accountViewProps,
   playerStatusMessage,
-  audioPlayerProps
+  audioPlayerProps,
+  onAutoPlaylistsRegenerated
 }: AppShellProps): JSX.Element {
   const shouldRenderPlayer = Boolean(audioPlayerProps.track) || activeView === "player";
 
@@ -149,7 +151,7 @@ export function AppShell({
             ) : null}
 
             {configViewProps.activeSection === "library" ? (
-              <AdminLibraryView />
+              <AdminLibraryView onAutoPlaylistsRegenerated={onAutoPlaylistsRegenerated} />
             ) : null}
           </div>
         ) : null}

--- a/frontend/src/components/AutoPlaylistDetailView.tsx
+++ b/frontend/src/components/AutoPlaylistDetailView.tsx
@@ -127,6 +127,8 @@ export function AutoPlaylistDetailView({
   }
 
   const decadeLabel = detail.decade % 100 === 0 ? `${detail.decade}` : `${detail.decade % 100}s`;
+  const [c1, c2, c3] = detail.colors ?? ["hsl(220, 60%, 50%)", "hsl(260, 60%, 50%)", "hsl(340, 60%, 50%)"];
+  const gradientStyle = { background: `linear-gradient(135deg, ${c1}, ${c2}, ${c3})` };
 
   return (
     <section className="m-4 space-y-4">
@@ -144,14 +146,14 @@ export function AutoPlaylistDetailView({
 
       {/* Header card */}
       <div className="rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-white/85 to-flaque-cream/40 p-5 shadow-panel backdrop-blur-sm">
-        <div className="flex flex-col gap-5 sm:flex-row">
+        <div className="group flex flex-col gap-5 sm:flex-row">
            {/* Genre/decade visual */}
-           <div className="relative h-48 w-48 shrink-0 items-center justify-center self-center overflow-hidden rounded-2xl bg-gradient-to-br from-flaque-sand/50 to-flaque-clay/30 sm:self-start">
-             <div className="text-center">
-               <p className="font-display text-5xl font-bold text-flaque-ink/60">{decadeLabel}</p>
-               <p className="mt-1 text-sm font-medium text-flaque-steel">{detail.genre}</p>
+           <div className="relative h-48 w-48 shrink-0 self-center overflow-hidden rounded-2xl sm:self-start" style={gradientStyle}>
+             <div className="flex h-full w-full flex-col items-center justify-center">
+               <p className="font-display text-6xl font-extrabold text-white drop-shadow-md">{decadeLabel}</p>
+               <p className="mt-1 text-sm font-medium text-white/80">{detail.genre}</p>
              </div>
-             
+
              {/* Play button overlay */}
              <button
                type="button"
@@ -159,7 +161,7 @@ export function AutoPlaylistDetailView({
                onClick={handlePlayAll}
                aria-label={`Play ${detail.name}`}
              >
-               <svg className="h-10 w-10 text-[#ffffff] drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+               <svg className="h-12 w-12 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
                  <path d="M8 6v12l10-6-10-6z" />
                </svg>
              </button>

--- a/frontend/src/components/AutoPlaylistDetailView.tsx
+++ b/frontend/src/components/AutoPlaylistDetailView.tsx
@@ -128,7 +128,8 @@ export function AutoPlaylistDetailView({
 
   const decadeLabel = detail.decade % 100 === 0 ? `${detail.decade}` : `${detail.decade % 100}s`;
   const [c1, c2, c3] = detail.colors ?? ["hsl(220, 60%, 50%)", "hsl(260, 60%, 50%)", "hsl(340, 60%, 50%)"];
-  const gradientStyle = { background: `linear-gradient(135deg, ${c1}, ${c2}, ${c3})` };
+  const angle = detail.gradientAngle ?? 135;
+  const gradientStyle = { background: `linear-gradient(${angle}deg, ${c1}, ${c2}, ${c3})` };
 
   return (
     <section className="m-4 space-y-4">

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -416,30 +416,45 @@ export function LibraryPlaylistSection({
           </p>
         ) : (
           <div className="mt-4 grid grid-cols-3 gap-2.5 sm:grid-cols-4 lg:grid-cols-6">
-            {autoPlaylists.map((ap) => (
-              <div
-                key={ap.id}
-                className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-flaque-ink/5 to-flaque-sand/30 shadow-sm transition hover:shadow-md"
-                onClick={() => onNavigateToPlaylist(ap.id)}
-                role="link"
-                tabIndex={0}
-                onKeyDown={(e) => { if (e.key === "Enter") onNavigateToPlaylist(ap.id); }}
-              >
-                <div className="flex aspect-square w-full items-center justify-center bg-gradient-to-br from-flaque-sand/40 to-flaque-clay/20">
-                  <div className="text-center">
-                    <p className="font-display text-2xl font-bold text-flaque-ink/70">{ap.decade % 100 === 0 ? ap.decade : `${ap.decade % 100}s`}</p>
-                    <p className="mt-0.5 text-xs font-medium text-flaque-steel">{ap.genre}</p>
+            {autoPlaylists.map((ap) => {
+              const [c1, c2, c3] = ap.colors ?? ["hsl(220, 60%, 50%)", "hsl(260, 60%, 50%)", "hsl(340, 60%, 50%)"];
+              const gradientStyle = { background: `linear-gradient(135deg, ${c1}, ${c2}, ${c3})` };
+              return (
+                <div
+                  key={ap.id}
+                  className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-sm transition hover:shadow-md"
+                  onClick={() => onNavigateToPlaylist(ap.id)}
+                  role="link"
+                  tabIndex={0}
+                  onKeyDown={(e) => { if (e.key === "Enter") onNavigateToPlaylist(ap.id); }}
+                >
+                  <div className="relative aspect-square w-full overflow-hidden" style={gradientStyle}>
+                    <div className="flex h-full w-full flex-col items-center justify-center">
+                      <p className="font-display text-5xl font-extrabold text-white drop-shadow-md">{ap.decade % 100 === 0 ? ap.decade : `${ap.decade % 100}s`}</p>
+                      <p className="mt-1 text-xs font-medium text-white/80">{ap.genre}</p>
+                    </div>
+
+                    {/* Play button overlay */}
+                    <button
+                      type="button"
+                      className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100"
+                      onClick={(e) => { e.stopPropagation(); onNavigateToPlaylist(ap.id); }}
+                      aria-label={`Play ${ap.name}`}
+                    >
+                      <svg className="h-10 w-10 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
+                        <path d="M8 6v12l10-6-10-6z" />
+                      </svg>
+                    </button>
+                  </div>
+                  <div className="p-2">
+                    <p className="truncate text-xs font-semibold text-flaque-ink">{ap.name}</p>
+                    <p className="mt-0.5 text-xs text-flaque-steel">
+                      {ap.trackCount} track{ap.trackCount !== 1 ? "s" : ""}
+                    </p>
                   </div>
                 </div>
-                <div className="p-3">
-                  <p className="truncate text-sm font-semibold text-flaque-ink">{ap.name}</p>
-                  <p className="mt-0.5 text-xs text-flaque-steel">
-                    {ap.trackCount} track{ap.trackCount !== 1 ? "s" : ""}
-                    {" \u00b7 "}Generated {new Date(ap.generatedAt).toLocaleDateString()}
-                  </p>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </section>

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -418,7 +418,8 @@ export function LibraryPlaylistSection({
           <div className="mt-4 grid grid-cols-3 gap-2.5 sm:grid-cols-4 lg:grid-cols-6">
             {autoPlaylists.map((ap) => {
               const [c1, c2, c3] = ap.colors ?? ["hsl(220, 60%, 50%)", "hsl(260, 60%, 50%)", "hsl(340, 60%, 50%)"];
-              const gradientStyle = { background: `linear-gradient(135deg, ${c1}, ${c2}, ${c3})` };
+              const angle = ap.gradientAngle ?? 135;
+              const gradientStyle = { background: `linear-gradient(${angle}deg, ${c1}, ${c2}, ${c3})` };
               return (
                 <div
                   key={ap.id}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -168,6 +168,7 @@ export type AutoPlaylistSummary = {
   decade: number;
   trackCount: number;
   generatedAt: string;
+  colors?: [string, string, string];
 };
 
 export type AutoPlaylistDetail = AutoPlaylistSummary & {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -169,6 +169,7 @@ export type AutoPlaylistSummary = {
   trackCount: number;
   generatedAt: string;
   colors?: [string, string, string];
+  gradientAngle?: number;
 };
 
 export type AutoPlaylistDetail = AutoPlaylistSummary & {


### PR DESCRIPTION
## Summary
- **Fix genre synonyms 400**: frontend now sends `{ from, to }` instead of `{ key, value }` and handles flat response from backend (no wrapper)
- **Fix enriched genres not visible on tracks**: scanner now applies genre overrides from metadata override store during index build
- **Fix auto/for-you playlists not loading**: moved auto-playlist and for-you-playlist routers before the generic `/playlists/:id` route to prevent route shadowing
- **Fix stale auto playlists list after regeneration**: admin view now triggers a refresh of the playlists section after regeneration
- **Auto playlist gradient covers**: each auto playlist gets 3 harmonious HSL colors generated at creation time, used as gradient background on cards and detail view with large white decade text and play button overlay on hover

## Test plan
- [ ] Add a genre synonym via admin library view — should succeed (no 400)
- [ ] Run genre enrichment, rebuild index — enriched genres should appear on tracks in the library
- [ ] Regenerate auto playlists — playlists should appear in the playlists view with colorful gradient covers
- [ ] Hover auto playlist card — black veil with white play button should appear
- [ ] Click into auto playlist detail — header visual should use the same gradient with large decade text
- [ ] Verify for-you playlists also load correctly in the playlists view

🤖 Generated with [Claude Code](https://claude.com/claude-code)