### PR TITLE
refactor: Phase 4 — shared types + backend/frontend test coverage

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@flaque/shared": "*",
     "bcryptjs": "^2.4.3",
     "better-sqlite3": "^11.9.0",
     "cookie-parser": "^1.4.7",

--- a/backend/src/services/activity/trackActivityStore.test.ts
+++ b/backend/src/services/activity/trackActivityStore.test.ts
@@ -1,0 +1,91 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { tmpDir } = vi.hoisted(() => {
+  const fsS = require("node:fs") as typeof import("node:fs");
+  const osM = require("node:os") as typeof import("node:os");
+  const pathM = require("node:path") as typeof import("node:path");
+  return {
+    tmpDir: fsS.mkdtempSync(pathM.join(osM.tmpdir(), "track-activity-test-"))
+  };
+});
+
+vi.mock("../../utils/paths", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../utils/paths")>()),
+  trackActivityLogFilePath: path.join(tmpDir, "track-activity-log.json")
+}));
+
+import type { Track } from "../../types/library";
+import {
+  appendTrackActivityLogEntries,
+  readTrackActivityLog
+} from "./trackActivityStore";
+
+function makeTrack(id: string): Track {
+  return {
+    id,
+    owner: "user-1",
+    path: `/music/${id}.flac`,
+    duration: 200,
+    mimeType: "audio/flac",
+    codec: "flac",
+    tags: { title: id }
+  };
+}
+
+beforeEach(async () => {
+  for (const entry of await fs.readdir(tmpDir)) {
+    await fs.rm(path.join(tmpDir, entry), { recursive: true, force: true });
+  }
+});
+
+afterAll(() => {
+  fsSync.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("trackActivityStore", () => {
+  it("returns an empty log when the file does not exist", async () => {
+    expect(await readTrackActivityLog()).toEqual([]);
+  });
+
+  it("is a no-op when appending zero entries", async () => {
+    await appendTrackActivityLogEntries([]);
+    expect(fsSync.existsSync(path.join(tmpDir, "track-activity-log.json"))).toBe(false);
+  });
+
+  it("appends new entries to the log in order", async () => {
+    await appendTrackActivityLogEntries([makeTrack("a"), makeTrack("b")]);
+    await appendTrackActivityLogEntries([makeTrack("c")]);
+    const log = await readTrackActivityLog();
+    expect(log.map((t) => t.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("caps the log at 10 most recent entries", async () => {
+    const batch = Array.from({ length: 15 }, (_, i) => makeTrack(`t${i}`));
+    await appendTrackActivityLogEntries(batch);
+    const log = await readTrackActivityLog();
+    expect(log).toHaveLength(10);
+    expect(log.map((t) => t.id)).toEqual([
+      "t5", "t6", "t7", "t8", "t9", "t10", "t11", "t12", "t13", "t14"
+    ]);
+  });
+
+  it("drops the oldest entries across multiple appends once past the cap", async () => {
+    await appendTrackActivityLogEntries(
+      Array.from({ length: 8 }, (_, i) => makeTrack(`old-${i}`))
+    );
+    await appendTrackActivityLogEntries([
+      makeTrack("new-0"),
+      makeTrack("new-1"),
+      makeTrack("new-2"),
+      makeTrack("new-3")
+    ]);
+    const log = await readTrackActivityLog();
+    expect(log).toHaveLength(10);
+    expect(log[0]?.id).toBe("old-2");
+    expect(log[9]?.id).toBe("new-3");
+  });
+});

--- a/backend/src/services/genre/genreSynonymService.test.ts
+++ b/backend/src/services/genre/genreSynonymService.test.ts
@@ -1,0 +1,89 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { tmpDir } = vi.hoisted(() => {
+  const fsS = require("node:fs") as typeof import("node:fs");
+  const osM = require("node:os") as typeof import("node:os");
+  const pathM = require("node:path") as typeof import("node:path");
+  return {
+    tmpDir: fsS.mkdtempSync(pathM.join(osM.tmpdir(), "genre-synonyms-test-"))
+  };
+});
+
+vi.mock("../../utils/paths", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../utils/paths")>()),
+  configRoot: tmpDir
+}));
+
+vi.mock("../../utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+import {
+  getSynonyms,
+  normalizeGenreLabel,
+  normalizeGenreLabels,
+  removeSynonym,
+  resetSynonymsToDefaults,
+  setSynonym
+} from "./genreSynonymService";
+
+beforeEach(async () => {
+  for (const entry of await fs.readdir(tmpDir).catch(() => [])) {
+    await fs.rm(path.join(tmpDir, entry), { recursive: true, force: true });
+  }
+  resetSynonymsToDefaults();
+});
+
+afterAll(() => {
+  fsSync.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("genreSynonymService", () => {
+  it("maps a known lowercase alias to its canonical label", () => {
+    expect(normalizeGenreLabel("prog rock")).toBe("Progressive Rock");
+    expect(normalizeGenreLabel("hip hop")).toBe("Hip-Hop");
+  });
+
+  it("is case- and whitespace-insensitive when matching aliases", () => {
+    expect(normalizeGenreLabel("  Prog Rock  ")).toBe("Progressive Rock");
+    expect(normalizeGenreLabel("HIPHOP")).toBe("Hip-Hop");
+  });
+
+  it("returns the trimmed input for unknown genres", () => {
+    expect(normalizeGenreLabel("  Klezmer  ")).toBe("Klezmer");
+  });
+
+  it("deduplicates normalized labels case-insensitively", () => {
+    const result = normalizeGenreLabels(["rap", "Hip-Hop", "hip hop", "Rock"]);
+    expect(result).toEqual(["Hip-Hop", "Rock"]);
+  });
+
+  it("persists a new synonym across calls", () => {
+    setSynonym("vapor", "Vaporwave");
+    expect(normalizeGenreLabel("vapor")).toBe("Vaporwave");
+    expect(getSynonyms()["vapor"]).toBe("Vaporwave");
+  });
+
+  it("removes a synonym and reports whether anything was removed", () => {
+    setSynonym("vapor", "Vaporwave");
+    expect(removeSynonym("vapor")).toBe(true);
+    expect(removeSynonym("vapor")).toBe(false);
+    expect(normalizeGenreLabel("vapor")).toBe("vapor");
+  });
+
+  it("resets synonyms back to defaults", () => {
+    setSynonym("custom-key", "Custom");
+    resetSynonymsToDefaults();
+    expect(getSynonyms()["custom-key"]).toBeUndefined();
+    expect(normalizeGenreLabel("rap")).toBe("Hip-Hop");
+  });
+});

--- a/backend/src/services/playlists/autoPlaylistService.test.ts
+++ b/backend/src/services/playlists/autoPlaylistService.test.ts
@@ -44,7 +44,6 @@ import {
 
 function makeTrack(overrides: Partial<Track> & { id: string }): Track {
   return {
-    id: overrides.id,
     owner: "user-1",
     path: `/music/${overrides.id}.flac`,
     duration: 240,

--- a/backend/src/services/playlists/autoPlaylistService.test.ts
+++ b/backend/src/services/playlists/autoPlaylistService.test.ts
@@ -1,0 +1,191 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { tmpDir } = vi.hoisted(() => {
+  const fsS = require("node:fs") as typeof import("node:fs");
+  const osM = require("node:os") as typeof import("node:os");
+  const pathM = require("node:path") as typeof import("node:path");
+  return {
+    tmpDir: fsS.mkdtempSync(pathM.join(osM.tmpdir(), "auto-playlist-test-"))
+  };
+});
+
+vi.mock("../../utils/paths", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../utils/paths")>()),
+  dataRoot: tmpDir
+}));
+
+vi.mock("../../utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+vi.mock("../genre/genreSynonymService", () => ({
+  normalizeGenreLabel: (g: string) => g
+}));
+
+import type { Track } from "../../types/library";
+import {
+  generateAutoPlaylists,
+  getAutoPlaylistById,
+  getAutoPlaylistConfig,
+  loadAutoPlaylists,
+  needsRegeneration,
+  saveAutoPlaylists,
+  updateAutoPlaylistConfig
+} from "./autoPlaylistService";
+
+function makeTrack(overrides: Partial<Track> & { id: string }): Track {
+  return {
+    id: overrides.id,
+    owner: "user-1",
+    path: `/music/${overrides.id}.flac`,
+    duration: 240,
+    mimeType: "audio/flac",
+    codec: "flac",
+    tags: {},
+    ...overrides
+  };
+}
+
+function tracksForGroup(genre: string, year: number, count: number, prefix: string): Track[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeTrack({
+      id: `${prefix}-${i}`,
+      tags: {
+        title: `${prefix}-${i}`,
+        artist: `artist-${i}`,
+        album: `album-${i}`,
+        genre: [genre],
+        year
+      }
+    })
+  );
+}
+
+beforeEach(async () => {
+  for (const entry of await fs.readdir(tmpDir).catch(() => [])) {
+    await fs.rm(path.join(tmpDir, entry), { recursive: true, force: true });
+  }
+  await fs.mkdir(path.join(tmpDir, "config"), { recursive: true });
+  await fs.mkdir(path.join(tmpDir, "auto-playlists"), { recursive: true });
+});
+
+afterAll(() => {
+  fsSync.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("autoPlaylistService", () => {
+  describe("config", () => {
+    it("returns defaults when no config file exists", async () => {
+      expect(await getAutoPlaylistConfig()).toEqual({
+        maxPlaylists: 0,
+        minTracksPerPlaylist: 8,
+        tracksPerPlaylist: 30
+      });
+    });
+
+    it("persists partial updates and rejects out-of-range values", async () => {
+      await updateAutoPlaylistConfig({ minTracksPerPlaylist: 5, tracksPerPlaylist: 0 });
+      const config = await getAutoPlaylistConfig();
+      expect(config.minTracksPerPlaylist).toBe(5);
+      expect(config.tracksPerPlaylist).toBe(30);
+    });
+  });
+
+  describe("generateAutoPlaylists", () => {
+    it("groups tracks by genre and decade, skipping groups below the minimum", async () => {
+      await updateAutoPlaylistConfig({ minTracksPerPlaylist: 8, tracksPerPlaylist: 20 });
+      const tracks = [
+        ...tracksForGroup("Rock", 1975, 10, "rock70s"),
+        ...tracksForGroup("Jazz", 1965, 3, "jazz60s")
+      ];
+      const playlists = await generateAutoPlaylists(tracks);
+      expect(playlists).toHaveLength(1);
+      expect(playlists[0]?.name).toBe("70s Rock");
+      expect(playlists[0]?.decade).toBe(1970);
+      expect(playlists[0]?.id).toBe("auto:70s-rock");
+    });
+
+    it("ignores tracks missing genre or year", async () => {
+      await updateAutoPlaylistConfig({ minTracksPerPlaylist: 4, tracksPerPlaylist: 10 });
+      const tracks = [
+        ...tracksForGroup("Rock", 1985, 4, "rock80s"),
+        makeTrack({ id: "no-year", tags: { genre: ["Rock"] } }),
+        makeTrack({ id: "no-genre", tags: { year: 1985 } })
+      ];
+      const playlists = await generateAutoPlaylists(tracks);
+      expect(playlists).toHaveLength(1);
+      expect(playlists[0]?.trackIds).toHaveLength(4);
+      expect(playlists[0]?.trackIds).not.toContain("no-year");
+      expect(playlists[0]?.trackIds).not.toContain("no-genre");
+    });
+
+    it("caps the number of playlists at maxPlaylists when positive", async () => {
+      await updateAutoPlaylistConfig({
+        maxPlaylists: 2,
+        minTracksPerPlaylist: 3,
+        tracksPerPlaylist: 10
+      });
+      const tracks = [
+        ...tracksForGroup("Rock", 1975, 10, "r70"),
+        ...tracksForGroup("Jazz", 1965, 8, "j60"),
+        ...tracksForGroup("Funk", 1985, 5, "f80")
+      ];
+      const playlists = await generateAutoPlaylists(tracks);
+      expect(playlists).toHaveLength(2);
+    });
+
+    it("caps each playlist at tracksPerPlaylist", async () => {
+      await updateAutoPlaylistConfig({ minTracksPerPlaylist: 5, tracksPerPlaylist: 5 });
+      const tracks = tracksForGroup("Rock", 1975, 20, "r70");
+      const playlists = await generateAutoPlaylists(tracks);
+      expect(playlists[0]?.trackIds).toHaveLength(5);
+    });
+  });
+
+  describe("storage round-trip", () => {
+    it("persists playlists to disk and loads them back", async () => {
+      await updateAutoPlaylistConfig({ minTracksPerPlaylist: 4, tracksPerPlaylist: 10 });
+      const tracks = tracksForGroup("Rock", 1975, 8, "r70");
+      const generated = await generateAutoPlaylists(tracks);
+      await saveAutoPlaylists(generated);
+
+      const loaded = await loadAutoPlaylists();
+      expect(loaded.map((p) => p.id).sort()).toEqual(generated.map((p) => p.id).sort());
+
+      const single = await getAutoPlaylistById(generated[0]!.id);
+      expect(single?.name).toBe(generated[0]!.name);
+    });
+
+    it("replaces existing playlists on subsequent saves", async () => {
+      await updateAutoPlaylistConfig({ minTracksPerPlaylist: 4, tracksPerPlaylist: 10 });
+      const first = await generateAutoPlaylists(tracksForGroup("Rock", 1975, 8, "r"));
+      await saveAutoPlaylists(first);
+      const second = await generateAutoPlaylists(tracksForGroup("Jazz", 1965, 8, "j"));
+      await saveAutoPlaylists(second);
+
+      const loaded = await loadAutoPlaylists();
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0]?.genre).toBe("Jazz");
+    });
+  });
+
+  describe("needsRegeneration", () => {
+    it("returns true when no meta file exists", async () => {
+      expect(await needsRegeneration()).toBe(true);
+    });
+
+    it("returns false immediately after a save", async () => {
+      await saveAutoPlaylists([]);
+      expect(await needsRegeneration()).toBe(false);
+    });
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@flaque/shared": "*",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/src/components/PlaylistsSection.test.tsx
+++ b/frontend/src/components/PlaylistsSection.test.tsx
@@ -1,0 +1,85 @@
+/* @vitest-environment happy-dom */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./AutoPlaylistDetailView", () => ({
+  AutoPlaylistDetailView: ({ playlistId }: { playlistId: string }) => (
+    <div data-testid="auto-detail">{playlistId}</div>
+  )
+}));
+
+vi.mock("./ForYouPlaylistDetailView", () => ({
+  ForYouPlaylistDetailView: ({ playlistId }: { playlistId: string }) => (
+    <div data-testid="foryou-detail">{playlistId}</div>
+  )
+}));
+
+vi.mock("./PlaylistDetailView", () => ({
+  PlaylistDetailView: ({ playlistId }: { playlistId: string }) => (
+    <div data-testid="playlist-detail">{playlistId}</div>
+  )
+}));
+
+vi.mock("./LibraryPlaylistSection", () => ({
+  LibraryPlaylistSection: () => <div data-testid="library-playlists" />
+}));
+
+import type { Track, User } from "../types";
+import { PlaylistsSection, type PlaylistsSectionProps } from "./PlaylistsSection";
+
+const USER: User = {
+  id: "user-1",
+  username: "alice",
+  email: "a@b.c",
+  role: "user"
+};
+
+function baseProps(overrides: Partial<PlaylistsSectionProps> = {}): PlaylistsSectionProps {
+  return {
+    playlistDetailId: null,
+    onPlaylistDetailNavigate: vi.fn(),
+    availablePlaylists: [],
+    manageablePlaylists: [],
+    ownerNameById: {},
+    allTracksById: new Map<string, Track>(),
+    user: USER,
+    onCreatePlaylist: vi.fn(),
+    onPlayPlaylist: vi.fn(),
+    onPatchPlaylist: vi.fn(),
+    onDeletePlaylist: vi.fn(),
+    onHeartPlaylist: vi.fn(),
+    onReportPlaylistListen: vi.fn(),
+    autoPlaylists: [],
+    loadingAutoPlaylists: false,
+    forYouPlaylists: [],
+    loadingForYouPlaylists: false,
+    onDismissForYouPlaylist: vi.fn(),
+    ...overrides
+  };
+}
+
+describe("PlaylistsSection", () => {
+  it("renders the library section when no detail id is selected", () => {
+    render(<PlaylistsSection {...baseProps()} />);
+    expect(screen.getByTestId("library-playlists")).toBeTruthy();
+    expect(screen.queryByTestId("auto-detail")).toBeNull();
+    expect(screen.queryByTestId("foryou-detail")).toBeNull();
+    expect(screen.queryByTestId("playlist-detail")).toBeNull();
+  });
+
+  it("routes for-you ids to ForYouPlaylistDetailView", () => {
+    render(<PlaylistsSection {...baseProps({ playlistDetailId: "for-you:pop" })} />);
+    expect(screen.getByTestId("foryou-detail").textContent).toBe("for-you:pop");
+  });
+
+  it("routes auto ids to AutoPlaylistDetailView", () => {
+    render(<PlaylistsSection {...baseProps({ playlistDetailId: "auto:70s-rock" })} />);
+    expect(screen.getByTestId("auto-detail").textContent).toBe("auto:70s-rock");
+  });
+
+  it("routes any other id to the regular PlaylistDetailView", () => {
+    render(<PlaylistsSection {...baseProps({ playlistDetailId: "user-playlist-42" })} />);
+    expect(screen.getByTestId("playlist-detail").textContent).toBe("user-playlist-42");
+  });
+});

--- a/frontend/src/hooks/useAutoPlaylists.test.tsx
+++ b/frontend/src/hooks/useAutoPlaylists.test.tsx
@@ -1,0 +1,48 @@
+/* @vitest-environment happy-dom */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getAutoPlaylistsMock = vi.fn();
+
+vi.mock("../api", () => ({
+  getAutoPlaylists: (...args: unknown[]) => getAutoPlaylistsMock(...args)
+}));
+
+import { useAutoPlaylists } from "./useAutoPlaylists";
+
+beforeEach(() => {
+  getAutoPlaylistsMock.mockReset();
+});
+
+describe("useAutoPlaylists", () => {
+  it("starts loading=true and returns an empty list until the fetch resolves", async () => {
+    getAutoPlaylistsMock.mockResolvedValueOnce([{ id: "a", name: "Auto A" }]);
+    const { result } = renderHook(() => useAutoPlaylists());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.autoPlaylists).toEqual([]);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.autoPlaylists).toEqual([{ id: "a", name: "Auto A" }]);
+  });
+
+  it("re-fetches when refresh() is called", async () => {
+    getAutoPlaylistsMock
+      .mockResolvedValueOnce([{ id: "first" }])
+      .mockResolvedValueOnce([{ id: "second" }]);
+
+    const { result } = renderHook(() => useAutoPlaylists());
+    await waitFor(() =>
+      expect(result.current.autoPlaylists).toEqual([{ id: "first" }])
+    );
+
+    await act(async () => {
+      result.current.refresh();
+    });
+    await waitFor(() =>
+      expect(result.current.autoPlaylists).toEqual([{ id: "second" }])
+    );
+    expect(getAutoPlaylistsMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/hooks/useForYouPlaylists.test.tsx
+++ b/frontend/src/hooks/useForYouPlaylists.test.tsx
@@ -1,0 +1,68 @@
+/* @vitest-environment happy-dom */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getForYouPlaylistsMock = vi.fn();
+const dismissForYouPlaylistMock = vi.fn();
+
+vi.mock("../api", () => ({
+  getForYouPlaylists: (...args: unknown[]) => getForYouPlaylistsMock(...args),
+  dismissForYouPlaylist: (...args: unknown[]) => dismissForYouPlaylistMock(...args)
+}));
+
+import { useForYouPlaylists } from "./useForYouPlaylists";
+
+beforeEach(() => {
+  getForYouPlaylistsMock.mockReset();
+  dismissForYouPlaylistMock.mockReset();
+});
+
+describe("useForYouPlaylists", () => {
+  it("resolves the fetcher result and exposes it via forYouPlaylists", async () => {
+    getForYouPlaylistsMock.mockResolvedValueOnce([
+      { id: "p1", seedArtist: "A" },
+      { id: "p2", seedArtist: "B" }
+    ]);
+    const { result } = renderHook(() => useForYouPlaylists());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.forYouPlaylists.map((p) => p.id)).toEqual(["p1", "p2"]);
+  });
+
+  it("optimistically removes the playlist when dismiss succeeds", async () => {
+    getForYouPlaylistsMock.mockResolvedValueOnce([
+      { id: "p1", seedArtist: "A" },
+      { id: "p2", seedArtist: "B" }
+    ]);
+    dismissForYouPlaylistMock.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useForYouPlaylists());
+    await waitFor(() => expect(result.current.forYouPlaylists).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.dismiss("p1");
+    });
+
+    expect(result.current.forYouPlaylists.map((p) => p.id)).toEqual(["p2"]);
+    expect(dismissForYouPlaylistMock).toHaveBeenCalledWith("p1");
+  });
+
+  it("propagates errors from the dismiss API and leaves the list untouched", async () => {
+    getForYouPlaylistsMock.mockResolvedValueOnce([{ id: "p1" }]);
+    dismissForYouPlaylistMock.mockRejectedValueOnce(new Error("nope"));
+
+    const { result } = renderHook(() => useForYouPlaylists());
+    await waitFor(() => expect(result.current.forYouPlaylists).toHaveLength(1));
+
+    await expect(
+      (async () => {
+        await act(async () => {
+          await result.current.dismiss("p1");
+        });
+      })()
+    ).rejects.toThrow("nope");
+
+    expect(result.current.forYouPlaylists.map((p) => p.id)).toEqual(["p1"]);
+  });
+});

--- a/frontend/src/hooks/useRecentlyUploaded.test.tsx
+++ b/frontend/src/hooks/useRecentlyUploaded.test.tsx
@@ -1,0 +1,79 @@
+/* @vitest-environment happy-dom */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getTracksMock = vi.fn();
+
+vi.mock("../api", () => ({
+  getTracks: (...args: unknown[]) => getTracksMock(...args)
+}));
+
+import type { User } from "../types";
+import { useRecentlyUploaded } from "./useRecentlyUploaded";
+
+const USER: User = {
+  id: "user-1",
+  username: "alice",
+  email: "alice@example.com",
+  role: "user"
+};
+
+beforeEach(() => {
+  getTracksMock.mockReset();
+});
+
+describe("useRecentlyUploaded", () => {
+  it("does not fetch when no user is signed in", async () => {
+    const { result } = renderHook(() =>
+      useRecentlyUploaded({ user: null })
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.tracks).toEqual([]);
+    expect(getTracksMock).not.toHaveBeenCalled();
+  });
+
+  it("requests tracks sorted by addedAt desc with the 7d window by default", async () => {
+    getTracksMock.mockResolvedValueOnce({
+      tracks: [{ id: "t1" }, { id: "t2" }]
+    });
+
+    const { result } = renderHook(() => useRecentlyUploaded({ user: USER }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const call = getTracksMock.mock.calls[0]?.[0];
+    expect(call).toMatchObject({
+      sortBy: "addedAt",
+      sortDir: "desc",
+      limit: 12
+    });
+    expect(typeof call.addedAfter).toBe("string");
+    expect(result.current.period).toBe("7d");
+    expect(result.current.tracks.map((t) => t.id)).toEqual(["t1", "t2"]);
+  });
+
+  it("re-fetches with a wider addedAfter window when period flips to 30d", async () => {
+    getTracksMock.mockResolvedValue({ tracks: [] });
+    const { result } = renderHook(() => useRecentlyUploaded({ user: USER }));
+    await waitFor(() => expect(getTracksMock).toHaveBeenCalledTimes(1));
+    const first = getTracksMock.mock.calls[0]![0].addedAfter as string;
+
+    await act(async () => {
+      result.current.setPeriod("30d");
+    });
+    await waitFor(() => expect(getTracksMock).toHaveBeenCalledTimes(2));
+
+    const second = getTracksMock.mock.calls[1]![0].addedAfter as string;
+    expect(new Date(second).getTime()).toBeLessThan(new Date(first).getTime());
+  });
+
+  it("forwards the ownerFilter argument to the API call", async () => {
+    getTracksMock.mockResolvedValueOnce({ tracks: [] });
+    renderHook(() =>
+      useRecentlyUploaded({ user: USER, ownerFilter: "user-2" })
+    );
+    await waitFor(() => expect(getTracksMock).toHaveBeenCalled());
+    expect(getTracksMock.mock.calls[0]?.[0].owner).toBe("user-2");
+  });
+});

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,3 +1,13 @@
+import type { Playlist, Track } from "@flaque/shared";
+
+export type {
+  Playlist,
+  PlaylistVisibility,
+  Track,
+  TrackTagExtraValue,
+  TrackTags
+} from "@flaque/shared";
+
 export type User = {
   id: string;
   username: string;
@@ -15,52 +25,6 @@ export type UserSession = {
   ipAddress: string | null;
   label: string | null;
   current: boolean;
-};
-
-export type TrackTagExtraValue =
-  | string
-  | number
-  | boolean
-  | Array<string | number | boolean>;
-
-export type TrackTags = {
-  title?: string;
-  artist?: string;
-  artists?: string[];
-  album?: string;
-  albumArtist?: string;
-  year?: number;
-  date?: string;
-  originalDate?: string;
-  genre?: string[];
-  trackNumber?: number;
-  trackTotal?: number;
-  discNumber?: number;
-  discTotal?: number;
-  composer?: string[];
-  lyricist?: string[];
-  comment?: string[];
-  bpm?: number;
-  isrc?: string[];
-  label?: string[];
-  copyright?: string;
-  language?: string;
-  encodedBy?: string;
-  extra?: Record<string, TrackTagExtraValue>;
-};
-
-export type Track = {
-  id: string;
-  owner: string;
-  path: string;
-  duration: number;
-  mimeType: string;
-  codec: string;
-  bitrate?: number;
-  sampleRate?: number;
-  tags: TrackTags;
-  cover?: string;
-  addedAt?: string;
 };
 
 export type ArtistEntry = {
@@ -83,23 +47,6 @@ export type AlbumEntry = {
   totalDuration?: number;
   cover?: string;
   previewTrackId?: string;
-};
-
-export type PlaylistVisibility = "public" | "private";
-
-export type Playlist = {
-  id: string;
-  name: string;
-  authorId: string;
-  visibility: PlaylistVisibility;
-  trackIds: string[];
-  trackCount?: number;
-  description: string;
-  cover: string | null;
-  hearts: string[];
-  heartCount: number;
-  listenCount: number;
-  collaborators: string[];
 };
 
 export type LibraryResponse = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "flaque",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flaque",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "workspaces": [
+        "shared",
         "backend",
         "frontend"
       ],
@@ -18,8 +19,9 @@
     },
     "backend": {
       "name": "flaque-backend",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "dependencies": {
+        "@flaque/shared": "*",
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.9.0",
         "cookie-parser": "^1.4.7",
@@ -49,11 +51,12 @@
     },
     "frontend": {
       "name": "flaque-frontend",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@flaque/shared": "*",
         "music-metadata": "^10.9.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -917,6 +920,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@flaque/shared": {
+      "resolved": "shared",
+      "link": true
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
@@ -6827,6 +6834,10 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "shared": {
+      "name": "@flaque/shared",
+      "version": "0.3.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.1",
   "private": true,
   "workspaces": [
+    "shared",
     "backend",
     "frontend"
   ],

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@flaque/shared",
+  "version": "0.3.1",
+  "private": true,
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "sideEffects": false
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -5,4 +5,4 @@ export type {
   Track,
   TrackTagExtraValue,
   TrackTags
-} from "@flaque/shared";
+} from "./library";

--- a/shared/src/library.ts
+++ b/shared/src/library.ts
@@ -1,0 +1,73 @@
+export type TrackTagExtraValue =
+  | string
+  | number
+  | boolean
+  | Array<string | number | boolean>;
+
+export type TrackTags = {
+  title?: string;
+  artist?: string;
+  artists?: string[];
+  album?: string;
+  albumArtist?: string;
+  year?: number;
+  date?: string;
+  originalDate?: string;
+  genre?: string[];
+  trackNumber?: number;
+  trackTotal?: number;
+  discNumber?: number;
+  discTotal?: number;
+  composer?: string[];
+  lyricist?: string[];
+  comment?: string[];
+  bpm?: number;
+  isrc?: string[];
+  label?: string[];
+  copyright?: string;
+  language?: string;
+  encodedBy?: string;
+  extra?: Record<string, TrackTagExtraValue>;
+};
+
+export type Track = {
+  id: string;
+  owner: string;
+  path: string;
+  duration: number;
+  mimeType: string;
+  codec: string;
+  bitrate?: number;
+  sampleRate?: number;
+  tags: TrackTags;
+  cover?: string;
+  addedAt?: string;
+};
+
+export type PlaylistVisibility = "public" | "private";
+
+export type Playlist = {
+  id: string;
+  name: string;
+  authorId: string;
+  visibility: PlaylistVisibility;
+  trackIds: string[];
+  trackCount?: number;
+  description: string;
+  cover: string | null;
+  hearts: string[];
+  heartCount: number;
+  listenCount: number;
+  /**
+   * Collaborators - array of user IDs who can collaborate on this playlist.
+   * Special value "everyone" indicates all authenticated users can collaborate.
+   */
+  collaborators: string[];
+};
+
+export type LibraryIndex = {
+  generatedAt: string;
+  totalTracks: number;
+  tracks: Track[];
+  playlists?: Playlist[];
+};


### PR DESCRIPTION
## Summary

Phase 4 of the refactoring roadmap: **testing & type safety**.

- **4.3 — shared types workspace**: new `@flaque/shared` workspace package holds `Track`, `TrackTags`, `TrackTagExtraValue`, `Playlist`, `PlaylistVisibility`, and `LibraryIndex`. Backend and frontend now import from a single source of truth instead of maintaining drifting copies. `Playlist` gained the optional `trackCount?: number` (previously frontend-only) to align the shape across sides. Pure-types package — no build step needed, TypeScript erases the imports.
- **4.1 — backend coverage**: new tests for `trackActivityStore`, `genreSynonymService`, and `autoPlaylistService` (the three services that had no coverage). Backend: **300 → 322 tests**.
- **4.2 — frontend coverage**: new tests for the recently-migrated `useAutoPlaylists`, `useForYouPlaylists`, `useRecentlyUploaded` hooks, plus a smoke test for `PlaylistsSection`'s detail-route switching. Frontend: **138 → 151 tests**.

## Test plan
- [x] `npm run build --workspace backend` — typecheck passes
- [x] `npx tsc -p tsconfig.json --noEmit` in `frontend/` — typecheck passes
- [x] Backend suite: 322/322 passing
- [x] Frontend suite: 151/151 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
