### PR TITLE
refactor: roadmap tail — docker fix, ArtistCard, scanner tests

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,12 +5,15 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY backend/package.json backend/package.json
 COPY frontend/package.json frontend/package.json
+COPY shared/package.json shared/package.json
 
 RUN npm ci
 
+COPY shared shared
 COPY backend backend
 
-RUN npm run build --workspace backend
+RUN npm run build --workspace backend \
+  && npm prune --omit=dev --workspaces --include-workspace-root
 
 
 FROM node:20-bookworm-slim AS runtime
@@ -27,6 +30,7 @@ ENV DATA_ROOT=/app/data
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/package-lock.json ./package-lock.json
 COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/shared ./shared
 COPY --from=build /app/backend/package.json ./backend/package.json
 COPY --from=build /app/backend/dist ./backend/dist
 

--- a/backend/src/services/scanner/changeDetector.test.ts
+++ b/backend/src/services/scanner/changeDetector.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import type { Track } from "../../types/library";
+import { classifyTrackChanges } from "./changeDetector";
+import type { FileSystemTrackState, ScannerStateSnapshot } from "./scannerState";
+
+function makeFsState(overrides: Partial<FileSystemTrackState> & { trackId: string }): FileSystemTrackState {
+  return {
+    ownerId: "owner",
+    filePath: `/music/${overrides.trackId}.mp3`,
+    relativePath: `${overrides.trackId}.mp3`,
+    size: 1000,
+    mtimeMs: 1,
+    identity: "default-identity",
+    ...overrides
+  };
+}
+
+function makeTrack(id: string): Track {
+  return {
+    id,
+    owner: "owner",
+    path: `${id}.mp3`,
+    duration: 10,
+    mimeType: "audio/mpeg",
+    codec: "mp3",
+    tags: { title: id }
+  };
+}
+
+function makeSnapshot(
+  entries: Array<{ trackId: string; identity: string }>
+): ScannerStateSnapshot {
+  return {
+    version: 1,
+    tracks: entries.map(({ trackId, identity }) => ({
+      trackId,
+      path: `${trackId}.mp3`,
+      size: 1000,
+      mtimeMs: 1,
+      identity
+    }))
+  };
+}
+
+describe("classifyTrackChanges", () => {
+  it("returns empty partitions when inputs are empty", () => {
+    const result = classifyTrackChanges([], [], { version: 1, tracks: [] });
+
+    expect(result).toEqual({ changed: [], unchanged: [], deletedTrackIds: [] });
+  });
+
+  it("marks a track as unchanged when identity matches prior state", () => {
+    const state = makeFsState({ trackId: "a", identity: "v1" });
+    const previousTrack = makeTrack("a");
+    const snapshot = makeSnapshot([{ trackId: "a", identity: "v1" }]);
+
+    const result = classifyTrackChanges([state], [previousTrack], snapshot);
+
+    expect(result.changed).toEqual([]);
+    expect(result.deletedTrackIds).toEqual([]);
+    expect(result.unchanged).toEqual([{ state, track: previousTrack }]);
+  });
+
+  it("marks a track as changed when identity differs", () => {
+    const state = makeFsState({ trackId: "a", identity: "v2" });
+    const previousTrack = makeTrack("a");
+    const snapshot = makeSnapshot([{ trackId: "a", identity: "v1" }]);
+
+    const result = classifyTrackChanges([state], [previousTrack], snapshot);
+
+    expect(result.changed).toEqual([state]);
+    expect(result.unchanged).toEqual([]);
+    expect(result.deletedTrackIds).toEqual([]);
+  });
+
+  it("treats a track with no prior state as changed (new file)", () => {
+    const state = makeFsState({ trackId: "new", identity: "v1" });
+
+    const result = classifyTrackChanges([state], [], { version: 1, tracks: [] });
+
+    expect(result.changed).toEqual([state]);
+    expect(result.unchanged).toEqual([]);
+    expect(result.deletedTrackIds).toEqual([]);
+  });
+
+  it("treats a track with prior state but missing track record as changed", () => {
+    const state = makeFsState({ trackId: "a", identity: "v1" });
+    const snapshot = makeSnapshot([{ trackId: "a", identity: "v1" }]);
+
+    const result = classifyTrackChanges([state], [], snapshot);
+
+    expect(result.changed).toEqual([state]);
+    expect(result.unchanged).toEqual([]);
+  });
+
+  it("reports previous tracks absent from the filesystem as deleted", () => {
+    const previousTracks = [makeTrack("a"), makeTrack("b"), makeTrack("c")];
+    const snapshot = makeSnapshot([
+      { trackId: "a", identity: "v1" },
+      { trackId: "b", identity: "v1" },
+      { trackId: "c", identity: "v1" }
+    ]);
+    const currentState = [makeFsState({ trackId: "a", identity: "v1" })];
+
+    const result = classifyTrackChanges(currentState, previousTracks, snapshot);
+
+    expect(result.unchanged.map((u) => u.track.id)).toEqual(["a"]);
+    expect(result.changed).toEqual([]);
+    expect(result.deletedTrackIds.sort()).toEqual(["b", "c"]);
+  });
+
+  it("partitions a mixed batch into changed, unchanged, and deleted", () => {
+    const unchangedState = makeFsState({ trackId: "keep", identity: "v1" });
+    const modifiedState = makeFsState({ trackId: "edit", identity: "v2" });
+    const newState = makeFsState({ trackId: "new", identity: "v1" });
+
+    const previousTracks = [makeTrack("keep"), makeTrack("edit"), makeTrack("gone")];
+    const snapshot = makeSnapshot([
+      { trackId: "keep", identity: "v1" },
+      { trackId: "edit", identity: "v1" },
+      { trackId: "gone", identity: "v1" }
+    ]);
+
+    const result = classifyTrackChanges(
+      [unchangedState, modifiedState, newState],
+      previousTracks,
+      snapshot
+    );
+
+    expect(result.unchanged.map((u) => u.state.trackId)).toEqual(["keep"]);
+    expect(result.changed.map((s) => s.trackId)).toEqual(["edit", "new"]);
+    expect(result.deletedTrackIds).toEqual(["gone"]);
+  });
+});

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,9 +5,11 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY backend/package.json backend/package.json
 COPY frontend/package.json frontend/package.json
