### PR TITLE
fix: user-reported bugs (symlinks, library filter leaks, enrichment)

### DIFF
--- a/backend/src/services/genre/genreEnrichmentService.ts
+++ b/backend/src/services/genre/genreEnrichmentService.ts
@@ -58,6 +58,11 @@ export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<v
     return;
   }
 
+  // Refresh the index so tracks added since the last scan (including files
+  // dropped directly into storage rather than uploaded via the UI) are
+  // considered.
+  await indexStore.rebuild();
+
   const tracks = indexStore.getTracks();
   const tracksWithoutGenre = tracks.filter(
     (t) => !t.tags.genre || t.tags.genre.length === 0
@@ -65,6 +70,14 @@ export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<v
 
   if (tracksWithoutGenre.length === 0) {
     log.info("All tracks have genre metadata, nothing to enrich");
+    status = {
+      running: false,
+      total: 0,
+      processed: 0,
+      enriched: 0,
+      failed: 0,
+      startedAt: new Date().toISOString()
+    };
     return;
   }
 

--- a/backend/src/services/scanner/filesystemCollector.ts
+++ b/backend/src/services/scanner/filesystemCollector.ts
@@ -82,12 +82,26 @@ async function sortRootMusicFiles(
 async function collectAudioFiles(rootDir: string): Promise<string[]> {
   const queue = [rootDir];
   const files: string[] = [];
+  const visitedDirs = new Set<string>();
 
   while (queue.length > 0) {
     const current = queue.pop();
     if (!current) {
       continue;
     }
+
+    // Resolve through symlinks so loops can't traverse forever.
+    let realDir: string;
+    try {
+      realDir = await fs.realpath(current);
+    } catch {
+      continue;
+    }
+
+    if (visitedDirs.has(realDir)) {
+      continue;
+    }
+    visitedDirs.add(realDir);
 
     let entries: Dirent[] = [];
     try {
@@ -97,17 +111,26 @@ async function collectAudioFiles(rootDir: string): Promise<string[]> {
     }
 
     for (const entry of entries) {
+      const absoluteEntryPath = path.join(current, entry.name);
+
+      let isDirectory = entry.isDirectory();
+      let isFile = entry.isFile();
       if (entry.isSymbolicLink()) {
-        continue;
+        try {
+          const resolved = await fs.stat(absoluteEntryPath);
+          isDirectory = resolved.isDirectory();
+          isFile = resolved.isFile();
+        } catch {
+          continue;
+        }
       }
 
-      const absoluteEntryPath = path.join(current, entry.name);
-      if (entry.isDirectory()) {
+      if (isDirectory) {
         queue.push(absoluteEntryPath);
         continue;
       }
 
-      if (entry.isFile() && isSupportedAudioFile(absoluteEntryPath)) {
+      if (isFile && isSupportedAudioFile(absoluteEntryPath)) {
         files.push(absoluteEntryPath);
       }
     }

--- a/backend/src/services/scanner/scannerService.test.ts
+++ b/backend/src/services/scanner/scannerService.test.ts
@@ -226,6 +226,29 @@ describe("scanFilesystemLibrary incremental mode", () => {
     expect(result.totalTracks).toBe(1);
   });
 
+  it("traverses symlinked directories inside the music root", async () => {
+    // External directory (e.g. a bigger disk) the user has symlinked in.
+    const externalDir = await fs.mkdtemp(path.join(os.tmpdir(), "flaque-external-"));
+    try {
+      const externalAlbumDir = path.join(externalDir, "album_b");
+      await fs.mkdir(externalAlbumDir, { recursive: true });
+      await fs.writeFile(path.join(externalAlbumDir, "track-b.mp3"), "bbbb", "utf8");
+
+      await writeAudioFile("artist_a/album_a/track-a.mp3", "aaa");
+
+      const linkPath = path.join(getSharedMusicRoot(), "artist_b");
+      await fs.symlink(externalDir, linkPath, "dir");
+
+      const { scanFilesystemLibrary } = await import("./scannerService");
+      const result = await scanFilesystemLibrary({ mode: "full" });
+
+      expect(result.totalTracks).toBe(2);
+      expect(result.tracks.map((track) => track.tags.title).sort()).toEqual(["track-a", "track-b"]);
+    } finally {
+      await fs.rm(externalDir, { recursive: true, force: true });
+    }
+  });
+
   it("fetches album cover when album-cover.jpg is missing", async () => {
     await writeAudioFile("artist_a/album_a/track-a.mp3", "aaa");
 

--- a/frontend/src/hooks/useLibraryData.ts
+++ b/frontend/src/hooks/useLibraryData.ts
@@ -195,9 +195,7 @@ export function useLibraryData({
     setLoadingLibraryArtists(true);
     setLibraryMetadataError(null);
 
-    getArtists({
-      q: filters.q
-    })
+    getArtists({})
       .then((artists) => {
         if (artistsRequestIdRef.current !== requestId) {
           return;
@@ -217,7 +215,7 @@ export function useLibraryData({
           setLoadingLibraryArtists(false);
         }
       });
-  }, [activeLibrarySection, activeView, filters.q, user]);
+  }, [activeLibrarySection, activeView, user]);
 
   useEffect(() => {
     if (activeLibrarySection !== "artists") {
@@ -251,9 +249,7 @@ export function useLibraryData({
     setLoadingArtistAlbums(true);
     setLibraryMetadataError(null);
 
-    getArtistAlbums(selectedArtist.normalizedName, {
-      q: filters.q
-    })
+    getArtistAlbums(selectedArtist.normalizedName, {})
       .then((albums) => {
         if (artistAlbumsRequestIdRef.current !== requestId) {
           return;
@@ -285,7 +281,7 @@ export function useLibraryData({
           setLoadingArtistAlbums(false);
         }
       });
-  }, [activeLibrarySection, filters.q, selectedArtist]);
+  }, [activeLibrarySection, selectedArtist]);
 
   useEffect(() => {
     if (activeLibrarySection !== "artists" || !selectedArtistAlbum) {
@@ -351,9 +347,7 @@ export function useLibraryData({
     setLoadingLibraryAlbums(true);
     setLibraryMetadataError(null);
 
-    getAlbums({
-      q: filters.q
-    })
+    getAlbums({})
       .then((albums) => {
         if (albumsRequestIdRef.current !== requestId) {
           return;
@@ -373,7 +367,7 @@ export function useLibraryData({
           setLoadingLibraryAlbums(false);
         }
       });
-  }, [activeLibrarySection, activeView, filters.q, user]);
+  }, [activeLibrarySection, activeView, user]);
 
   useEffect(() => {
     if (activeLibrarySection !== "albums") {

--- a/frontend/src/hooks/useLibraryData.ts
+++ b/frontend/src/hooks/useLibraryData.ts
@@ -360,7 +360,6 @@ export function useLibraryData({
 
     getAlbums({
       owner: filters.owner,
-      artist: filters.artist,
       q: filters.q
     })
       .then((albums) => {
@@ -382,7 +381,7 @@ export function useLibraryData({
           setLoadingLibraryAlbums(false);
         }
       });
-  }, [activeLibrarySection, activeView, filters.artist, filters.owner, filters.q, user]);
+  }, [activeLibrarySection, activeView, filters.owner, filters.q, user]);
 
   useEffect(() => {
     if (activeLibrarySection !== "albums") {

--- a/frontend/src/hooks/useLibraryData.ts
+++ b/frontend/src/hooks/useLibraryData.ts
@@ -109,7 +109,6 @@ export function useLibraryData({
   function getAlbumTracksFromLoadedLibraries(album: AlbumEntry): Track[] {
     const selectedAlbumName = normalizeText(album.name);
     const selectedAlbumArtist = normalizeText(album.artist);
-    const ownerFilter = normalizeText(filters.owner);
 
     const trackMap = new Map<string, Track>();
     for (const track of allTracksLibrary.tracks) {
@@ -123,10 +122,6 @@ export function useLibraryData({
 
     return sourceTracks.filter((track) => {
       if (normalizeText(getTrackDisplayAlbum(track)) !== selectedAlbumName) {
-        return false;
-      }
-
-      if (ownerFilter && normalizeText(track.owner) !== ownerFilter) {
         return false;
       }
 
@@ -201,7 +196,6 @@ export function useLibraryData({
     setLibraryMetadataError(null);
 
     getArtists({
-      owner: filters.owner,
       q: filters.q
     })
       .then((artists) => {
@@ -223,7 +217,7 @@ export function useLibraryData({
           setLoadingLibraryArtists(false);
         }
       });
-  }, [activeLibrarySection, activeView, filters.owner, filters.q, user]);
+  }, [activeLibrarySection, activeView, filters.q, user]);
 
   useEffect(() => {
     if (activeLibrarySection !== "artists") {
@@ -258,7 +252,6 @@ export function useLibraryData({
     setLibraryMetadataError(null);
 
     getArtistAlbums(selectedArtist.normalizedName, {
-      owner: filters.owner,
       q: filters.q
     })
       .then((albums) => {
@@ -292,7 +285,7 @@ export function useLibraryData({
           setLoadingArtistAlbums(false);
         }
       });
-  }, [activeLibrarySection, filters.owner, filters.q, selectedArtist]);
+  }, [activeLibrarySection, filters.q, selectedArtist]);
 
   useEffect(() => {
     if (activeLibrarySection !== "artists" || !selectedArtistAlbum) {
@@ -335,7 +328,7 @@ export function useLibraryData({
           setLoadingSelectedArtistAlbumTracks(false);
         }
       });
-  }, [activeLibrarySection, allTracksLibrary.tracks, filters.owner, library.tracks, selectedArtistAlbum]);
+  }, [activeLibrarySection, allTracksLibrary.tracks, library.tracks, selectedArtistAlbum]);
 
   useEffect(() => {
     if (activeLibrarySection !== "artists" || selectedArtistAlbum) {
@@ -359,7 +352,6 @@ export function useLibraryData({
     setLibraryMetadataError(null);
 
     getAlbums({
-      owner: filters.owner,
       q: filters.q
     })
       .then((albums) => {
@@ -381,7 +373,7 @@ export function useLibraryData({
           setLoadingLibraryAlbums(false);
         }
       });
-  }, [activeLibrarySection, activeView, filters.owner, filters.q, user]);
+  }, [activeLibrarySection, activeView, filters.q, user]);
 
   useEffect(() => {
     if (activeLibrarySection !== "albums") {
@@ -443,7 +435,7 @@ export function useLibraryData({
           setLoadingSelectedAlbumTracks(false);
         }
       });
-  }, [activeLibrarySection, allTracksLibrary.tracks, filters.owner, library.tracks, selectedAlbum]);
+  }, [activeLibrarySection, allTracksLibrary.tracks, library.tracks, selectedAlbum]);
 
   useEffect(() => {
     if (!user) {


### PR DESCRIPTION
Three independent user-reported issues, fixed together because they all surfaced during the same session of hands-on use.

## 1. Scanner silently skipped every symlink

`backend/src/services/scanner/filesystemCollector.ts` would `continue` on any symlinked dirent. Users who point part of their music tree at a bigger disk via a symlink saw their tracks disappear from the index after any scan. The update flow doesn't touch `${FLAQUE_STORAGE_DIR}`, but it does recreate the backend container, which triggers a scan on boot — so the symptom read as "update wiped my storage."

`collectAudioFiles` now `stat`s symlinked entries to resolve their type (directory vs. file) and follows both, with a `realpath`-keyed visited set so cycles can't loop forever. File listing via `fs.readdir` still uses the `dirent` type directly for non-symlink entries.

New test in `scannerService.test.ts` covers the directory-symlink case end-to-end.

## 2. Library filters leaked into Artists/Albums views

`frontend/src/hooks/useLibraryData.ts` shares one `filters` state across library sections. The Artists, Albums, and per-artist Albums fetches were forwarding `filters.artist`, `filters.owner`, and `filters.q` — so any filter (including the Music tab's search box) set in Library followed the user into the Artists and Albums sections.

Fix: the Artists and Albums metadata fetches now call their APIs unfiltered (`getArtists({})`, `getAlbums({})`, `getArtistAlbums(name, {})`), and `filters.artist` / `filters.owner` / `filters.q` have been removed from the corresponding effect dep arrays. Music-tab filtering behavior is unchanged — only `getLibrary(filters)` still receives them.

## 3. Second enrichment cycle appeared to do nothing

After a first run, every previously-enriched track in the in-memory snapshot already has a genre (from overrides). New tracks added by dropping files directly into storage never hit the upload flow that triggers a rebuild, so `indexStore.getTracks()` didn't see them. Result: `tracksWithoutGenre` was empty, the service returned immediately, and the status object stayed frozen on the previous run's numbers — the UI looked unchanged on each click.

`runBackgroundEnrichment` now calls `indexStore.rebuild()` first so the work queue reflects current disk state, and writes a fresh `{ total: 0, processed: 0, startedAt: now }` status in the empty-queue case so the UI can distinguish "just ran, nothing to do" from "stale."

## Test plan

- [x] `npx vitest run` in backend — 330/330 (includes new symlink test)
- [x] `npx vitest run` in frontend — 151/151
- [x] `npx tsc --noEmit` in frontend — clean
- [ ] Manual: place a symlink under `storage/music/` pointing to an external dir with audio files; scan; verify tracks appear
- [ ] Manual: in Library tab set Artist / Owner filters and type a search query; switch to Artists and Albums tabs; verify all artists/albums are listed regardless of filters
- [ ] Manual: run enrichment once, drop new files directly into storage, re-run; verify it picks them up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
