### PR TITLE
fix(api): correct auto-playlist config endpoint URL

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1074,11 +1074,11 @@ export type AutoPlaylistConfig = {
 };
 
 export async function getAutoPlaylistConfig(): Promise<AutoPlaylistConfig> {
-  return requestJson<AutoPlaylistConfig>("/api/config/auto-playlists");
+  return requestJson<AutoPlaylistConfig>("/api/playlists/automatic/config");
 }
 
 export async function patchAutoPlaylistConfig(patch: Partial<AutoPlaylistConfig>): Promise<AutoPlaylistConfig> {
-  return requestJson<AutoPlaylistConfig>("/api/config/auto-playlists", {
+  return requestJson<AutoPlaylistConfig>("/api/playlists/automatic/config", {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(patch)


### PR DESCRIPTION
## Summary
- `getAutoPlaylistConfig` and `patchAutoPlaylistConfig` in `api.ts` were calling `/api/config/auto-playlists`, which has no matching router in the backend.
- The actual routes are registered at `/api/playlists/automatic/config` (GET and PATCH) inside `playlistRoutes.ts`.
- Two-character fix: updated both calls to use the correct path.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open Admin → auto-playlist config panel; verify it loads and saves without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)