+COPY shared/package.json shared/package.json
 
 RUN npm ci
 
+COPY shared shared
 COPY frontend frontend
 
 RUN npm run build --workspace frontend

--- a/frontend/src/components/ArtistCard.tsx
+++ b/frontend/src/components/ArtistCard.tsx
@@ -1,0 +1,43 @@
+import { memo, useCallback } from "react";
+
+import type { ArtistEntry } from "../types";
+import { defaultCoverImage, getArtistPhotoSrc } from "../utils/covers";
+import { formatDurationHuman } from "../utils/format";
+
+type ArtistCardProps = {
+  artist: ArtistEntry;
+  onSelect: (artist: ArtistEntry) => void;
+};
+
+export const ArtistCard = memo(function ArtistCard({ artist, onSelect }: ArtistCardProps): JSX.Element {
+  const artistPhoto = getArtistPhotoSrc(artist);
+  const handleClick = useCallback(() => onSelect(artist), [artist, onSelect]);
+
+  return (
+    <button
+      className="aspect-square rounded-xl bg-white/85 p-3 text-center transition hover:bg-flaque-cream"
+      title={artist.name}
+      type="button"
+      onClick={handleClick}
+    >
+      <img
+        className="mx-auto h-full max-h-44 w-full max-w-44 rounded-full border border-flaque-clay/50 object-cover"
+        src={artistPhoto}
+        alt={`Artwork for ${artist.name}`}
+        onError={(event) => {
+          event.currentTarget.src = defaultCoverImage;
+        }}
+      />
+      <div className="mt-2 min-w-0">
+        <p className="truncate text-sm font-medium text-flaque-ink">{artist.name}</p>
+        <p className="text-xs text-flaque-steel">
+          {artist.albumCount} album{artist.albumCount !== 1 ? "s" : ""}
+          {" · "}
+          {artist.trackCount} track{artist.trackCount !== 1 ? "s" : ""}
+          {" · "}
+          {formatDurationHuman(artist.totalDuration)}
+        </p>
+      </div>
+    </button>
+  );
+});

