### PR TITLE
feat(improvements): home redesign, for-you section, player nav, faster API tests

### DIFF
--- a/backend/src/api/backupRoutes.test.ts
+++ b/backend/src/api/backupRoutes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { apiRequest, getBaseUrl, login, setupTestServer, teardownTestServer } from "./testHelpers";
+import { apiRequest, fetchApi, login, setupTestServer, teardownTestServer } from "./testHelpers";
 
 describe("backupRoutes", () => {
   beforeEach(async () => {
@@ -200,7 +200,7 @@ describe("backupRoutes", () => {
     expect(createRes.status).toBe(201);
     const manifest = createRes.payload as { id: string };
 
-    const downloadRes = await fetch(`${getBaseUrl()}/api/backups/${encodeURIComponent(manifest.id)}/download`, {
+    const downloadRes = await fetchApi(`/api/backups/${encodeURIComponent(manifest.id)}/download`, {
       headers: { Cookie: cookie }
     });
 

--- a/backend/src/api/libraryRoutes.ts
+++ b/backend/src/api/libraryRoutes.ts
@@ -160,6 +160,90 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
     });
   });
 
+  // GET /recent-uploads
+  router.get("/recent-uploads", requireAuth, (req, res, next) => {
+    const addedAfterRaw = typeof req.query.addedAfter === "string" ? req.query.addedAfter : "";
+    if (!addedAfterRaw) {
+      return next(new AppError("addedAfter is required", 400));
+    }
+    const parsedDate = Date.parse(addedAfterRaw);
+    if (Number.isNaN(parsedDate)) {
+      return next(new AppError("addedAfter must be a valid ISO 8601 date string", 400));
+    }
+    const addedAfter = new Date(parsedDate).toISOString();
+
+    const limitRaw = Number(req.query.limit ?? 12);
+    const limit = Number.isFinite(limitRaw) && limitRaw > 0
+      ? Math.min(Math.floor(limitRaw), 100)
+      : 12;
+
+    const ownerNamesById = getOwnerNamesById();
+    const filter = readFilter(req.query as Record<string, unknown>);
+    const filteredTracks = resolveFilteredTracks(indexStore, filter, ownerNamesById)
+      .filter((t) => (t.addedAt ?? "") >= addedAfter)
+      .sort((a, b) => (b.addedAt ?? "").localeCompare(a.addedAt ?? ""));
+
+    const albumKeyOf = (t: Track): string | null => {
+      const album = t.tags.album?.trim();
+      if (!album) return null;
+      const albumArtist = t.tags.albumArtist?.trim() ?? t.tags.artist?.trim() ?? "";
+      return `${album}\u0000${albumArtist}\u0000${t.owner}`;
+    };
+
+    const buckets = new Map<string, Track[]>();
+    for (const t of filteredTracks) {
+      const k = albumKeyOf(t);
+      if (k) {
+        const existing = buckets.get(k);
+        if (existing) existing.push(t);
+        else buckets.set(k, [t]);
+      }
+    }
+
+    const seen = new Set<string>();
+    const items: Array<
+      | { kind: "track"; track: ReturnType<typeof mapTrackResponse> }
+      | {
+          kind: "album";
+          album: {
+            albumName: string;
+            artist: string;
+            owner: string;
+            ownerName?: string;
+            trackCount: number;
+            coverTrackId: string;
+            tracks: ReturnType<typeof mapTrackResponse>[];
+          };
+        }
+    > = [];
+
+    for (const t of filteredTracks) {
+      if (items.length >= limit) break;
+      const k = albumKeyOf(t);
+      if (k && (buckets.get(k)?.length ?? 0) >= 2) {
+        if (seen.has(k)) continue;
+        seen.add(k);
+        const groupTracks = [...buckets.get(k)!].sort(compareAlbumTrackOrder);
+        const firstTrack = groupTracks[0]!;
+        items.push({
+          kind: "album",
+          album: {
+            albumName: t.tags.album!.trim(),
+            artist: t.tags.albumArtist?.trim() ?? t.tags.artist?.trim() ?? "Unknown artist",
+            owner: t.owner,
+            trackCount: groupTracks.length,
+            coverTrackId: firstTrack.id,
+            tracks: groupTracks.map(mapTrackResponse)
+          }
+        });
+      } else {
+        items.push({ kind: "track", track: mapTrackResponse(t) });
+      }
+    }
+
+    res.json({ items });
+  });
+
   // GET /tracks/:id/adjacent
   router.get("/tracks/:id/adjacent", requireAuth, (req, res, next) => {
     const trackId = req.params.id;

--- a/backend/src/api/playlistRoutes.test.ts
+++ b/backend/src/api/playlistRoutes.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { LibraryIndex, Playlist, Track } from "../types/library";
-import { apiRequest, getBaseUrl, getDataRoot, login, setupTestServer, teardownTestServer } from "./testHelpers";
+import { apiRequest, fetchApi, getDataRoot, login, setupTestServer, teardownTestServer } from "./testHelpers";
 
 function createTrack(id: string, relativePath: string): Track {
   return {
@@ -80,7 +80,7 @@ async function apiMultipartRequest(input: {
   const binary = Uint8Array.from(input.bytes);
   formData.append(input.fileFieldName, new Blob([binary.buffer as ArrayBuffer], { type: input.mimeType }), input.fileName);
 
-  const response = await fetch(`${getBaseUrl()}${input.pathname}`, {
+  const response = await fetchApi(input.pathname, {
     method: "POST",
     headers: { Cookie: input.cookie },
     body: formData

--- a/backend/src/api/testHelpers.ts
+++ b/backend/src/api/testHelpers.ts
@@ -1,23 +1,24 @@
 import fs from "node:fs/promises";
-import { createServer, type Server } from "node:http";
+import { IncomingMessage, ServerResponse } from "node:http";
+import type { Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { Duplex } from "node:stream";
 
+import type express from "express";
 import { expect, vi } from "vitest";
 
 import type { IndexStore } from "../services/indexer/indexStore";
 
 type TestServerContext = {
   dataRoot: string;
-  baseUrl: string;
-  server: Server;
+  app: express.Express;
 };
 
 let ctx: TestServerContext | null = null;
 
 export function getBaseUrl(): string {
-  if (!ctx) throw new Error("Test server not initialized");
-  return ctx.baseUrl;
+  return "http://flaque.test";
 }
 
 export function getDataRoot(): string {
@@ -30,6 +31,182 @@ export type BootstrapOptions = {
   indexStore?: unknown;
   beforeInit?: () => Promise<void> | void;
 };
+
+class MockSocket extends Duplex {
+  remoteAddress = "127.0.0.1";
+  encrypted = false;
+
+  override _read(): void {}
+
+  override _write(
+    _chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void
+  ): void {
+    callback();
+  }
+
+  override destroy(error?: Error): this {
+    if (error) {
+      this.emit("error", error);
+    }
+    return super.destroy();
+  }
+
+  setTimeout(): this {
+    return this;
+  }
+
+  setNoDelay(): this {
+    return this;
+  }
+
+  setKeepAlive(): this {
+    return this;
+  }
+}
+
+type TestResponse = {
+  status: number;
+  headers: Headers;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+};
+
+function normalizeBodyChunk(chunk: Buffer | string, encoding?: BufferEncoding): Buffer {
+  if (Buffer.isBuffer(chunk)) {
+    return Buffer.from(chunk);
+  }
+
+  return Buffer.from(chunk, encoding ?? "utf8");
+}
+
+async function invokeApp(pathname: string, options: RequestInit = {}): Promise<TestResponse> {
+  if (!ctx) {
+    throw new Error("Test server not initialized");
+  }
+
+  const request = new Request(`${getBaseUrl()}${pathname}`, options);
+  const requestBody = request.body ? Buffer.from(await request.arrayBuffer()) : Buffer.alloc(0);
+  const requestHeaders = new Headers(request.headers);
+  const app = ctx.app as unknown as {
+    handle: (req: IncomingMessage, res: ServerResponse, next: (error?: unknown) => void) => void;
+  };
+
+  if (!requestHeaders.has("host")) {
+    requestHeaders.set("host", new URL(getBaseUrl()).host);
+  }
+  if (requestBody.length > 0 && !requestHeaders.has("content-length")) {
+    requestHeaders.set("content-length", String(requestBody.length));
+  }
+
+  const socket = new MockSocket() as unknown as Socket;
+  const req = new IncomingMessage(socket);
+  req.url = pathname;
+  req.method = request.method;
+  req.headers = Object.fromEntries(requestHeaders.entries());
+  req.connection = socket;
+  req.socket = socket;
+  req.push(requestBody);
+  req.push(null);
+
+  const res = new ServerResponse(req);
+  res.assignSocket(socket);
+
+  const bodyChunks: Buffer[] = [];
+  const originalWrite = res.write.bind(res);
+  const originalEnd = res.end.bind(res);
+
+  res.write = ((chunk: Buffer | string, encoding?: BufferEncoding, callback?: (error?: Error | null) => void) => {
+    if (chunk) {
+      bodyChunks.push(normalizeBodyChunk(chunk, encoding));
+    }
+
+    if (encoding !== undefined) {
+      return originalWrite(chunk, encoding, callback);
+    }
+
+    return callback ? originalWrite(chunk, callback) : originalWrite(chunk);
+  }) as typeof res.write;
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+
+    const settle = (callback: () => void): void => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      callback();
+    };
+
+    res.end = ((chunk?: Buffer | string, encoding?: BufferEncoding, callback?: () => void) => {
+      if (chunk) {
+        bodyChunks.push(normalizeBodyChunk(chunk, encoding));
+      }
+
+      const result =
+        encoding !== undefined
+          ? originalEnd(chunk, encoding, callback)
+          : callback
+            ? originalEnd(chunk, callback)
+            : originalEnd(chunk);
+      queueMicrotask(() => {
+        settle(resolve);
+      });
+      return result;
+    }) as typeof res.end;
+
+    res.on("error", (error) => {
+      settle(() => reject(error));
+    });
+
+    app.handle(req, res, (error?: unknown) => {
+      if (error instanceof Error) {
+        settle(() => reject(error));
+        return;
+      }
+
+      settle(() => resolve());
+    });
+  });
+
+  const responseHeaders = new Headers();
+  for (const [key, value] of Object.entries(res.getHeaders())) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        responseHeaders.append(key, String(item));
+      }
+      continue;
+    }
+
+    if (value !== undefined) {
+      responseHeaders.set(key, String(value));
+    }
+  }
+
+  const responseBody = Buffer.concat(bodyChunks);
+
+  return {
+    status: res.statusCode,
+    headers: responseHeaders,
+    async text() {
+      return responseBody.toString("utf8");
+    },
+    async json() {
+      const text = responseBody.toString("utf8");
+      return text ? (JSON.parse(text) as unknown) : undefined;
+    },
+    async arrayBuffer() {
+      return responseBody.buffer.slice(
+        responseBody.byteOffset,
+        responseBody.byteOffset + responseBody.byteLength
+      );
+    }
+  };
+}
 
 export async function setupTestServer(options: BootstrapOptions): Promise<void> {
   vi.resetModules();
@@ -66,37 +243,14 @@ export async function setupTestServer(options: BootstrapOptions): Promise<void> 
   }
 
   const app = createApp(indexStore);
-  const server = createServer(app);
-
-  const baseUrl = await new Promise<string>((resolve, reject) => {
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        reject(new Error("Unable to resolve test server address"));
-        return;
-      }
-      resolve(`http://127.0.0.1:${address.port}`);
-    });
-  });
-
-  ctx = { dataRoot, baseUrl, server };
+  ctx = { dataRoot, app };
 }
 
 export async function teardownTestServer(): Promise<void> {
   if (!ctx) return;
 
-  const { dataRoot, server } = ctx;
+  const { dataRoot } = ctx;
   ctx = null;
-
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
 
   await fs.rm(dataRoot, { recursive: true, force: true });
   vi.resetModules();
@@ -110,12 +264,14 @@ export type ApiResponse = {
 };
 
 export async function apiRequest(pathname: string, options: RequestInit = {}): Promise<ApiResponse> {
-  const response = await fetch(`${getBaseUrl()}${pathname}`, {
+  const headers = new Headers(options.headers);
+  if (!headers.has("Content-Type") && !(options.body instanceof FormData)) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const response = await invokeApp(pathname, {
     ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...(options.headers ?? {})
-    }
+    headers
   });
 
   const text = await response.text();
@@ -135,6 +291,10 @@ export async function apiRequest(pathname: string, options: RequestInit = {}): P
     cookie: response.headers.get("set-cookie"),
     retryAfter: response.headers.get("retry-after")
   };
+}
+
+export async function fetchApi(pathname: string, options: RequestInit = {}): Promise<TestResponse> {
+  return invokeApp(pathname, options);
 }
 
 export async function login(username: string, password: string): Promise<string> {

--- a/backend/src/api/uploadRoutes.test.ts
+++ b/backend/src/api/uploadRoutes.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   apiRequest,
-  getBaseUrl,
+  fetchApi,
   getDataRoot,
   login,
   setupTestServer,
@@ -25,7 +25,7 @@ async function postForm(
   if (cookie) {
     headers.Cookie = cookie;
   }
-  const response = await fetch(`${getBaseUrl()}${pathname}`, {
+  const response = await fetchApi(pathname, {
     method: "POST",
     headers,
     body: form

--- a/backend/src/api/uploadRoutes.test.ts
+++ b/backend/src/api/uploadRoutes.test.ts
@@ -81,16 +81,6 @@ describe("uploadRoutes", () => {
     });
   });
 
-  describe("GET /api/recent-uploads", () => {
-    it("returns an empty list when no tracks have been uploaded", async () => {
-      const res = await apiRequest("/api/recent-uploads", { headers: { Cookie: cookie } });
-      expect(res.status).toBe(200);
-      const body = res.payload as { tracks: unknown[] };
-      expect(Array.isArray(body.tracks)).toBe(true);
-      expect(body.tracks).toHaveLength(0);
-    });
-  });
-
   describe("POST /api/upload/chunked/init", () => {
     it("requires authentication", async () => {
       const res = await apiRequest("/api/upload/chunked/init", {

--- a/backend/src/api/uploadRoutes.ts
+++ b/backend/src/api/uploadRoutes.ts
@@ -5,7 +5,7 @@ import multer from "multer";
 import { Router, type NextFunction, type Response } from "express";
 
 import { requireAuth } from "../auth/middleware";
-import { appendTrackActivityLogEntries, readTrackActivityLog } from "../services/activity/trackActivityStore";
+import { appendTrackActivityLogEntries } from "../services/activity/trackActivityStore";
 import { enrichTrackGenre } from "../services/genre/genreEnrichmentService";
 import { mergeTrackMetadataOverrides } from "../services/indexer/metadataOverrideStore";
 import { IndexStore } from "../services/indexer/indexStore";
@@ -543,15 +543,6 @@ export function createUploadRouter(indexStore: IndexStore): Router {
       if (directTempPath) {
         await cleanupTemporaryFiles([directTempPath]);
       }
-      next(error);
-    }
-  });
-
-  router.get("/recent-uploads", requireAuth, async (_req, res, next) => {
-    try {
-      const tracks = await readTrackActivityLog();
-      res.json({ tracks });
-    } catch (error) {
       next(error);
     }
   });

--- a/backend/src/api/userRoutes.test.ts
+++ b/backend/src/api/userRoutes.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { apiRequest, getBaseUrl, getDataRoot, login, setupTestServer, teardownTestServer } from "./testHelpers";
+import { apiRequest, fetchApi, getDataRoot, login, setupTestServer, teardownTestServer } from "./testHelpers";
 
 async function apiMultipartRequest(input: {
   pathname: string;
@@ -17,7 +17,7 @@ async function apiMultipartRequest(input: {
   const binary = Uint8Array.from(input.bytes);
   formData.append(input.fileFieldName, new Blob([binary.buffer as ArrayBuffer], { type: input.mimeType }), input.fileName);
 
-  const response = await fetch(`${getBaseUrl()}${input.pathname}`, {
+  const response = await fetchApi(input.pathname, {
     method: "POST",
     headers: {
       Cookie: input.cookie
@@ -401,7 +401,7 @@ describe("userRoutes", () => {
     const avatarFiles = profileEntries.filter((entry: string) => entry.startsWith("avatar."));
     expect(avatarFiles).toEqual(["avatar.webp"]);
 
-    const photoResponse = await fetch(`${getBaseUrl()}/api/users/me/photo`, {
+    const photoResponse = await fetchApi("/api/users/me/photo", {
       method: "GET",
       headers: {
         Cookie: userCookie

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -72,7 +72,7 @@ export function AuthenticatedApp({
 
   // ── Recently uploaded ────────────────────────────────────────────────
   const {
-    tracks: recentlyUploadedTracks,
+    items: recentlyUploadedItems,
     loading: recentlyUploadedLoading,
     period: recentlyUploadedPeriod,
     setPeriod: setRecentlyUploadedPeriod,
@@ -335,7 +335,7 @@ export function AuthenticatedApp({
         homeProps: {
           recentTracks,
           onRecentTrackReplay: handleReplayRecentTrack,
-          recentlyUploadedTracks,
+          recentlyUploadedItems,
           recentlyUploadedLoading,
           recentlyUploadedPeriod,
           onRecentlyUploadedPeriodChange: setRecentlyUploadedPeriod,

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -6,6 +6,7 @@ import type { ConfigSection } from "./components/ConfigView";
 import type { Track, User } from "./types";
 import type { LibrarySection } from "./types/library";
 import { navigateTo, normalizeText, sortAlbumTracksByNumber, type ViewName } from "./utils/appUtils";
+import { getTrackDisplayAlbum, getTrackDisplayArtist } from "./utils/tracks";
 import { useAdminUsers } from "./hooks/useAdminUsers";
 import { useAppNotice } from "./hooks/useAppNotice";
 import { useDocumentTitle } from "./hooks/useDocumentTitle";
@@ -239,6 +240,103 @@ export function AuthenticatedApp({
     setActiveView(nextView);
   }
 
+  const handleOpenCurrentTrackArtist = useCallback((): void => {
+    if (!selectedTrackRefreshed) {
+      return;
+    }
+
+    const artistName = getTrackDisplayArtist(selectedTrackRefreshed);
+    if (!artistName) {
+      return;
+    }
+
+    const targetArtist = normalizeText(artistName);
+    const matchedArtist =
+      libraryArtists.find((entry) => normalizeText(entry.name) === targetArtist) ??
+      library.artists.find((entry) => normalizeText(entry.name) === targetArtist);
+    const artistEntry = matchedArtist ?? {
+      name: artistName,
+      normalizedName: targetArtist,
+      albumCount: 0,
+      trackCount: 0,
+      totalDuration: 0,
+      previewTrackId: selectedTrackRefreshed.id
+    };
+
+    navigateTo("library", "artists");
+    setActiveView("library");
+    setActiveLibrarySection("artists");
+    setPlaylistDetailId(null);
+    clearSelectedAlbum();
+    clearSelectedArtistAlbum();
+    selectArtist(artistEntry);
+  }, [
+    clearSelectedAlbum,
+    clearSelectedArtistAlbum,
+    library.artists,
+    libraryArtists,
+    selectArtist,
+    selectedTrackRefreshed,
+    setActiveLibrarySection,
+    setActiveView,
+    setPlaylistDetailId
+  ]);
+
+  const handleOpenCurrentTrackAlbum = useCallback((): void => {
+    if (!selectedTrackRefreshed) {
+      return;
+    }
+
+    const albumName = getTrackDisplayAlbum(selectedTrackRefreshed);
+    if (!albumName) {
+      return;
+    }
+
+    const artistName = getTrackDisplayArtist(selectedTrackRefreshed);
+    const targetName = normalizeText(albumName);
+    const targetArtist = normalizeText(artistName);
+    const matchAlbum = (name: string, artist?: string): boolean => {
+      if (normalizeText(name) !== targetName) {
+        return false;
+      }
+
+      if (!targetArtist) {
+        return true;
+      }
+
+      return normalizeText(artist) === targetArtist;
+    };
+
+    const matchedAlbum =
+      libraryAlbums.find((entry) => matchAlbum(entry.name, entry.artist)) ??
+      library.albums.find((entry) => matchAlbum(entry.name, entry.artist));
+    const albumEntry = matchedAlbum ?? {
+      name: albumName,
+      artist: artistName,
+      trackCount: 0,
+      cover: selectedTrackRefreshed.cover,
+      previewTrackId: selectedTrackRefreshed.id
+    };
+
+    navigateTo("library", "albums");
+    setActiveView("library");
+    setActiveLibrarySection("albums");
+    setPlaylistDetailId(null);
+    clearSelectedArtist();
+    clearSelectedArtistAlbum();
+    selectAlbum(albumEntry);
+  }, [
+    clearSelectedArtist,
+    clearSelectedArtistAlbum,
+    library.albums,
+    libraryAlbums,
+    selectAlbum,
+    selectedTrackRefreshed,
+    setActiveLibrarySection,
+    setActiveView,
+    setPlaylistDetailId
+  ]);
+
   async function handleLogout(): Promise<void> {
     await logout();
     setUser(null);
@@ -467,7 +565,9 @@ export function AuthenticatedApp({
           ? undefined
           : (queueTrack) => {
             requestTrackPlaybackWithStatus(queueTrack, refreshedQueue.length > 0 ? refreshedQueue : undefined);
-          }
+          },
+        onOpenTrackArtist: handleOpenCurrentTrackArtist,
+        onOpenTrackAlbum: handleOpenCurrentTrackAlbum
       }}
     />
   );

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -91,7 +91,7 @@ export function AuthenticatedApp({
   } = useInfiniteLibrary({ user, filters, pageSize: 30 });
 
   const { autoPlaylists, loading: loadingAutoPlaylists, refresh: refreshAutoPlaylists } = useAutoPlaylists();
-  const { forYouPlaylists, loading: loadingForYouPlaylists, dismiss: dismissForYouPlaylist } = useForYouPlaylists();
+  const { forYouPlaylists, loading: loadingForYouPlaylists, dismiss: dismissForYouPlaylist, regenerate: regenerateForYouPlaylists } = useForYouPlaylists();
 
   const allTracksById = useMemo(
     () => new Map(allTracksLibrary.tracks.map((track) => [track.id, track])),
@@ -290,7 +290,8 @@ export function AuthenticatedApp({
           loadingAutoPlaylists,
           forYouPlaylists,
           loadingForYouPlaylists,
-          onDismissForYouPlaylist: dismissForYouPlaylist
+          onDismissForYouPlaylist: dismissForYouPlaylist,
+          onRefreshForYouPlaylists: regenerateForYouPlaylists
         },
         artistsProps: {
           libraryMetadataError,

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -5,7 +5,7 @@ import { AppShell } from "./components/AppShell";
 import type { ConfigSection } from "./components/ConfigView";
 import type { Track, User } from "./types";
 import type { LibrarySection } from "./types/library";
-import { navigateTo, type ViewName } from "./utils/appUtils";
+import { navigateTo, normalizeText, sortAlbumTracksByNumber, type ViewName } from "./utils/appUtils";
 import { useAdminUsers } from "./hooks/useAdminUsers";
 import { useAppNotice } from "./hooks/useAppNotice";
 import { useDocumentTitle } from "./hooks/useDocumentTitle";
@@ -340,6 +340,36 @@ export function AuthenticatedApp({
           recentlyUploadedPeriod,
           onRecentlyUploadedPeriodChange: setRecentlyUploadedPeriod,
           onRecentlyUploadedTrackSelect: (track) => requestTrackPlaybackWithStatus(track, paginatedTracks),
+          onRecentlyUploadedAlbumPlay: (album) => {
+            const sortedTracks = sortAlbumTracksByNumber(album.tracks);
+            if (sortedTracks.length === 0) return;
+            requestTrackPlaybackWithStatus(sortedTracks[0], sortedTracks);
+          },
+          onRecentlyUploadedAlbumOpen: (album) => {
+            const targetName = normalizeText(album.albumName);
+            const targetArtist = normalizeText(album.artist);
+            const matched =
+              libraryAlbums.find((entry) =>
+                normalizeText(entry.name) === targetName &&
+                normalizeText(entry.artist) === targetArtist
+              ) ??
+              library.albums.find((entry) =>
+                normalizeText(entry.name) === targetName &&
+                normalizeText(entry.artist) === targetArtist
+              );
+            const albumEntry = matched ?? {
+              name: album.albumName,
+              artist: album.artist,
+              trackCount: album.trackCount,
+              cover: album.coverTrackId
+            };
+            navigateTo("library", "albums");
+            setActiveLibrarySection("albums");
+            setPlaylistDetailId(null);
+            clearSelectedArtist();
+            clearSelectedArtistAlbum();
+            selectAlbum(albumEntry);
+          },
           ownerNameById,
           radioLoading: loadingRadio,
           radioStationId,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -228,6 +228,32 @@ export type TracksResponse = {
   tracks: Track[];
 };
 
+export type RecentUploadAlbum = {
+  albumName: string;
+  artist: string;
+  owner: string;
+  trackCount: number;
+  coverTrackId: string;
+  tracks: Track[];
+};
+
+export type RecentUploadItem =
+  | { kind: "track"; track: Track }
+  | { kind: "album"; album: RecentUploadAlbum };
+
+export async function getRecentUploads(params: {
+  addedAfter: string;
+  limit?: number;
+  owner?: string;
+}): Promise<RecentUploadItem[]> {
+  const searchParams = new URLSearchParams();
+  searchParams.set("addedAfter", params.addedAfter);
+  if (params.limit !== undefined) searchParams.set("limit", String(params.limit));
+  if (params.owner) searchParams.set("owner", params.owner);
+  const payload = await requestJson<{ items?: RecentUploadItem[] }>(`/api/recent-uploads?${searchParams.toString()}`);
+  return payload.items ?? [];
+}
+
 export async function getTracks(params: {
   page?: number;
   limit?: number;

--- a/frontend/src/components/AccountView.test.tsx
+++ b/frontend/src/components/AccountView.test.tsx
@@ -6,12 +6,33 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { User, UserSession } from "../types";
 import { AccountView } from "./AccountView";
 
-const mockHandleUpdateProfilePhoto = vi.fn().mockResolvedValue(undefined);
-const mockHandleUpdateEmail = vi.fn().mockResolvedValue(undefined);
-const mockHandleUpdateOwnPassword = vi.fn().mockResolvedValue(undefined);
-const mockHandleListMySessions = vi.fn<() => Promise<UserSession[]>>();
-const mockHandleRevokeMySession = vi.fn<(sessionId: string) => Promise<void>>().mockResolvedValue(undefined);
-const mockHandleLogoutOtherSessions = vi.fn<() => Promise<number>>();
+const {
+  mockHandleUpdateProfilePhoto,
+  mockHandleUpdateEmail,
+  mockHandleUpdateOwnPassword,
+  mockHandleListMySessions,
+  mockHandleRevokeMySession,
+  mockHandleLogoutOtherSessions,
+  mockGetMyPlayStats
+} = vi.hoisted(() => ({
+  mockHandleUpdateProfilePhoto: vi.fn().mockResolvedValue(undefined),
+  mockHandleUpdateEmail: vi.fn().mockResolvedValue(undefined),
+  mockHandleUpdateOwnPassword: vi.fn().mockResolvedValue(undefined),
+  mockHandleListMySessions: vi.fn<() => Promise<UserSession[]>>(),
+  mockHandleRevokeMySession: vi.fn<(sessionId: string) => Promise<void>>().mockResolvedValue(undefined),
+  mockHandleLogoutOtherSessions: vi.fn<() => Promise<number>>(),
+  mockGetMyPlayStats: vi.fn().mockResolvedValue({
+    topTracks: [],
+    topArtists: [],
+    totalPlays: 0,
+    uniqueTracksPlayed: 0
+  })
+}));
+
+vi.mock("../api", () => ({
+  coverUrl: (trackId: string, coverPath?: string) => coverPath ?? `/mock-covers/${trackId}`,
+  getMyPlayStats: mockGetMyPlayStats
+}));
 
 vi.mock("../hooks/useAccountActions", () => ({
   useAccountActions: () => ({

--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -47,6 +47,8 @@ type AudioPlayerProps = {
   onQueueTrackSelect?: (track: Track) => void;
   onArtworkClick?: () => void;
   onNavigateToLibrary?: () => void;
+  onOpenTrackArtist?: () => void;
+  onOpenTrackAlbum?: () => void;
 };
 
 export function AudioPlayer({
@@ -73,7 +75,9 @@ export function AudioPlayer({
   currentQueueTrackId = null,
   onQueueTrackSelect,
   onArtworkClick,
-  onNavigateToLibrary
+  onNavigateToLibrary,
+  onOpenTrackArtist,
+  onOpenTrackAlbum
 }: AudioPlayerProps): JSX.Element {
   const {
     audioRef, streamSource,
@@ -171,7 +175,8 @@ export function AudioPlayer({
     showQueuePanel ? "ring-2 ring-flaque-sand/55" : ""
   }`;
   const displayTitle = getTrackDisplayTitle(track);
-  const displayArtist = getTrackDisplayArtist(track) ?? "Unknown artist";
+  const trackArtist = getTrackDisplayArtist(track);
+  const displayArtist = trackArtist ?? "Unknown artist";
   const displayAlbumWithYear = getTrackDisplayAlbumWithYear(track);
   const displayLyrics = getTrackDisplayLyrics(track);
   const syncedLyrics = useMemo(() => getTrackSyncedLyrics(track), [track]);
@@ -179,6 +184,8 @@ export function AudioPlayer({
   const isRadioMode = track.owner === "radio";
   const isRadioStopped = isRadioMode && radioStopped;
   const codecLabel = `${track.codec}${track.sampleRate ? ` - ${Math.round(track.sampleRate / 1000)} kHz` : ""}`;
+  const canOpenTrackArtist = Boolean(onOpenTrackArtist && trackArtist);
+  const canOpenTrackAlbum = Boolean(onOpenTrackAlbum && displayAlbumWithYear);
 
   const hasPlayablePlaylists = playlists.length > 0;
   const effectiveQueue = queueTracks.length > 0 ? queueTracks : [track];
@@ -329,9 +336,35 @@ export function AudioPlayer({
                 )}
                 {expanded ? (
                   <>
-                    <p className={secondaryTextClassName}>{displayArtist}</p>
+                    <p className={secondaryTextClassName}>
+                      {canOpenTrackArtist ? (
+                        <button
+                          className="max-w-full truncate rounded-sm text-left underline-offset-2 transition hover:text-flaque-ink hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-flaque-sand/70"
+                          type="button"
+                          title={`Open artist: ${displayArtist}`}
+                          onClick={onOpenTrackArtist}
+                        >
+                          {displayArtist}
+                        </button>
+                      ) : (
+                        displayArtist
+                      )}
+                    </p>
                     {displayAlbumWithYear ? (
-                      <p className="truncate text-xs text-flaque-steel/80">{displayAlbumWithYear}</p>
+                      <p className="truncate text-xs text-flaque-steel/80">
+                        {canOpenTrackAlbum ? (
+                          <button
+                            className="max-w-full truncate rounded-sm text-left underline-offset-2 transition hover:text-flaque-ink hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-flaque-sand/70"
+                            type="button"
+                            title={`Open album: ${displayAlbumWithYear}`}
+                            onClick={onOpenTrackAlbum}
+                          >
+                            {displayAlbumWithYear}
+                          </button>
+                        ) : (
+                          displayAlbumWithYear
+                        )}
+                      </p>
                     ) : null}
                     <p className={metaTextClassName}>
                       {codecLabel}
@@ -345,8 +378,35 @@ export function AudioPlayer({
                 ) : (
                   <div className="flex items-baseline gap-2">
                     <p className="min-w-0 flex-1 overflow-x-auto scrollbar-hide whitespace-nowrap font-body text-xs text-flaque-steel">
-                      {displayArtist}
-                      {displayAlbumWithYear ? ` - ${displayAlbumWithYear}` : ""}
+                      {canOpenTrackArtist ? (
+                        <button
+                          className="rounded-sm text-left underline-offset-2 transition hover:text-flaque-ink hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-flaque-sand/70"
+                          type="button"
+                          title={`Open artist: ${displayArtist}`}
+                          onClick={onOpenTrackArtist}
+                        >
+                          {displayArtist}
+                        </button>
+                      ) : (
+                        displayArtist
+                      )}
+                      {displayAlbumWithYear ? (
+                        <>
+                          {" - "}
+                          {canOpenTrackAlbum ? (
+                            <button
+                              className="rounded-sm text-left underline-offset-2 transition hover:text-flaque-ink hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-flaque-sand/70"
+                              type="button"
+                              title={`Open album: ${displayAlbumWithYear}`}
+                              onClick={onOpenTrackAlbum}
+                            >
+                              {displayAlbumWithYear}
+                            </button>
+                          ) : (
+                            displayAlbumWithYear
+                          )}
+                        </>
+                      ) : null}
                     </p>
                     <p className={`${metaTextClassName} shrink-0 whitespace-nowrap`}>{codecLabel}</p>
                   </div>

--- a/frontend/src/components/AutoPlaylistDetailView.tsx
+++ b/frontend/src/components/AutoPlaylistDetailView.tsx
@@ -90,6 +90,27 @@ export function AutoPlaylistDetailView({
     onPlayTrack(fakePlaylist);
   }
 
+  function handlePlayFromTrack(track: Track): void {
+    if (!detail || tracks.length === 0) return;
+    const idx = tracks.indexOf(track);
+    if (idx < 0) return;
+    const reordered = [...tracks.slice(idx), ...tracks.slice(0, idx)];
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: reordered.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
   if (loading) {
     return (
       <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
@@ -146,10 +167,10 @@ export function AutoPlaylistDetailView({
       </button>
 
       {/* Header card */}
-      <div className="rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-white/85 to-flaque-cream/40 p-5 shadow-panel backdrop-blur-sm">
-        <div className="group flex flex-col gap-5 sm:flex-row">
+      <div className="rounded-2xl p-5">
+        <div className="flex flex-col gap-5 sm:flex-row">
            {/* Genre/decade visual */}
-           <div className="relative h-48 w-48 shrink-0 self-center overflow-hidden rounded-2xl sm:self-start" style={gradientStyle}>
+           <div className="group relative h-48 w-48 shrink-0 self-center overflow-hidden rounded-2xl sm:self-start" style={gradientStyle}>
              <div className="flex h-full w-full flex-col items-center justify-center">
                <p className="font-display text-6xl font-extrabold text-white drop-shadow-md">{decadeLabel}</p>
                <p className="mt-1 text-sm font-medium text-white/80">{detail.genre}</p>
@@ -199,8 +220,12 @@ export function AutoPlaylistDetailView({
                 className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
                 onClick={handleShufflePlay}
               >
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4" />
+                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+                  <path d="M16 3h5v5" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M4 20l8-8" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M21 3l-7 7" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M4 4l6 6" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M15 16l2 2" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
                 Shuffle
               </button>
@@ -218,7 +243,11 @@ export function AutoPlaylistDetailView({
             {tracks.map((track, index) => (
               <li
                 key={track.id}
-                className="flex items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+                className="flex cursor-pointer items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+                role="button"
+                tabIndex={0}
+                onClick={() => handlePlayFromTrack(track)}
+                onKeyDown={(e) => { if (e.key === "Enter") handlePlayFromTrack(track); }}
               >
                 <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
                 <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">

--- a/frontend/src/components/HomePanels.tsx
+++ b/frontend/src/components/HomePanels.tsx
@@ -50,47 +50,48 @@ export function HomePanels({
   return (
     <div className="space-y-4 m-4">
       <section className="rounded-xl border border-flaque-clay/60 bg-white/80 p-4 shadow-panel backdrop-blur-sm">
-        <button
-          className="mt-2 w-full rounded-xl bg-flaque-ink cursor-pointer px-4 py-3 text-left text-flaque-cream transition hover:bg-black disabled:cursor-not-allowed disabled:opacity-60"
-          type="button"
-          disabled={!canStartRadio}
-          onClick={() => onStartRadioPlayback?.()}
-        >
-          <p className="flex items-center gap-2 font-display text-xl">
-            <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <div className="flex items-stretch gap-3">
+          <button
+            type="button"
+            disabled={!canStartRadio}
+            onClick={() => onStartRadioPlayback?.()}
+            className="radio-play-btn shrink-0 flex w-20 flex-col items-center justify-center rounded-lg cursor-pointer disabled:cursor-not-allowed sm:w-24 mb-[5px]"
+            aria-label="Launch radio"
+            title="Launch radio"
+          >
+            <svg className="h-7 w-7 drop-shadow-sm sm:h-8 sm:w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M8 6v12l10-6-10-6z" />
             </svg>
-            <span>Launch radio</span>
-          </p>
-        </button>
+            <span className="mt-1 font-display text-[10px] font-semibold tracking-[0.25em]">PLAY</span>
+          </button>
 
-        <button
-          className="mt-3 w-full rounded-xl border border-flaque-clay/70 bg-flaque-cream/60 px-4 py-3 text-left transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-70"
-          type="button"
-          disabled={!canStartRadio}
-          onClick={() => onStartRadioPlayback?.()}
-        >
-          <p className="text-[11px] uppercase tracking-[0.2em] text-flaque-steel">Now Playing</p>
-          {radioLoading ? (
-            <p className="mt-1 text-sm text-flaque-steel">Syncing station state...</p>
-          ) : radioCurrentTrack ? (
-            <>
-              <p className="mt-1 truncate font-display text-lg text-flaque-ink" title={radioCurrentTrack.title ?? "Untitled"}>
-                {radioCurrentTrack.title ?? "Untitled"}
-              </p>
-              <p className="mt-1 truncate text-sm text-flaque-steel">
-                {radioCurrentTrack.artist ?? "Unknown artist"}
-                {radioCurrentTrack.album ? ` - ${radioCurrentTrack.album}` : ""}
-              </p>
-            </>
-          ) : (
-            <p className="mt-1 text-sm text-flaque-steel">No active track yet.</p>
-          )}
-          {/* <p className="mt-2 text-xs text-flaque-steel/90">
-            Station: {radioStationId ?? "stopped"}
-            {radioNextTrack?.title ? ` · Up next: ${radioNextTrack.title}` : ""}
-          </p> */}
-        </button>
+          <button
+            className="radio-screen font-lcd flex-1 min-w-0 rounded-xl px-4 py-3 text-left transition disabled:cursor-not-allowed disabled:opacity-70"
+            type="button"
+            disabled={!canStartRadio}
+            onClick={() => onStartRadioPlayback?.()}
+          >
+            <div className="flex items-center justify-between gap-3 border-b border-current/20 pb-1">
+              <p className="truncate text-sm font-bold tracking-[0.25em]">FLAQUE FM</p>
+              <p className="radio-screen-subtle shrink-0 text-[10px] uppercase tracking-[0.3em]">Now Playing</p>
+            </div>
+            {radioLoading ? (
+              <p className="radio-screen-subtle mt-2 text-sm">Syncing station state...</p>
+            ) : radioCurrentTrack ? (
+              <>
+                <p className="mt-2 truncate text-lg" title={radioCurrentTrack.title ?? "Untitled"}>
+                  {radioCurrentTrack.title ?? "Untitled"}
+                </p>
+                <p className="radio-screen-subtle mt-1 truncate text-sm">
+                  {radioCurrentTrack.artist ?? "Unknown artist"}
+                  {radioCurrentTrack.album ? ` - ${radioCurrentTrack.album}` : ""}
+                </p>
+              </>
+            ) : (
+              <p className="radio-screen-subtle mt-2 text-sm">No active track yet.</p>
+            )}
+          </button>
+        </div>
       </section>
 
       {hasRecent ? (

--- a/frontend/src/components/HomePanels.tsx
+++ b/frontend/src/components/HomePanels.tsx
@@ -1,5 +1,5 @@
 import type { RadioTrack, Track } from "../types";
-import type { RecentUploadItem } from "../api";
+import type { RecentUploadAlbum, RecentUploadItem } from "../api";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
 import { RecentTracksPanel } from "./RecentTracksPanel";
 import { RecentlyUploadedPanel } from "./RecentlyUploadedPanel";
@@ -12,6 +12,8 @@ export type HomePanelsProps = {
   recentlyUploadedPeriod: UploadPeriod;
   onRecentlyUploadedPeriodChange: (period: UploadPeriod) => void;
   onRecentlyUploadedTrackSelect: (track: Track) => void;
+  onRecentlyUploadedAlbumPlay: (album: RecentUploadAlbum) => void;
+  onRecentlyUploadedAlbumOpen: (album: RecentUploadAlbum) => void;
   ownerNameById?: Record<string, string>;
   onNavigateToLibrary?: () => void;
   radioLoading?: boolean;
@@ -33,6 +35,8 @@ export function HomePanels({
   recentlyUploadedPeriod,
   onRecentlyUploadedPeriodChange,
   onRecentlyUploadedTrackSelect,
+  onRecentlyUploadedAlbumPlay,
+  onRecentlyUploadedAlbumOpen,
   ownerNameById,
   onNavigateToLibrary,
   radioLoading = false,
@@ -108,6 +112,8 @@ export function HomePanels({
           period={recentlyUploadedPeriod}
           onPeriodChange={onRecentlyUploadedPeriodChange}
           onTrackSelect={onRecentlyUploadedTrackSelect}
+          onAlbumPlay={onRecentlyUploadedAlbumPlay}
+          onAlbumOpen={onRecentlyUploadedAlbumOpen}
           ownerNameById={ownerNameById}
         />
       ) : null}

--- a/frontend/src/components/HomePanels.tsx
+++ b/frontend/src/components/HomePanels.tsx
@@ -1,4 +1,5 @@
 import type { RadioTrack, Track } from "../types";
+import type { RecentUploadItem } from "../api";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
 import { RecentTracksPanel } from "./RecentTracksPanel";
 import { RecentlyUploadedPanel } from "./RecentlyUploadedPanel";
@@ -6,7 +7,7 @@ import { RecentlyUploadedPanel } from "./RecentlyUploadedPanel";
 export type HomePanelsProps = {
   recentTracks: Track[];
   onRecentTrackReplay: (track: Track) => void;
-  recentlyUploadedTracks: Track[];
+  recentlyUploadedItems: RecentUploadItem[];
   recentlyUploadedLoading: boolean;
   recentlyUploadedPeriod: UploadPeriod;
   onRecentlyUploadedPeriodChange: (period: UploadPeriod) => void;
@@ -27,7 +28,7 @@ export type HomePanelsProps = {
 export function HomePanels({
   recentTracks,
   onRecentTrackReplay,
-  recentlyUploadedTracks,
+  recentlyUploadedItems,
   recentlyUploadedLoading,
   recentlyUploadedPeriod,
   onRecentlyUploadedPeriodChange,
@@ -41,7 +42,7 @@ export function HomePanels({
   onStartRadioPlayback
 }: HomePanelsProps): JSX.Element | null {
   const hasRecent = recentTracks.length > 0;
-  const hasUploaded = recentlyUploadedTracks.length > 0 || recentlyUploadedLoading;
+  const hasUploaded = recentlyUploadedItems.length > 0 || recentlyUploadedLoading;
   const canStartRadio = Boolean(onStartRadioPlayback && !radioLoading);
 
   const cardGridClass = "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4";
@@ -101,12 +102,11 @@ export function HomePanels({
       ) : null}
       {hasUploaded ? (
         <RecentlyUploadedPanel
-          tracks={recentlyUploadedTracks}
+          items={recentlyUploadedItems}
           loading={recentlyUploadedLoading}
           period={recentlyUploadedPeriod}
           onPeriodChange={onRecentlyUploadedPeriodChange}
           onTrackSelect={onRecentlyUploadedTrackSelect}
-          gridClassName={cardGridClass}
           ownerNameById={ownerNameById}
         />
       ) : null}

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -481,7 +481,7 @@ describe("LibraryPlaylistSection", () => {
     expect(screen.getByText(/20 tracks/)).toBeTruthy();
   });
 
-  it("hides Made for you section when empty", () => {
+  it("shows Made for you section with info message when empty", () => {
     render(
       <LibraryPlaylistSection
         {...defaultProps}
@@ -493,7 +493,8 @@ describe("LibraryPlaylistSection", () => {
       />
     );
 
-    expect(screen.queryByText("Made for you")).toBeNull();
+    expect(screen.getByText("Made for you")).toBeTruthy();
+    expect(screen.getByText(/Listen to more music/)).toBeTruthy();
   });
 
   it("calls dismiss on for-you playlist", () => {

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -22,6 +22,7 @@ export type LibraryPlaylistSectionProps = {
   forYouPlaylists: ForYouPlaylistSummary[];
   loadingForYouPlaylists: boolean;
   onDismissForYouPlaylist: (playlistId: string) => Promise<void>;
+  onRefreshForYouPlaylists?: () => Promise<{ regenerated: number }>;
 };
 
 // ── Mosaic cover (compact) ─────────────────────────────────────────
@@ -229,7 +230,8 @@ export function LibraryPlaylistSection({
   loadingAutoPlaylists,
   forYouPlaylists,
   loadingForYouPlaylists,
-  onDismissForYouPlaylist
+  onDismissForYouPlaylist,
+  onRefreshForYouPlaylists
 }: LibraryPlaylistSectionProps): JSX.Element {
   const [playlistName, setPlaylistName] = useState("");
   const [playlistDescription, setPlaylistDescription] = useState("");
@@ -334,9 +336,25 @@ export function LibraryPlaylistSection({
       </section>
 
       {/* ── Made For You ────────────────────────────────────────── */}
-      {!loadingForYouPlaylists && forYouPlaylists.length > 0 ? (
-        <section className="rounded-xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/60 to-purple-50/40 p-5 shadow-panel backdrop-blur-sm">
+      <section className="rounded-xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/60 to-purple-50/40 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex items-center justify-between">
           <SectionHeader title="Made for you" />
+          {!loadingForYouPlaylists && forYouPlaylists.length > 0 && (
+            <button
+              type="button"
+              className="text-xs text-indigo-600 hover:text-indigo-800"
+              onClick={() => { void onRefreshForYouPlaylists?.(); }}
+              title="Refresh recommendations"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+          )}
+        </div>
+        {loadingForYouPlaylists ? (
+          <p className="mt-2 text-sm text-flaque-steel">Loading recommendations...</p>
+        ) : forYouPlaylists.length > 0 ? (
           <div className="mt-4 grid grid-cols-3 gap-2.5 sm:grid-cols-4 lg:grid-cols-6">
             {forYouPlaylists.map((fy) => (
               <div
@@ -380,8 +398,10 @@ export function LibraryPlaylistSection({
               </div>
             ))}
           </div>
-        </section>
-      ) : null}
+        ) : (
+          <p className="mt-2 text-sm text-flaque-steel">No recommendations yet. Listen to more music!</p>
+        )}
+      </section>
 
       {/* ── Popular Playlists ─────────────────────────────────────── */}
       {popularPlaylists.length > 0 ? (

--- a/frontend/src/components/PlaylistsSection.tsx
+++ b/frontend/src/components/PlaylistsSection.tsx
@@ -23,6 +23,7 @@ export type PlaylistsSectionProps = {
   forYouPlaylists: ForYouPlaylistSummary[];
   loadingForYouPlaylists: boolean;
   onDismissForYouPlaylist: (playlistId: string) => Promise<void>;
+  onRefreshForYouPlaylists?: () => Promise<{ regenerated: number }>;
 };
 
 export function PlaylistsSection({
@@ -43,7 +44,8 @@ export function PlaylistsSection({
   loadingAutoPlaylists,
   forYouPlaylists,
   loadingForYouPlaylists,
-  onDismissForYouPlaylist
+  onDismissForYouPlaylist,
+  onRefreshForYouPlaylists
 }: PlaylistsSectionProps): JSX.Element {
   if (playlistDetailId && playlistDetailId.startsWith("for-you:")) {
     return (
@@ -107,6 +109,7 @@ export function PlaylistsSection({
       forYouPlaylists={forYouPlaylists}
       loadingForYouPlaylists={loadingForYouPlaylists}
       onDismissForYouPlaylist={onDismissForYouPlaylist}
+      onRefreshForYouPlaylists={onRefreshForYouPlaylists}
     />
   );
 }

--- a/frontend/src/components/RecentlyUploadedPanel.tsx
+++ b/frontend/src/components/RecentlyUploadedPanel.tsx
@@ -15,6 +15,8 @@ type RecentlyUploadedPanelProps = {
   period: UploadPeriod;
   onPeriodChange: (period: UploadPeriod) => void;
   onTrackSelect: (track: Track) => void;
+  onAlbumPlay: (album: RecentUploadAlbum) => void;
+  onAlbumOpen: (album: RecentUploadAlbum) => void;
   ownerNameById?: Record<string, string>;
 };
 
@@ -31,21 +33,23 @@ const GRID_CLASS =
 function VinylAlbumCard({
   album,
   onPlay,
+  onOpen,
   ownerLabel
 }: {
   album: RecentUploadAlbum;
-  onPlay: (track: Track) => void;
+  onPlay: (album: RecentUploadAlbum) => void;
+  onOpen: (album: RecentUploadAlbum) => void;
   ownerLabel?: string;
 }): JSX.Element {
-  const firstTrack = album.tracks[0]!;
   return (
-    <button
-      type="button"
-      className="group w-full overflow-hidden rounded-xl border border-flaque-clay/60 bg-white/85 text-left shadow-sm transition hover:shadow-md"
-      onClick={() => onPlay(firstTrack)}
-      title={`${album.albumName} · ${album.trackCount} tracks`}
-    >
-      <div className="relative aspect-square w-full overflow-hidden p-2">
+    <div className="group w-full overflow-hidden rounded-xl border border-flaque-clay/60 bg-flaque-cream/60 text-left shadow-sm transition hover:shadow-md">
+      <button
+        type="button"
+        className="relative block aspect-square w-full overflow-hidden cursor-pointer"
+        onClick={() => onPlay(album)}
+        title={`Play ${album.albumName}`}
+        aria-label={`Play ${album.albumName}`}
+      >
         {/* Vinyl disc */}
         <div className="absolute inset-2 rounded-full bg-gradient-to-br from-neutral-800 via-neutral-900 to-black shadow-md transition-transform duration-700 ease-out group-hover:rotate-[20deg]">
           {/* Grooves */}
@@ -64,9 +68,9 @@ function VinylAlbumCard({
             <div className="absolute left-1/2 top-1/2 h-[14%] w-[14%] -translate-x-1/2 -translate-y-1/2 rounded-full bg-black ring-1 ring-white/10" />
           </div>
         </div>
-        {/* Play overlay */}
-        <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-black/0 opacity-0 transition group-hover:bg-black/20 group-hover:opacity-100">
-          <svg className="h-7 w-7 text-white drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        {/* Round play overlay (covers the disc only) */}
+        <div className="pointer-events-none absolute inset-2 flex items-center justify-center rounded-full bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100">
+          <svg className="h-7 w-7 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
             <path d="M8 6v12l10-6-10-6z" />
           </svg>
         </div>
@@ -74,15 +78,20 @@ function VinylAlbumCard({
         <span className="absolute bottom-1 right-1 rounded-md bg-indigo-700/85 px-1.5 py-0.5 text-[9px] font-semibold text-white">
           {album.trackCount}
         </span>
-      </div>
-      <div className="bg-flaque-cream/60 px-2 py-1.5">
+      </button>
+      <button
+        type="button"
+        className="block w-full cursor-pointer px-2 py-1.5 text-left transition hover:bg-flaque-cream"
+        onClick={() => onOpen(album)}
+        title={`Open ${album.albumName}`}
+      >
         <p className="truncate text-[11px] font-semibold text-flaque-ink">{album.albumName}</p>
         <p className="truncate text-[10px] text-flaque-steel">{album.artist}</p>
         {ownerLabel ? (
           <p className="truncate text-[10px] text-flaque-steel/50">{ownerLabel}</p>
         ) : null}
-      </div>
-    </button>
+      </button>
+    </div>
   );
 }
 
@@ -116,7 +125,7 @@ function TrackCard({
           onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
         />
         <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100">
-          <svg className="h-7 w-7 text-white drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <svg className="h-7 w-7 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
             <path d="M8 6v12l10-6-10-6z" />
           </svg>
         </div>
@@ -143,6 +152,8 @@ export function RecentlyUploadedPanel({
   period,
   onPeriodChange,
   onTrackSelect,
+  onAlbumPlay,
+  onAlbumOpen,
   ownerNameById
 }: RecentlyUploadedPanelProps): JSX.Element | null {
   if (!loading && items.length === 0) {
@@ -183,7 +194,8 @@ export function RecentlyUploadedPanel({
               <VinylAlbumCard
                 key={`album:${item.album.albumName}:${item.album.owner}`}
                 album={item.album}
-                onPlay={onTrackSelect}
+                onPlay={onAlbumPlay}
+                onOpen={onAlbumOpen}
                 ownerLabel={ownerNameById ? resolveOwner(item.album.owner) : undefined}
               />
             ) : (

--- a/frontend/src/components/RecentlyUploadedPanel.tsx
+++ b/frontend/src/components/RecentlyUploadedPanel.tsx
@@ -1,14 +1,20 @@
+import { coverUrl } from "../api";
+import defaultCoverImage from "../assets/default-cover.png";
+import type { RecentUploadAlbum, RecentUploadItem } from "../api";
 import type { Track } from "../types";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
-import { TrackCardGrid } from "./TrackCardGrid";
+import {
+  getTrackDisplayAlbumWithYear,
+  getTrackDisplayArtist,
+  getTrackDisplayTitle
+} from "../utils/tracks";
 
 type RecentlyUploadedPanelProps = {
-  tracks: Track[];
+  items: RecentUploadItem[];
   loading: boolean;
   period: UploadPeriod;
   onPeriodChange: (period: UploadPeriod) => void;
   onTrackSelect: (track: Track) => void;
-  gridClassName?: string;
   ownerNameById?: Record<string, string>;
 };
 
@@ -17,18 +23,133 @@ const periodOptions: { value: UploadPeriod; label: string; shortLabel: string }[
   { value: "30d", label: "30 days", shortLabel: "30d" }
 ];
 
+const GRID_CLASS =
+  "grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-6";
+
+// ── Album card (vinyl) ────────────────────────────────────────────
+
+function VinylAlbumCard({
+  album,
+  onPlay,
+  ownerLabel
+}: {
+  album: RecentUploadAlbum;
+  onPlay: (track: Track) => void;
+  ownerLabel?: string;
+}): JSX.Element {
+  const firstTrack = album.tracks[0]!;
+  return (
+    <button
+      type="button"
+      className="group w-full overflow-hidden rounded-xl border border-flaque-clay/60 bg-white/85 text-left shadow-sm transition hover:shadow-md"
+      onClick={() => onPlay(firstTrack)}
+      title={`${album.albumName} · ${album.trackCount} tracks`}
+    >
+      <div className="relative aspect-square w-full overflow-hidden p-2">
+        {/* Vinyl disc */}
+        <div className="absolute inset-2 rounded-full bg-gradient-to-br from-neutral-800 via-neutral-900 to-black shadow-md transition-transform duration-700 ease-out group-hover:rotate-[20deg]">
+          {/* Grooves */}
+          <div className="absolute inset-[4%] rounded-full border border-white/[0.04]" />
+          <div className="absolute inset-[11%] rounded-full border border-white/[0.05]" />
+          <div className="absolute inset-[18%] rounded-full border border-white/[0.06]" />
+          {/* Label (album cover clipped to circle) */}
+          <div className="absolute inset-[22%] overflow-hidden rounded-full border border-black/60 shadow-inner">
+            <img
+              className="h-full w-full object-cover"
+              src={coverUrl(album.coverTrackId)}
+              alt={`Cover for ${album.albumName}`}
+              onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
+            />
+            {/* Center spindle hole */}
+            <div className="absolute left-1/2 top-1/2 h-[14%] w-[14%] -translate-x-1/2 -translate-y-1/2 rounded-full bg-black ring-1 ring-white/10" />
+          </div>
+        </div>
+        {/* Play overlay */}
+        <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-black/0 opacity-0 transition group-hover:bg-black/20 group-hover:opacity-100">
+          <svg className="h-7 w-7 text-white drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M8 6v12l10-6-10-6z" />
+          </svg>
+        </div>
+        {/* Track count badge */}
+        <span className="absolute bottom-1 right-1 rounded-md bg-indigo-700/85 px-1.5 py-0.5 text-[9px] font-semibold text-white">
+          {album.trackCount}
+        </span>
+      </div>
+      <div className="bg-flaque-cream/60 px-2 py-1.5">
+        <p className="truncate text-[11px] font-semibold text-flaque-ink">{album.albumName}</p>
+        <p className="truncate text-[10px] text-flaque-steel">{album.artist}</p>
+        {ownerLabel ? (
+          <p className="truncate text-[10px] text-flaque-steel/50">{ownerLabel}</p>
+        ) : null}
+      </div>
+    </button>
+  );
+}
+
+// ── Track card ────────────────────────────────────────────────────
+
+function TrackCard({
+  track,
+  onSelect,
+  ownerLabel
+}: {
+  track: Track;
+  onSelect: (track: Track) => void;
+  ownerLabel?: string;
+}): JSX.Element {
+  const title = getTrackDisplayTitle(track);
+  const artist = getTrackDisplayArtist(track) ?? "Unknown artist";
+  const albumWithYear = getTrackDisplayAlbumWithYear(track);
+
+  return (
+    <button
+      type="button"
+      className="group w-full overflow-hidden rounded-xl border border-flaque-clay/60 bg-white/85 text-left shadow-sm transition hover:shadow-md"
+      onClick={() => onSelect(track)}
+      title={title}
+    >
+      <div className="relative aspect-square w-full overflow-hidden">
+        <img
+          className="h-full w-full object-cover"
+          src={coverUrl(track.id, track.cover)}
+          alt={albumWithYear ? `Cover for ${albumWithYear}` : `Cover for ${title}`}
+          onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
+        />
+        <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100">
+          <svg className="h-7 w-7 text-white drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M8 6v12l10-6-10-6z" />
+          </svg>
+        </div>
+      </div>
+      <div className="bg-flaque-cream/60 px-2 py-1.5">
+        <p className="truncate text-[11px] font-semibold text-flaque-ink">{title}</p>
+        <p className="truncate text-[10px] text-flaque-steel">{artist}</p>
+        {albumWithYear ? (
+          <p className="truncate text-[10px] text-flaque-steel/70">{albumWithYear}</p>
+        ) : null}
+        {ownerLabel ? (
+          <p className="truncate text-[10px] text-flaque-steel/50">{ownerLabel}</p>
+        ) : null}
+      </div>
+    </button>
+  );
+}
+
+// ── Panel ─────────────────────────────────────────────────────────
+
 export function RecentlyUploadedPanel({
-  tracks,
+  items,
   loading,
   period,
   onPeriodChange,
   onTrackSelect,
-  gridClassName,
   ownerNameById
 }: RecentlyUploadedPanelProps): JSX.Element | null {
-  if (!loading && tracks.length === 0) {
+  if (!loading && items.length === 0) {
     return null;
   }
+
+  const resolveOwner = (owner: string): string => ownerNameById?.[owner] ?? owner;
 
   return (
     <section className="border border-flaque-clay/60 rounded-xl bg-white/85 p-5 shadow-panel backdrop-blur-sm">
@@ -53,10 +174,28 @@ export function RecentlyUploadedPanel({
         </div>
       </div>
 
-      {loading && tracks.length === 0 ? (
+      {loading && items.length === 0 ? (
         <p className="mt-3 text-sm text-flaque-steel">Loading...</p>
       ) : (
-        <TrackCardGrid tracks={tracks} onTrackSelect={onTrackSelect} gridClassName={gridClassName} ownerNameById={ownerNameById} showOwner />
+        <div className={`mt-3 grid gap-2 ${GRID_CLASS}`}>
+          {items.map((item) =>
+            item.kind === "album" ? (
+              <VinylAlbumCard
+                key={`album:${item.album.albumName}:${item.album.owner}`}
+                album={item.album}
+                onPlay={onTrackSelect}
+                ownerLabel={ownerNameById ? resolveOwner(item.album.owner) : undefined}
+              />
+            ) : (
+              <TrackCard
+                key={item.track.id}
+                track={item.track}
+                onSelect={onTrackSelect}
+                ownerLabel={ownerNameById ? resolveOwner(item.track.owner) : undefined}
+              />
+            )
+          )}
+        </div>
       )}
     </section>
   );

--- a/frontend/src/hooks/useLibraryData.ts
+++ b/frontend/src/hooks/useLibraryData.ts
@@ -234,7 +234,15 @@ export function useLibraryData({
         return null;
       }
 
-      return libraryArtists.some((artist) => normalizeText(artist.name) === normalizeText(current.name)) ? current : null;
+      // Skip validation while artists are still loading — would otherwise
+      // discard a selection made while navigating in (e.g. from the player).
+      if (libraryArtists.length === 0) {
+        return current;
+      }
+
+      const target = normalizeText(current.name);
+      const match = libraryArtists.find((artist) => normalizeText(artist.name) === target);
+      return match ?? null;
     });
   }, [activeLibrarySection, libraryArtists]);
 
@@ -390,7 +398,16 @@ export function useLibraryData({
       }
 
       const currentKey = getAlbumKey(current);
-      const match = libraryAlbums.find((album) => getAlbumKey(album) === currentKey);
+      const currentName = normalizeText(current.name);
+      const currentArtist = normalizeText(current.artist);
+      // Match by stable key first; fall back to name+artist so a synthetic
+      // entry created without an id (e.g. from the player) gets upgraded to
+      // the canonical indexed album once it loads.
+      const match = libraryAlbums.find(
+        (album) =>
+          getAlbumKey(album) === currentKey ||
+          (normalizeText(album.name) === currentName && normalizeText(album.artist) === currentArtist)
+      );
       return match ?? null;
     });
   }, [activeLibrarySection, libraryAlbums]);

--- a/frontend/src/hooks/useLibraryData.ts
+++ b/frontend/src/hooks/useLibraryData.ts
@@ -383,8 +383,15 @@ export function useLibraryData({
         return null;
       }
 
+      // Skip validation while albums are still loading — would otherwise
+      // discard a selection made while navigating in (e.g. from Home).
+      if (libraryAlbums.length === 0) {
+        return current;
+      }
+
       const currentKey = getAlbumKey(current);
-      return libraryAlbums.some((album) => getAlbumKey(album) === currentKey) ? current : null;
+      const match = libraryAlbums.find((album) => getAlbumKey(album) === currentKey);
+      return match ?? null;
     });
   }, [activeLibrarySection, libraryAlbums]);
 

--- a/frontend/src/hooks/useRecentlyUploaded.test.tsx
+++ b/frontend/src/hooks/useRecentlyUploaded.test.tsx
@@ -3,10 +3,10 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getTracksMock = vi.fn();
+const getRecentUploadsMock = vi.fn();
 
 vi.mock("../api", () => ({
-  getTracks: (...args: unknown[]) => getTracksMock(...args)
+  getRecentUploads: (...args: unknown[]) => getRecentUploadsMock(...args)
 }));
 
 import type { User } from "../types";
@@ -20,7 +20,7 @@ const USER: User = {
 };
 
 beforeEach(() => {
-  getTracksMock.mockReset();
+  getRecentUploadsMock.mockReset();
 });
 
 describe("useRecentlyUploaded", () => {
@@ -30,50 +30,47 @@ describe("useRecentlyUploaded", () => {
     );
 
     expect(result.current.loading).toBe(false);
-    expect(result.current.tracks).toEqual([]);
-    expect(getTracksMock).not.toHaveBeenCalled();
+    expect(result.current.items).toEqual([]);
+    expect(getRecentUploadsMock).not.toHaveBeenCalled();
   });
 
-  it("requests tracks sorted by addedAt desc with the 7d window by default", async () => {
-    getTracksMock.mockResolvedValueOnce({
-      tracks: [{ id: "t1" }, { id: "t2" }]
-    });
+  it("requests recent uploads with the 7d window by default", async () => {
+    getRecentUploadsMock.mockResolvedValueOnce([
+      { kind: "track", track: { id: "t1" } },
+      { kind: "track", track: { id: "t2" } }
+    ]);
 
     const { result } = renderHook(() => useRecentlyUploaded({ user: USER }));
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    const call = getTracksMock.mock.calls[0]?.[0];
-    expect(call).toMatchObject({
-      sortBy: "addedAt",
-      sortDir: "desc",
-      limit: 12
-    });
+    const call = getRecentUploadsMock.mock.calls[0]?.[0];
+    expect(call).toMatchObject({ limit: 12 });
     expect(typeof call.addedAfter).toBe("string");
     expect(result.current.period).toBe("7d");
-    expect(result.current.tracks.map((t) => t.id)).toEqual(["t1", "t2"]);
+    expect(result.current.items).toHaveLength(2);
   });
 
   it("re-fetches with a wider addedAfter window when period flips to 30d", async () => {
-    getTracksMock.mockResolvedValue({ tracks: [] });
+    getRecentUploadsMock.mockResolvedValue([]);
     const { result } = renderHook(() => useRecentlyUploaded({ user: USER }));
-    await waitFor(() => expect(getTracksMock).toHaveBeenCalledTimes(1));
-    const first = getTracksMock.mock.calls[0]![0].addedAfter as string;
+    await waitFor(() => expect(getRecentUploadsMock).toHaveBeenCalledTimes(1));
+    const first = getRecentUploadsMock.mock.calls[0]![0].addedAfter as string;
 
     await act(async () => {
       result.current.setPeriod("30d");
     });
-    await waitFor(() => expect(getTracksMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(getRecentUploadsMock).toHaveBeenCalledTimes(2));
 
-    const second = getTracksMock.mock.calls[1]![0].addedAfter as string;
+    const second = getRecentUploadsMock.mock.calls[1]![0].addedAfter as string;
     expect(new Date(second).getTime()).toBeLessThan(new Date(first).getTime());
   });
 
   it("forwards the ownerFilter argument to the API call", async () => {
-    getTracksMock.mockResolvedValueOnce({ tracks: [] });
+    getRecentUploadsMock.mockResolvedValueOnce([]);
     renderHook(() =>
       useRecentlyUploaded({ user: USER, ownerFilter: "user-2" })
     );
-    await waitFor(() => expect(getTracksMock).toHaveBeenCalled());
-    expect(getTracksMock.mock.calls[0]?.[0].owner).toBe("user-2");
+    await waitFor(() => expect(getRecentUploadsMock).toHaveBeenCalled());
+    expect(getRecentUploadsMock.mock.calls[0]?.[0].owner).toBe("user-2");
   });
 });

--- a/frontend/src/hooks/useRecentlyUploaded.ts
+++ b/frontend/src/hooks/useRecentlyUploaded.ts
@@ -1,7 +1,8 @@
 import { useCallback, useState } from "react";
 
-import { getTracks } from "../api";
-import type { Track, User } from "../types";
+import { getRecentUploads } from "../api";
+import type { RecentUploadItem } from "../api";
+import type { User } from "../types";
 import { useQuery } from "./useQuery";
 
 export type UploadPeriod = "7d" | "30d";
@@ -17,14 +18,14 @@ type UseRecentlyUploadedArgs = {
 };
 
 type UseRecentlyUploadedResult = {
-  tracks: Track[];
+  items: RecentUploadItem[];
   loading: boolean;
   period: UploadPeriod;
   setPeriod: (period: UploadPeriod) => void;
   refresh: () => void;
 };
 
-const EMPTY: Track[] = [];
+const EMPTY: RecentUploadItem[] = [];
 
 export function useRecentlyUploaded({
   user,
@@ -34,17 +35,10 @@ export function useRecentlyUploaded({
 
   const fetcher = useCallback(async () => {
     const addedAfter = new Date(Date.now() - PERIOD_MS[period]).toISOString();
-    const response = await getTracks({
-      sortBy: "addedAt",
-      sortDir: "desc",
-      limit: 12,
-      addedAfter,
-      owner: ownerFilter
-    });
-    return response.tracks;
+    return getRecentUploads({ addedAfter, limit: 12, owner: ownerFilter });
   }, [period, ownerFilter]);
 
-  const { data, loading, refresh } = useQuery<Track[]>(fetcher, EMPTY, { enabled: Boolean(user) });
+  const { data, loading, refresh } = useQuery<RecentUploadItem[]>(fetcher, EMPTY, { enabled: Boolean(user) });
 
-  return { tracks: data, loading, period, setPeriod, refresh };
+  return { items: data, loading, period, setPeriod, refresh };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=Space+Grotesk:wght@400;500;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=Share+Tech+Mono&family=Space+Grotesk:wght@400;500;700&family=VT323&display=swap");
 
 @tailwind base;
 @tailwind components;
@@ -79,6 +79,114 @@ input[type="range"]::-moz-range-thumb {
   border-radius: 9999px;
   background: rgb(var(--flaque-ink-rgb));
   cursor: pointer;
+}
+
+.font-lcd {
+  font-family: "VT323", "Share Tech Mono", ui-monospace, Menlo, monospace;
+  letter-spacing: 0.02em;
+}
+
+.radio-screen {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(44, 31, 26, 0.05) 100%),
+    #bdb3a1;
+  color: rgb(var(--flaque-ink-rgb));
+  border: 1px solid #8f8270;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.25),
+    inset 0 -2px 6px rgba(44, 31, 26, 0.12),
+    inset 0 0 26px rgba(44, 31, 26, 0.08);
+}
+
+.radio-screen .radio-screen-subtle {
+  color: rgb(var(--flaque-ink-rgb) / 0.55);
+}
+
+:root[data-theme="dark"] .radio-screen {
+  background:
+    radial-gradient(ellipse at 50% -20%, rgba(168, 183, 208, 0.12), transparent 60%),
+    linear-gradient(180deg, #1c2635 0%, #131a27 100%);
+  color: rgb(var(--flaque-steel-rgb));
+  border: 1px solid #3a4658;
+  box-shadow:
+    inset 0 0 28px rgba(168, 183, 208, 0.1),
+    inset 0 1px 0 rgba(168, 183, 208, 0.12),
+    0 0 14px rgba(30, 41, 59, 0.4);
+  text-shadow:
+    0 0 5px rgba(168, 183, 208, 0.45),
+    0 0 12px rgba(123, 144, 174, 0.2);
+}
+
+:root[data-theme="dark"] .radio-screen .radio-screen-subtle {
+  color: rgb(var(--flaque-steel-rgb) / 0.65);
+}
+
+.radio-play-btn {
+  color: rgb(var(--flaque-ink-rgb));
+  background:
+    linear-gradient(180deg, #ebe3d2 0%, #d2c5ad 48%, #a89a82 100%);
+  border: 1px solid #7d7058;
+  box-shadow:
+    inset 0 2px 0 rgba(255, 255, 255, 0.6),
+    inset 0 -4px 8px rgba(44, 31, 26, 0.2),
+    0 5px 0 rgba(110, 93, 68, 0.55),
+    0 8px 16px rgba(44, 31, 26, 0.22);
+  transition:
+    transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    filter 180ms ease;
+  will-change: transform, box-shadow;
+}
+
+.radio-play-btn:hover:not(:disabled) {
+  transform: translateY(3px);
+  filter: brightness(0.97);
+  box-shadow:
+    inset 0 2px 5px rgba(44, 31, 26, 0.3),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.2),
+    0 2px 0 rgba(110, 93, 68, 0.45),
+    0 3px 6px rgba(44, 31, 26, 0.18);
+}
+
+.radio-play-btn:active:not(:disabled) {
+  transform: translateY(5px);
+  box-shadow:
+    inset 0 3px 7px rgba(44, 31, 26, 0.38),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.12),
+    0 0 0 rgba(110, 93, 68, 0.3),
+    0 1px 2px rgba(44, 31, 26, 0.15);
+}
+
+.radio-play-btn:disabled {
+  opacity: 0.6;
+}
+
+:root[data-theme="dark"] .radio-play-btn {
+  color: rgb(var(--flaque-ink-rgb));
+  background:
+    linear-gradient(180deg, #58647a 0%, #3a4356 50%, #232936 100%);
+  border: 1px solid #15181f;
+  box-shadow:
+    inset 0 2px 0 rgba(236, 242, 250, 0.1),
+    inset 0 -4px 8px rgba(0, 0, 0, 0.45),
+    0 5px 0 #0c0f15,
+    0 8px 16px rgba(0, 0, 0, 0.5);
+}
+
+:root[data-theme="dark"] .radio-play-btn:hover:not(:disabled) {
+  box-shadow:
+    inset 0 2px 5px rgba(0, 0, 0, 0.55),
+    inset 0 -1px 0 rgba(236, 242, 250, 0.07),
+    0 2px 0 #0c0f15,
+    0 3px 6px rgba(0, 0, 0, 0.4);
+}
+
+:root[data-theme="dark"] .radio-play-btn:active:not(:disabled) {
+  box-shadow:
+    inset 0 3px 7px rgba(0, 0, 0, 0.65),
+    inset 0 -1px 0 rgba(236, 242, 250, 0.04),
+    0 0 0 #0c0f15,
+    0 1px 2px rgba(0, 0, 0, 0.35);
 }
 
 .header-logo-dark {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "frontend"
   ],
   "scripts": {
-    "dev": "npm run dev:all",
-    "dev:all": "concurrently -n backend,frontend -c cyan,magenta \"npm run dev:backend\" \"npm run dev:frontend\"",
+    "dev": "concurrently --kill-others-on-fail -n backend,frontend -c cyan,magenta \"npm run dev:backend\" \"npm run dev:frontend\"",
     "dev:backend": "npm run dev --workspace backend",
     "dev:frontend": "npm run dev --workspace frontend",
+    "dev:clean": "rm -rf frontend/dist frontend/node_modules/.vite && npm run dev",
     "build": "npm run build --workspace backend && npm run build --workspace frontend",
     "test": "npm run test:backend && npm run test:frontend",
     "test:backend": "npm run test --workspace backend",


### PR DESCRIPTION
## Summary
- **For You**: always render the *Made for you* section with proper loading/empty states + manual refresh button; fixes playlists never showing after boot or manual regeneration.
- **Home**: vinyl-grouped Recent Uploads panel with compact cards, redesigned radio panel as a cassette-deck PLAY + LCD screen, and a clean-up pass on Recent Uploads album cards.
- **Player**: artist and album in the now-playing chrome are now clickable and navigate to the matching library entry, with a fix for the first-click race that previously dropped the selection during navigation.
- **Auto-playlist detail**: clicking a track row plays from that track (rotating the queue), header card visual refresh, and shuffle icon swapped to match the rest of the app.
- **Tests**: backend API tests now run in-process via `app.handle` against a mocked `IncomingMessage`/`ServerResponse` pair instead of binding a real HTTP port per test (faster, no port flakiness); `AccountView` tests use `vi.hoisted` and stub the `api` module so they render under jsdom.

## Test plan
- [x] `npm run test:backend` — 331/331 pass
- [x] `npm run test:frontend` — 151/151 pass
- [x] `npm run build` — backend `tsc` + frontend `tsc && vite build` clean
- [x] Manual: open the app, click the artist and album in the player chrome on first load and confirm both navigate to the correct library entry
- [x] Manual: open an auto-playlist, click a track in the list, confirm playback starts from that track
- [x] Manual: home page renders Recent Uploads grouped by vinyl + the cassette-deck radio panel
- [x] Manual: For You section renders loading/empty states and the refresh button works