### PR TITLE
UI: artist & album view improvements

### DIFF
--- a/frontend/src/components/AlbumList.tsx
+++ b/frontend/src/components/AlbumList.tsx
@@ -33,7 +33,7 @@ export function AlbumList({ albums, selectedAlbum, onAlbumSelect, onPlayAlbum, g
           >
             <div className="group relative">
               <img
-                className="aspect-square w-full rounded-lg border border-flaque-clay/50 object-cover"
+                className="aspect-square w-full border border-flaque-clay/50 object-cover"
                 src={getAlbumCoverSrc(album)}
                 alt={album.artist ? `Cover for ${album.artist} - ${album.name}${album.year ? ` (${album.year})` : ""}` : `Cover for ${album.name}${album.year ? ` (${album.year})` : ""}`}
                 onError={(event) => {
@@ -42,7 +42,7 @@ export function AlbumList({ albums, selectedAlbum, onAlbumSelect, onPlayAlbum, g
               />
               {onPlayAlbum ? (
                 <button
-                  className="absolute inset-0 flex items-center justify-center rounded-lg bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100"
+                  className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100"
                   type="button"
                   aria-label={`Play ${album.name}${album.year ? ` (${album.year})` : ""}`}
                   onClick={(event) => {

--- a/frontend/src/components/AlbumList.tsx
+++ b/frontend/src/components/AlbumList.tsx
@@ -23,17 +23,17 @@ export function AlbumList({ albums, selectedAlbum, onAlbumSelect, onPlayAlbum, g
         return (
           <div
             key={albumKey}
-            className={`rounded-xl border p-2 text-left transition cursor-pointer ${
+            className={`rounded-xl p-2 text-left transition cursor-pointer ${
               isSelected
-                ? "border-flaque-ink bg-flaque-sand/25"
-                : "border-flaque-clay/60 bg-flaque-cream/45 hover:bg-flaque-cream"
+                ? "bg-flaque-sand/25"
+                : "hover:bg-flaque-cream/60"
             }`}
             onClick={() => onAlbumSelect(album)}
             title={album.artist ? `${album.artist} - ${album.name}${album.year ? ` (${album.year})` : ""}` : `${album.name}${album.year ? ` (${album.year})` : ""}`}
           >
             <div className="group relative">
               <img
-                className="aspect-square w-full border border-flaque-clay/50 object-cover"
+                className="aspect-square w-full object-cover"
                 src={getAlbumCoverSrc(album)}
                 alt={album.artist ? `Cover for ${album.artist} - ${album.name}${album.year ? ` (${album.year})` : ""}` : `Cover for ${album.name}${album.year ? ` (${album.year})` : ""}`}
                 onError={(event) => {

--- a/frontend/src/components/Coverflow.tsx
+++ b/frontend/src/components/Coverflow.tsx
@@ -121,6 +121,24 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverS
     };
   }, [updateTransforms, albums]);
 
+  // Scroll to the selected album on mount
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper || !selectedKey) return;
+
+    const items = wrapper.querySelectorAll<HTMLElement>(".cards li");
+    for (let i = 0; i < items.length; i++) {
+      if (items[i].classList.contains("selected")) {
+        wrapper.scrollTo({
+          left: items[i].offsetLeft - wrapper.clientWidth / 2 + items[i].offsetWidth / 2,
+          behavior: "instant"
+        });
+        break;
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <>
       <style>{`
@@ -339,8 +357,8 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect, getAlbumCoverS
           </ul>
         </div>
         <div className="coverflow-label" ref={labelRef}>
-          <span className="coverflow-title">{albums[0]?.name ?? ""}</span>
-          <span className="coverflow-artist">{albums[0]?.artist ?? ""}</span>
+          <span className="coverflow-title">{(selectedAlbum ?? albums[0])?.name ?? ""}</span>
+          <span className="coverflow-artist">{(selectedAlbum ?? albums[0])?.artist ?? ""}</span>
         </div>
       </section>
     </>

--- a/frontend/src/components/LibraryAlbumsSection.test.tsx
+++ b/frontend/src/components/LibraryAlbumsSection.test.tsx
@@ -150,7 +150,7 @@ describe("LibraryAlbumsSection", () => {
     );
 
     expect(screen.getByText("Album route timeout")).toBeTruthy();
-    expect(screen.getByText("Album tracks")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Immunity", level: 3 })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Play Open Eye Signal" }));
 
     expect(onTrackSelect).toHaveBeenCalledWith(track);

--- a/frontend/src/components/LibraryAlbumsSection.tsx
+++ b/frontend/src/components/LibraryAlbumsSection.tsx
@@ -1,6 +1,7 @@
 import { coverPathUrl, coverUrl } from "../api";
 import defaultCoverImage from "../assets/default-cover.png";
 import type { AlbumEntry, Playlist, Track } from "../types";
+import { formatDurationHuman } from "../utils/format";
 import { useState } from "react";
 import { AlbumList } from "./AlbumList";
 import { Coverflow } from "./Coverflow";
@@ -71,45 +72,86 @@ export function LibraryAlbumsSection({
     return defaultCoverImage;
   }
 
-  return (
-    <section className="border border-flaque-clay/60 rounded-xl m-4 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h2 className="font-display text-xl text-flaque-ink">Albums</h2>
-        </div>
+  const albumCoverSrc = selectedAlbum ? getAlbumCoverSrc(selectedAlbum) : defaultCoverImage;
 
-        <div className="flex items-center gap-3">
-          {!selectedAlbum && (
-            <input
-              className="rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-3 py-1.5 text-sm text-flaque-ink placeholder:text-flaque-steel/60 focus:border-flaque-ink/40 focus:outline-none"
-              type="text"
-              placeholder="Search albums..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
+  return (
+    <>
+      {/* Album header — transparent, above the main section */}
+      {selectedAlbum && isListModeTracklistVisible && (
+        <div className="mx-4 mt-4 px-4 py-6">
+          <div className="flex items-center gap-6">
+            <img
+              className="h-36 w-36 shrink-0 object-cover shadow-md"
+              src={albumCoverSrc}
+              alt={selectedAlbum.name}
+              onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
             />
-          )}
-        <div className="inline-flex rounded-xl border border-flaque-clay/70 bg-flaque-cream/50 p-1">
-          <button
-            className={`rounded-lg px-3 py-1.5 text-sm transition ${
-              viewMode === "list" ? "bg-white text-flaque-ink shadow-sm" : "text-flaque-steel hover:text-flaque-ink"
-            }`}
-            type="button"
-            onClick={() => setViewMode("list")}
-          >
-            List
-          </button>
-          <button
-            className={`rounded-lg px-3 py-1.5 text-sm transition ${
-              viewMode === "coverflow" ? "bg-white text-flaque-ink shadow-sm" : "text-flaque-steel hover:text-flaque-ink"
-            }`}
-            type="button"
-            onClick={() => setViewMode("coverflow")}
-          >
-            Coverflow
-          </button>
+            <div className="min-w-0">
+              <h3 className="truncate font-display text-4xl font-bold text-flaque-ink">{selectedAlbum.name}</h3>
+              <p className="mt-1 text-base text-flaque-steel">
+                {selectedAlbum.artist ?? "Unknown artist"}
+              </p>
+              <p className="mt-0.5 text-sm text-flaque-steel">
+                {selectedAlbum.year ? `${selectedAlbum.year} · ` : ""}
+                {selectedAlbum.trackCount} track{selectedAlbum.trackCount !== 1 ? "s" : ""}
+                {selectedAlbum.totalDuration ? ` · ${formatDurationHuman(selectedAlbum.totalDuration)}` : ""}
+              </p>
+            </div>
+          </div>
         </div>
+      )}
+
+    <section className="border border-flaque-clay/60 rounded-xl m-4 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+      {!isListModeTracklistVisible ? (
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="font-display text-xl text-flaque-ink">Albums</h2>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {!selectedAlbum && (
+              <input
+                className="rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-3 py-1.5 text-sm text-flaque-ink placeholder:text-flaque-steel/60 focus:border-flaque-ink/40 focus:outline-none"
+                type="text"
+                placeholder="Search albums..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            )}
+          <div className="inline-flex rounded-xl border border-flaque-clay/70 bg-flaque-cream/50 p-1">
+            <button
+              className={`rounded-lg px-3 py-1.5 text-sm transition ${
+                viewMode === "list" ? "bg-white text-flaque-ink shadow-sm" : "text-flaque-steel hover:text-flaque-ink"
+              }`}
+              type="button"
+              onClick={() => setViewMode("list")}
+            >
+              List
+            </button>
+            <button
+              className={`rounded-lg px-3 py-1.5 text-sm transition ${
+                viewMode === "coverflow" ? "bg-white text-flaque-ink shadow-sm" : "text-flaque-steel hover:text-flaque-ink"
+              }`}
+              type="button"
+              onClick={() => setViewMode("coverflow")}
+            >
+              Coverflow
+            </button>
+          </div>
+          </div>
         </div>
-      </div>
+      ) : (
+        <button
+          className="mb-3 inline-flex items-center rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-2.5 py-1 text-xs font-medium text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
+          type="button"
+          onClick={onBack}
+          aria-label="Back"
+        >
+          <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M19 12H5" /><path d="M12 19l-7-7 7-7" />
+          </svg>
+        </button>
+      )}
 
       {libraryMetadataError ? (
         <p className="mt-3 rounded-xl border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">{libraryMetadataError}</p>
@@ -138,35 +180,14 @@ export function LibraryAlbumsSection({
             />
           ) : null}
 
-          {selectedAlbum ? (
-            <div className="mt-4 overflow-hidden rounded-2xl border border-flaque-clay/60 bg-white/75">
-              <div className="border-b border-flaque-clay/55 px-4 py-3">
-                {isListModeTracklistVisible ? (
-                  <button
-                    className="mb-2 inline-flex items-center rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-2.5 py-1 text-xs font-medium text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
-                    type="button"
-                    onClick={onBack}
-                    aria-label="Back"
-                  >
-                    <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                      <path d="M19 12H5" /><path d="M12 19l-7-7 7-7" />
-                    </svg>
-                  </button>
-                ) : null}
-                <p className="text-xs uppercase tracking-[0.14em] text-flaque-steel">Album tracks</p>
-                <p
-                  className="truncate text-sm text-flaque-ink"
-                  title={selectedAlbum.artist ? `${selectedAlbum.artist} - ${selectedAlbum.name}` : selectedAlbum.name}
-                >
-                  {selectedAlbum.artist ? `${selectedAlbum.artist} - ${selectedAlbum.name}` : selectedAlbum.name}
-                </p>
-                {loadingSelectedAlbumTracks ? (
-                  <p className="mt-1 text-xs text-flaque-steel">Loading album tracks...</p>
-                ) : null}
-                {selectedAlbumTracksError ? (
-                  <p className="mt-1 text-xs text-red-700">{selectedAlbumTracksError}</p>
-                ) : null}
-              </div>
+          {selectedAlbum && isListModeTracklistVisible ? (
+            <div className="overflow-hidden rounded-2xl border border-flaque-clay/60 bg-white/75">
+              {loadingSelectedAlbumTracks ? (
+                <p className="px-4 py-3 text-xs text-flaque-steel">Loading album tracks...</p>
+              ) : null}
+              {selectedAlbumTracksError ? (
+                <p className="px-4 py-3 text-xs text-red-700">{selectedAlbumTracksError}</p>
+              ) : null}
 
               <TrackList
                 tracks={selectedAlbumTracks}
@@ -184,5 +205,6 @@ export function LibraryAlbumsSection({
         </>
       )}
     </section>
+    </>
   );
 }

--- a/frontend/src/components/LibraryAlbumsSection.tsx
+++ b/frontend/src/components/LibraryAlbumsSection.tsx
@@ -105,7 +105,7 @@ export function LibraryAlbumsSection({
         </div>
       )}
 
-    <section className="border border-flaque-clay/60 rounded-xl m-4 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+    <section className={`border border-flaque-clay/60 rounded-xl m-4 bg-white/85 p-5 shadow-panel backdrop-blur-sm${!isAlbumSelected && viewMode === "coverflow" ? " flex flex-1 flex-col" : ""}`}>
       <div className="flex flex-wrap items-start justify-between gap-3">
         {isAlbumSelected ? (
           <button
@@ -165,12 +165,14 @@ export function LibraryAlbumsSection({
       ) : (
         <>
           {!isAlbumSelected && viewMode === "coverflow" ? (
-            <Coverflow
-              albums={filteredAlbums}
-              selectedAlbum={lastSelectedAlbumRef.current}
-              onAlbumSelect={onAlbumSelect}
-              getAlbumCoverSrc={getAlbumCoverSrc}
-            />
+            <div className="flex flex-1 items-center">
+              <Coverflow
+                albums={filteredAlbums}
+                selectedAlbum={lastSelectedAlbumRef.current}
+                onAlbumSelect={onAlbumSelect}
+                getAlbumCoverSrc={getAlbumCoverSrc}
+              />
+            </div>
           ) : !isAlbumSelected && viewMode === "list" ? (
             <AlbumList
               albums={filteredAlbums}

--- a/frontend/src/components/LibraryAlbumsSection.tsx
+++ b/frontend/src/components/LibraryAlbumsSection.tsx
@@ -102,22 +102,32 @@ export function LibraryAlbumsSection({
       )}
 
     <section className="border border-flaque-clay/60 rounded-xl m-4 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
-      {!isListModeTracklistVisible ? (
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <h2 className="font-display text-xl text-flaque-ink">Albums</h2>
-          </div>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        {isListModeTracklistVisible ? (
+          <button
+            className="inline-flex items-center rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-2.5 py-1 text-xs font-medium text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
+            type="button"
+            onClick={onBack}
+            aria-label="Back"
+          >
+            <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M19 12H5" /><path d="M12 19l-7-7 7-7" />
+            </svg>
+          </button>
+        ) : (
+          <h2 className="font-display text-xl text-flaque-ink">Albums</h2>
+        )}
 
-          <div className="flex items-center gap-3">
-            {!selectedAlbum && (
-              <input
-                className="rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-3 py-1.5 text-sm text-flaque-ink placeholder:text-flaque-steel/60 focus:border-flaque-ink/40 focus:outline-none"
-                type="text"
-                placeholder="Search albums..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-              />
-            )}
+        <div className="flex items-center gap-3">
+          {!selectedAlbum && (
+            <input
+              className="rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-3 py-1.5 text-sm text-flaque-ink placeholder:text-flaque-steel/60 focus:border-flaque-ink/40 focus:outline-none"
+              type="text"
+              placeholder="Search albums..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          )}
           <div className="inline-flex rounded-xl border border-flaque-clay/70 bg-flaque-cream/50 p-1">
             <button
               className={`rounded-lg px-3 py-1.5 text-sm transition ${
@@ -138,20 +148,8 @@ export function LibraryAlbumsSection({
               Coverflow
             </button>
           </div>
-          </div>
         </div>
-      ) : (
-        <button
-          className="mb-3 inline-flex items-center rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-2.5 py-1 text-xs font-medium text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
-          type="button"
-          onClick={onBack}
-          aria-label="Back"
-        >
-          <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-            <path d="M19 12H5" /><path d="M12 19l-7-7 7-7" />
-          </svg>
-        </button>
-      )}
+      </div>
 
       {libraryMetadataError ? (
         <p className="mt-3 rounded-xl border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">{libraryMetadataError}</p>

--- a/frontend/src/components/LibraryAlbumsSection.tsx
+++ b/frontend/src/components/LibraryAlbumsSection.tsx
@@ -2,7 +2,7 @@ import { coverPathUrl, coverUrl } from "../api";
 import defaultCoverImage from "../assets/default-cover.png";
 import type { AlbumEntry, Playlist, Track } from "../types";
 import { formatDurationHuman } from "../utils/format";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { AlbumList } from "./AlbumList";
 import { Coverflow } from "./Coverflow";
 import { TrackList } from "./TrackList";
@@ -49,7 +49,11 @@ export function LibraryAlbumsSection({
 }: LibraryAlbumsSectionProps): JSX.Element {
   const [viewMode, setViewMode] = useState<AlbumViewMode>("list");
   const [searchQuery, setSearchQuery] = useState("");
-  const isListModeTracklistVisible = viewMode === "list" && selectedAlbum !== null;
+  const isAlbumSelected = selectedAlbum !== null;
+  const lastSelectedAlbumRef = useRef<AlbumEntry | null>(null);
+  if (selectedAlbum && viewMode === "coverflow") {
+    lastSelectedAlbumRef.current = selectedAlbum;
+  }
 
   const normalizedQuery = searchQuery.trim().toLowerCase();
   const filteredAlbums = normalizedQuery
@@ -77,7 +81,7 @@ export function LibraryAlbumsSection({
   return (
     <>
       {/* Album header — transparent, above the main section */}
-      {selectedAlbum && isListModeTracklistVisible && (
+      {isAlbumSelected && (
         <div className="mx-4 mt-4 px-4 py-6">
           <div className="flex items-center gap-6">
             <img
@@ -103,9 +107,9 @@ export function LibraryAlbumsSection({
 
     <section className="border border-flaque-clay/60 rounded-xl m-4 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
       <div className="flex flex-wrap items-start justify-between gap-3">
-        {isListModeTracklistVisible ? (
+        {isAlbumSelected ? (
           <button
-            className="inline-flex items-center rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-2.5 py-1 text-xs font-medium text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
+            className="mb-3 inline-flex items-center rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-2.5 py-1 text-xs font-medium text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
             type="button"
             onClick={onBack}
             aria-label="Back"
@@ -115,40 +119,39 @@ export function LibraryAlbumsSection({
             </svg>
           </button>
         ) : (
-          <h2 className="font-display text-xl text-flaque-ink">Albums</h2>
+          <>
+            <h2 className="font-display text-xl text-flaque-ink">Albums</h2>
+            <div className="flex items-center gap-3">
+              <input
+                className="rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-3 py-1.5 text-sm text-flaque-ink placeholder:text-flaque-steel/60 focus:border-flaque-ink/40 focus:outline-none"
+                type="text"
+                placeholder="Search albums..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+              <div className="inline-flex rounded-xl border border-flaque-clay/70 bg-flaque-cream/50 p-1">
+                <button
+                  className={`rounded-lg px-3 py-1.5 text-sm transition ${
+                    viewMode === "list" ? "bg-white text-flaque-ink shadow-sm" : "text-flaque-steel hover:text-flaque-ink"
+                  }`}
+                  type="button"
+                  onClick={() => setViewMode("list")}
+                >
+                  List
+                </button>
+                <button
+                  className={`rounded-lg px-3 py-1.5 text-sm transition ${
+                    viewMode === "coverflow" ? "bg-white text-flaque-ink shadow-sm" : "text-flaque-steel hover:text-flaque-ink"
+                  }`}
+                  type="button"
+                  onClick={() => setViewMode("coverflow")}
+                >
+                  Coverflow
+                </button>
+              </div>
+            </div>
+          </>
         )}
-
-        <div className="flex items-center gap-3">
-          {!selectedAlbum && (
-            <input
-              className="rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-3 py-1.5 text-sm text-flaque-ink placeholder:text-flaque-steel/60 focus:border-flaque-ink/40 focus:outline-none"
-              type="text"
-              placeholder="Search albums..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
-          )}
-          <div className="inline-flex rounded-xl border border-flaque-clay/70 bg-flaque-cream/50 p-1">
-            <button
-              className={`rounded-lg px-3 py-1.5 text-sm transition ${
-                viewMode === "list" ? "bg-white text-flaque-ink shadow-sm" : "text-flaque-steel hover:text-flaque-ink"
-              }`}
-              type="button"
-              onClick={() => setViewMode("list")}
-            >
-              List
-            </button>
-            <button
-              className={`rounded-lg px-3 py-1.5 text-sm transition ${
-                viewMode === "coverflow" ? "bg-white text-flaque-ink shadow-sm" : "text-flaque-steel hover:text-flaque-ink"
-              }`}
-              type="button"
-              onClick={() => setViewMode("coverflow")}
-            >
-              Coverflow
-            </button>
-          </div>
-        </div>
       </div>
 
       {libraryMetadataError ? (
@@ -161,14 +164,14 @@ export function LibraryAlbumsSection({
         <p className="mt-3 text-sm text-flaque-steel">No albums found{normalizedQuery ? ` matching "${searchQuery.trim()}"` : " for these filters"}.</p>
       ) : (
         <>
-          {viewMode === "coverflow" ? (
+          {!isAlbumSelected && viewMode === "coverflow" ? (
             <Coverflow
               albums={filteredAlbums}
-              selectedAlbum={selectedAlbum}
+              selectedAlbum={lastSelectedAlbumRef.current}
               onAlbumSelect={onAlbumSelect}
               getAlbumCoverSrc={getAlbumCoverSrc}
             />
-          ) : !isListModeTracklistVisible ? (
+          ) : !isAlbumSelected && viewMode === "list" ? (
             <AlbumList
               albums={filteredAlbums}
               selectedAlbum={selectedAlbum}
@@ -178,7 +181,7 @@ export function LibraryAlbumsSection({
             />
           ) : null}
 
-          {selectedAlbum && isListModeTracklistVisible ? (
+          {isAlbumSelected ? (
             <div className="overflow-hidden rounded-2xl border border-flaque-clay/60 bg-white/75">
               {loadingSelectedAlbumTracks ? (
                 <p className="px-4 py-3 text-xs text-flaque-steel">Loading album tracks...</p>

--- a/frontend/src/components/LibraryArtistsSection.test.tsx
+++ b/frontend/src/components/LibraryArtistsSection.test.tsx
@@ -127,7 +127,7 @@ describe("LibraryArtistsSection", () => {
       selectedArtistAlbumTracks: [createTrack({ id: "t1", title: "Music Is Math", artist: "Boards of Canada", album: "Geogaddi" })]
     });
 
-    expect(screen.getByText("Album tracks")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Geogaddi", level: 3 })).toBeTruthy();
     expect(screen.getAllByText("Music Is Math").length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/components/LibraryArtistsSection.test.tsx
+++ b/frontend/src/components/LibraryArtistsSection.test.tsx
@@ -105,7 +105,7 @@ describe("LibraryArtistsSection", () => {
       artistAlbums: [createAlbum({ name: "Geogaddi", artist: "Boards of Canada", trackCount: 2 })]
     });
 
-    expect(screen.getByText(/Albums for/i)).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Boards of Canada", level: 3 })).toBeTruthy();
     expect(screen.getByText("Geogaddi")).toBeTruthy();
   });
 

--- a/frontend/src/components/LibraryArtistsSection.tsx
+++ b/frontend/src/components/LibraryArtistsSection.tsx
@@ -76,11 +76,44 @@ export function LibraryArtistsSection({
     ? artists.filter((artist) => artist.name.toLowerCase().includes(normalizedQuery))
     : artists;
 
+  const artistPhotoSrc = selectedArtist
+    ? (selectedArtist.photo
+        ? coverPathUrl(selectedArtist.photo)
+        : selectedArtist.previewTrackId
+          ? coverUrl(selectedArtist.previewTrackId)
+          : defaultCoverImage)
+    : defaultCoverImage;
+
   return (
+    <>
+      {/* Artist header — transparent, above the main section */}
+      {isArtistSelected && !isTracklistVisible && (
+        <div className="mx-4 mt-4 px-4 py-6">
+          <div className="flex items-center gap-6">
+            <img
+              className="h-36 w-36 shrink-0 rounded-full border-2 border-flaque-clay/50 object-cover shadow-md"
+              src={artistPhotoSrc}
+              alt={selectedArtist.name}
+              onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
+            />
+            <div className="min-w-0">
+              <h3 className="truncate font-display text-4xl font-bold text-flaque-ink">{selectedArtist.name}</h3>
+              <p className="mt-1 text-sm text-flaque-steel">
+                {selectedArtist.albumCount} album{selectedArtist.albumCount !== 1 ? "s" : ""}
+                {" · "}
+                {selectedArtist.trackCount} track{selectedArtist.trackCount !== 1 ? "s" : ""}
+                {" · "}
+                {formatDurationHuman(selectedArtist.totalDuration)}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
     <section className="border m-4 rounded-xl border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <h2 className="font-display text-xl text-flaque-ink">Artists</h2>
-        {!isArtistSelected && (
+      {!isArtistSelected && (
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <h2 className="font-display text-xl text-flaque-ink">Artists</h2>
           <input
             className="rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-3 py-1.5 text-sm text-flaque-ink placeholder:text-flaque-steel/60 focus:border-flaque-ink/40 focus:outline-none"
             type="text"
@@ -88,24 +121,19 @@ export function LibraryArtistsSection({
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />
-        )}
-      </div>
+        </div>
+      )}
       {isArtistSelected ? (
-        <>
-          <button
-            className="mt-2 inline-flex items-center rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-2.5 py-1 text-xs font-medium text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
-            type="button"
-            onClick={onArtistBack}
-            aria-label="Back"
-          >
-            <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <path d="M19 12H5" /><path d="M12 19l-7-7 7-7" />
-            </svg>
-          </button>
-          <p className="mt-2 text-sm text-flaque-steel" title={selectedArtist.name}>
-            Albums for <span className="font-medium text-flaque-ink">{selectedArtist.name}</span>
-          </p>
-        </>
+        <button
+          className={`inline-flex items-center rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-2.5 py-1 text-xs font-medium text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink${isTracklistVisible ? " mb-3" : ""}`}
+          type="button"
+          onClick={isTracklistVisible ? onArtistAlbumBack : onArtistBack}
+          aria-label="Back"
+        >
+          <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M19 12H5" /><path d="M12 19l-7-7 7-7" />
+          </svg>
+        </button>
       ) : (
         <p className="mt-1 text-sm text-flaque-steel"></p>
       )}
@@ -121,16 +149,6 @@ export function LibraryArtistsSection({
       ) : isArtistSelected && isTracklistVisible ? (
         <div className="mt-4 overflow-hidden rounded-2xl border border-flaque-clay/60 bg-white/75">
           <div className="border-b border-flaque-clay/55 px-4 py-3">
-            <button
-              className="mb-2 inline-flex items-center rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-2.5 py-1 text-xs font-medium text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
-              type="button"
-              onClick={onArtistAlbumBack}
-            aria-label="Back"
-            >
-              <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <path d="M19 12H5" /><path d="M12 19l-7-7 7-7" />
-              </svg>
-            </button>
             <p className="text-xs uppercase tracking-[0.14em] text-flaque-steel">Album tracks</p>
             <p
               className="truncate text-sm text-flaque-ink"
@@ -239,5 +257,6 @@ export function LibraryArtistsSection({
         </div>
       )}
     </section>
+    </>
   );
 }

--- a/frontend/src/components/LibraryArtistsSection.tsx
+++ b/frontend/src/components/LibraryArtistsSection.tsx
@@ -86,6 +86,31 @@ export function LibraryArtistsSection({
 
   return (
     <>
+      {/* Album header — transparent, when viewing album tracks */}
+      {isArtistSelected && isTracklistVisible && selectedArtistAlbum && (
+        <div className="mx-4 mt-4 px-4 py-6">
+          <div className="flex items-center gap-6">
+            <img
+              className="h-36 w-36 shrink-0 object-cover shadow-md"
+              src={getAlbumCoverSrc(selectedArtistAlbum)}
+              alt={selectedArtistAlbum.name}
+              onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
+            />
+            <div className="min-w-0">
+              <h3 className="truncate font-display text-4xl font-bold text-flaque-ink">{selectedArtistAlbum.name}</h3>
+              <p className="mt-1 text-base text-flaque-steel">
+                {selectedArtistAlbum.artist ?? selectedArtist.name}
+              </p>
+              <p className="mt-0.5 text-sm text-flaque-steel">
+                {selectedArtistAlbum.year ? `${selectedArtistAlbum.year} · ` : ""}
+                {selectedArtistAlbum.trackCount} track{selectedArtistAlbum.trackCount !== 1 ? "s" : ""}
+                {selectedArtistAlbum.totalDuration ? ` · ${formatDurationHuman(selectedArtistAlbum.totalDuration)}` : ""}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Artist header — transparent, above the main section */}
       {isArtistSelected && !isTracklistVisible && (
         <div className="mx-4 mt-4 px-4 py-6">
@@ -147,22 +172,13 @@ export function LibraryArtistsSection({
       ) : filteredArtists.length === 0 && !isArtistSelected ? (
         <p className="mt-3 text-sm text-flaque-steel">No artists found{normalizedQuery ? ` matching "${searchQuery.trim()}"` : " for these filters"}.</p>
       ) : isArtistSelected && isTracklistVisible ? (
-        <div className="mt-4 overflow-hidden rounded-2xl border border-flaque-clay/60 bg-white/75">
-          <div className="border-b border-flaque-clay/55 px-4 py-3">
-            <p className="text-xs uppercase tracking-[0.14em] text-flaque-steel">Album tracks</p>
-            <p
-              className="truncate text-sm text-flaque-ink"
-              title={selectedArtistAlbum.artist ? `${selectedArtistAlbum.artist} - ${selectedArtistAlbum.name}` : selectedArtistAlbum.name}
-            >
-              {selectedArtistAlbum.artist ? `${selectedArtistAlbum.artist} - ${selectedArtistAlbum.name}` : selectedArtistAlbum.name}
-            </p>
-            {loadingSelectedArtistAlbumTracks ? (
-              <p className="mt-1 text-xs text-flaque-steel">Loading album tracks...</p>
-            ) : null}
-            {selectedArtistAlbumTracksError ? (
-              <p className="mt-1 text-xs text-red-700">{selectedArtistAlbumTracksError}</p>
-            ) : null}
-          </div>
+        <div className="overflow-hidden rounded-2xl border border-flaque-clay/60 bg-white/75">
+          {loadingSelectedArtistAlbumTracks ? (
+            <p className="px-4 py-3 text-xs text-flaque-steel">Loading album tracks...</p>
+          ) : null}
+          {selectedArtistAlbumTracksError ? (
+            <p className="px-4 py-3 text-xs text-red-700">{selectedArtistAlbumTracksError}</p>
+          ) : null}
 
           <TrackList
             tracks={selectedArtistAlbumTracks}

--- a/frontend/src/components/LibraryWorkspace.tsx
+++ b/frontend/src/components/LibraryWorkspace.tsx
@@ -158,7 +158,7 @@ export function LibraryWorkspace({
   paginatedSentinelRef
 }: LibraryWorkspaceProps): JSX.Element {
   return (
-    <div className="h-full min-h-0 space-y-4 overflow-y-auto">
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto">
       {activeLibrarySection === "playlists" ? (
         playlistDetailId && playlistDetailId.startsWith("for-you:") ? (
           <ForYouPlaylistDetailView


### PR DESCRIPTION
## Summary
- **Artist detail header**: transparent header with large artist photo and name above album list
- **Album detail header**: transparent header with album cover, title, artist, year, track count and duration above tracklist (both in Albums and Artists views)
- **Sharp album covers**: removed rounded corners from album cover images in list and coverflow
- **Borderless album cards**: removed borders from album cards for a cleaner look
- **Coverflow scroll-to-selected**: coverflow auto-scrolls to the currently selected album on mount
- **Coverflow toggle persistence**: List/Coverflow toggle stays visible when an album is selected
- **Coverflow tracklist support**: selecting an album in coverflow mode now shows the tracklist (was list-mode only)
- **Coverflow scroll restoration**: going back from an album tracklist in coverflow mode returns to the same album position
- **Full-height coverflow**: coverflow view fills the entire available screen height

## Test plan
- [x] TypeScript compiles cleanly
- [x] All LibraryAlbumsSection and LibraryArtistsSection tests pass
- [ ] Verify artist detail header renders with photo, name, album/track counts
- [ ] Verify album detail header renders in both Albums and Artists views
- [ ] Verify coverflow centers on selected album when switching from list mode
- [ ] Verify coverflow shows tracklist when album is clicked
- [ ] Verify back button returns to coverflow at the correct scroll position
- [ ] Verify coverflow fills the full viewport height on desktop
- [ ] Verify no regressions in list view mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)