--- a/frontend/src/components/LibraryArtistsSection.tsx
+++ b/frontend/src/components/LibraryArtistsSection.tsx
@@ -4,6 +4,7 @@ import type { AlbumEntry, ArtistEntry, Playlist, Track } from "../types";
 import { defaultCoverImage, getAlbumCoverSrc, getArtistPhotoSrc } from "../utils/covers";
 import { formatDurationHuman } from "../utils/format";
 import { AlbumList } from "./AlbumList";
+import { ArtistCard } from "./ArtistCard";
 import { TrackList } from "./TrackList";
 
 export type LibraryArtistsSectionProps = {
@@ -212,38 +213,13 @@ export function LibraryArtistsSection({
                   <div className="flex-1 h-[2px] border-t-[2px] border-flaque-clay/40" style={{ maskImage: "linear-gradient(to right, black 50%, transparent)", WebkitMaskImage: "linear-gradient(to right, black 50%, transparent)" }} />
                 </div>
                 <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-                  {grouped.get(letter)!.map((artist) => {
-                    const artistPhoto = getArtistPhotoSrc(artist);
-
-                    return (
-                      <button
-                        key={artist.name}
-                        className="aspect-square rounded-xl bg-white/85 p-3 text-center transition hover:bg-flaque-cream"
-                        title={artist.name}
-                        type="button"
-                        onClick={() => onArtistSelect(artist)}
-                      >
-                        <img
-                          className="mx-auto h-full max-h-44 w-full max-w-44 rounded-full border border-flaque-clay/50 object-cover"
-                          src={artistPhoto}
-                          alt={`Artwork for ${artist.name}`}
-                          onError={(event) => {
-                            event.currentTarget.src = defaultCoverImage;
-                          }}
-                        />
-                        <div className="mt-2 min-w-0">
-                          <p className="truncate text-sm font-medium text-flaque-ink">{artist.name}</p>
-                          <p className="text-xs text-flaque-steel">
-                            {artist.albumCount} album{artist.albumCount !== 1 ? "s" : ""}
-                            {" · "}
-                            {artist.trackCount} track{artist.trackCount !== 1 ? "s" : ""}
-                            {" · "}
-                            {formatDurationHuman(artist.totalDuration)}
-                          </p>
-                        </div>
-                      </button>
-                    );
-                  })}
+                  {grouped.get(letter)!.map((artist) => (
+                    <ArtistCard
+                      key={artist.name}
+                      artist={artist}
+                      onSelect={onArtistSelect}
+                    />
+                  ))}
                 </div>
                 {idx < sortedKeys.length - 1 && <div className="mb-4" />}
               </div>


### PR DESCRIPTION
## Summary

Cleans up the three items genuinely missed across the earlier roadmap PRs (#148–#152).

- **fix(docker)**: Phase 4.3's `@flaque/shared` workspace broke both Dockerfiles — `npm ci` failed because `shared/package.json` was never copied, and the backend build never copied `shared/` sources. Both images now build. Backend runtime also runs `npm prune --omit=dev --workspaces --include-workspace-root` so dev deps (vitest, vite, etc.) don't ship in the production image.
- **refactor(ArtistCard)**: Finishes Phase 5.2 by extracting the artist grid-cell out of `LibraryArtistsSection.tsx` into a `React.memo`'d `ArtistCard` with a `useCallback`-stabilized click handler — mirroring the AlbumCard / TrackList pattern already in place.
- **test(changeDetector)**: Adds direct unit tests for `classifyTrackChanges`, the pure diff helper from the Phase 1.3 scanner decomposition. Previously it was only exercised indirectly via `scannerService.test.ts`.

## Test plan

- [x] `npx tsc -p tsconfig.json --noEmit` in frontend — clean
- [x] `npx vitest run` in frontend — 151/151
- [x] `npx vitest run` in backend — 329/329
- [x] `docker build -f backend/Dockerfile .` — succeeds, container boots and serves on :4000
- [x] `docker build -f frontend/Dockerfile .` — succeeds (nginx static image)
- [ ] Manual smoke: artist grid renders identically after ArtistCard extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)