### PR TITLE
style: polish recent uploads + recent tracks cards

### DIFF
--- a/frontend/src/components/RecentlyUploadedPanel.tsx
+++ b/frontend/src/components/RecentlyUploadedPanel.tsx
@@ -42,13 +42,19 @@ function VinylAlbumCard({
   ownerLabel?: string;
 }): JSX.Element {
   return (
-    <div className="group w-full overflow-hidden rounded-xl border border-flaque-clay/60 bg-flaque-cream/60 text-left shadow-sm transition hover:shadow-md">
+    <div className="group w-full overflow-hidden rounded-xl text-left shadow-sm transition hover:shadow-md">
       <button
         type="button"
-        className="relative block aspect-square w-full overflow-hidden cursor-pointer"
+        className="relative block aspect-square w-full cursor-pointer overflow-hidden bg-flaque-cream"
         onClick={() => onPlay(album)}
         title={`Play ${album.albumName}`}
         aria-label={`Play ${album.albumName}`}
+        style={{
+          WebkitMaskImage:
+            "radial-gradient(circle at 50% 50%, transparent 4%, black 4.5%)",
+          maskImage:
+            "radial-gradient(circle at 50% 50%, transparent 4%, black 4.5%)"
+        }}
       >
         {/* Vinyl disc */}
         <div className="absolute inset-2 rounded-full bg-gradient-to-br from-neutral-800 via-neutral-900 to-black shadow-md transition-transform duration-700 ease-out group-hover:rotate-[20deg]">
@@ -57,15 +63,13 @@ function VinylAlbumCard({
           <div className="absolute inset-[11%] rounded-full border border-white/[0.05]" />
           <div className="absolute inset-[18%] rounded-full border border-white/[0.06]" />
           {/* Label (album cover clipped to circle) */}
-          <div className="absolute inset-[22%] overflow-hidden rounded-full border border-black/60 shadow-inner">
+          <div className="absolute inset-[22%] overflow-hidden rounded-full border border-flaque-cream shadow-inner">
             <img
               className="h-full w-full object-cover"
               src={coverUrl(album.coverTrackId)}
               alt={`Cover for ${album.albumName}`}
               onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
             />
-            {/* Center spindle hole */}
-            <div className="absolute left-1/2 top-1/2 h-[14%] w-[14%] -translate-x-1/2 -translate-y-1/2 rounded-full bg-black ring-1 ring-white/10" />
           </div>
         </div>
         {/* Round play overlay (covers the disc only) */}
@@ -75,13 +79,13 @@ function VinylAlbumCard({
           </svg>
         </div>
         {/* Track count badge */}
-        <span className="absolute bottom-1 right-1 rounded-md bg-indigo-700/85 px-1.5 py-0.5 text-[9px] font-semibold text-white">
-          {album.trackCount}
+        <span className="absolute bottom-1 right-1 rounded-md bg-flaque-ink/85 px-1.5 py-0.5 text-[9px] font-semibold text-white">
+          +{album.trackCount} tracks
         </span>
       </button>
       <button
         type="button"
-        className="block w-full cursor-pointer px-2 py-1.5 text-left transition hover:bg-flaque-cream"
+        className="block w-full cursor-pointer bg-flaque-cream px-2 py-1.5 text-left"
         onClick={() => onOpen(album)}
         title={`Open ${album.albumName}`}
       >
@@ -113,7 +117,7 @@ function TrackCard({
   return (
     <button
       type="button"
-      className="group w-full overflow-hidden rounded-xl border border-flaque-clay/60 bg-white/85 text-left shadow-sm transition hover:shadow-md"
+      className="group w-full overflow-hidden rounded-xl bg-white/85 text-left shadow-sm transition hover:shadow-md"
       onClick={() => onSelect(track)}
       title={title}
     >
@@ -130,7 +134,7 @@ function TrackCard({
           </svg>
         </div>
       </div>
-      <div className="bg-flaque-cream/60 px-2 py-1.5">
+      <div className="bg-flaque-cream px-2 py-1.5">
         <p className="truncate text-[11px] font-semibold text-flaque-ink">{title}</p>
         <p className="truncate text-[10px] text-flaque-steel">{artist}</p>
         {albumWithYear ? (

--- a/frontend/src/components/RecentlyUploadedPanel.tsx
+++ b/frontend/src/components/RecentlyUploadedPanel.tsx
@@ -6,7 +6,8 @@ import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
 import {
   getTrackDisplayAlbumWithYear,
   getTrackDisplayArtist,
-  getTrackDisplayTitle
+  getTrackDisplayTitle,
+  getTrackDisplayYear
 } from "../utils/tracks";
 
 type RecentlyUploadedPanelProps = {
@@ -41,8 +42,12 @@ function VinylAlbumCard({
   onOpen: (album: RecentUploadAlbum) => void;
   ownerLabel?: string;
 }): JSX.Element {
+  const year = album.tracks
+    .map((track) => getTrackDisplayYear(track))
+    .find((value): value is string => Boolean(value));
+  const albumLabel = year ? `${album.albumName} (${year})` : album.albumName;
   return (
-    <div className="group w-full overflow-hidden rounded-xl text-left shadow-sm transition hover:shadow-md">
+    <div className="group relative flex w-full flex-col overflow-hidden rounded-xl text-left shadow-sm transition hover:shadow-md">
       <button
         type="button"
         className="relative block aspect-square w-full cursor-pointer overflow-hidden bg-flaque-cream"
@@ -72,29 +77,38 @@ function VinylAlbumCard({
             />
           </div>
         </div>
-        {/* Round play overlay (covers the disc only) */}
-        <div className="pointer-events-none absolute inset-2 flex items-center justify-center rounded-full bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100">
-          <svg className="h-7 w-7 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
-            <path d="M8 6v12l10-6-10-6z" />
-          </svg>
-        </div>
         {/* Track count badge */}
         <span className="absolute bottom-1 right-1 rounded-md bg-flaque-ink/85 px-1.5 py-0.5 text-[9px] font-semibold text-white">
           +{album.trackCount} tracks
         </span>
       </button>
-      <button
-        type="button"
-        className="block w-full cursor-pointer bg-flaque-cream px-2 py-1.5 text-left"
+      <div
+        role="button"
+        tabIndex={0}
+        className="w-full flex-1 cursor-pointer bg-flaque-cream px-2 py-1.5 text-left"
         onClick={() => onOpen(album)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onOpen(album);
+          }
+        }}
         title={`Open ${album.albumName}`}
       >
-        <p className="truncate text-[11px] font-semibold text-flaque-ink">{album.albumName}</p>
+        <p className="truncate text-[11px] font-semibold text-flaque-ink">{albumLabel}</p>
         <p className="truncate text-[10px] text-flaque-steel">{album.artist}</p>
         {ownerLabel ? (
           <p className="truncate text-[10px] text-flaque-steel/50">{ownerLabel}</p>
         ) : null}
-      </button>
+      </div>
+      {/* Round play overlay (sibling, so the vinyl mask doesn't hide it) */}
+      <div className="pointer-events-none absolute inset-x-0 top-0 aspect-square">
+        <div className="absolute inset-2 flex items-center justify-center rounded-full bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100">
+          <svg className="h-7 w-7 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
+            <path d="M8 6v12l10-6-10-6z" />
+          </svg>
+        </div>
+      </div>
     </div>
   );
 }
@@ -117,7 +131,7 @@ function TrackCard({
   return (
     <button
       type="button"
-      className="group w-full overflow-hidden rounded-xl bg-white/85 text-left shadow-sm transition hover:shadow-md"
+      className="group flex w-full flex-col overflow-hidden rounded-xl bg-white/85 text-left shadow-sm transition hover:shadow-md"
       onClick={() => onSelect(track)}
       title={title}
     >
@@ -134,7 +148,7 @@ function TrackCard({
           </svg>
         </div>
       </div>
-      <div className="bg-flaque-cream px-2 py-1.5">
+      <div className="flex-1 bg-flaque-cream px-2 py-1.5">
         <p className="truncate text-[11px] font-semibold text-flaque-ink">{title}</p>
         <p className="truncate text-[10px] text-flaque-steel">{artist}</p>
         {albumWithYear ? (

--- a/frontend/src/components/TrackCardGrid.tsx
+++ b/frontend/src/components/TrackCardGrid.tsx
@@ -35,14 +35,14 @@ export function TrackCardGrid({
         return (
           <button
             key={track.id}
-            className="w-full rounded-xl border border-flaque-clay/60 bg-flaque-cream/50 p-2.5 text-left transition hover:bg-flaque-cream"
+            className="w-full rounded-xl bg-flaque-cream/50 p-2.5 text-left transition hover:bg-flaque-cream"
             type="button"
             onClick={() => onTrackSelect(track)}
             title={title}
           >
             <div className="flex items-start gap-3">
               <img
-                className="h-14 w-14 shrink-0 rounded-lg border border-flaque-clay/50 object-cover"
+                className="h-14 w-14 shrink-0 rounded-lg object-cover"
                 src={coverUrl(track.id, track.cover)}
                 alt={albumWithYear ? `Cover for ${albumWithYear}` : `Cover for ${title}`}
                 onError={(event) => {


### PR DESCRIPTION
## Summary
- Recent Uploads: align album/track cards with the cream palette, show album year next to album name, refactor vinyl click overlay so the play affordance sits above the masked disc
- Played Recently: remove the clay borders around track cards and cover thumbnails for a cleaner look

## Test plan
- [x] Library view: Recent Uploads cards still play on cover click and open on label click; album year appears in parentheses when known
- [x] Library view: Played Recently cards no longer show outlines and still play on click
- [x] Recent tracks list still persists across page refreshes (existing localStorage behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)