### PR TITLE
Made-for-you polish, shuffle coherence, playlist refactor

### DIFF
--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -198,7 +198,7 @@ export function AuthenticatedApp({
     requestTrackPlaybackWithStatus, handleReplayRecentTrack,
     handlePlayPlaylist, handlePlayAlbum, handleNavigateTrack
   } = usePlaybackCommands({
-    selectedTrackRefreshed, refreshedQueue, shuffleEnabled,
+    selectedTrackRefreshed, refreshedQueue, shuffleEnabled, setShuffleEnabled,
     allTracks: allTracksLibrary.tracks, filters, allTracksById,
     requestTrackPlayback, replayRecentTrack, setSelectedTrack,
     setPlayerStatusMessage, setLibraryError, setAppNotice

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -377,6 +377,7 @@ export function AuthenticatedApp({
           manageablePlaylists,
           ownerNameById,
           allTracksById,
+          artists: library.artists,
           user,
           onCreatePlaylist: handleCreatePlaylist,
           onPlayPlaylist: handlePlayPlaylist,

--- a/frontend/src/components/AutoPlaylistDetailView.tsx
+++ b/frontend/src/components/AutoPlaylistDetailView.tsx
@@ -1,24 +1,17 @@
 import { useEffect, useMemo, useState } from "react";
 
-import { coverUrl, getAutoPlaylistDetail } from "../api";
+import { getAutoPlaylistDetail } from "../api";
+import { usePlaylistDetailPlayback } from "../hooks/usePlaylistDetailPlayback";
 import type { AutoPlaylistDetail, Playlist, Track } from "../types";
-import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+import { formatDurationCompact } from "../utils/format";
+import { PlaylistTrackList } from "./PlaylistTrackList";
 
 export type AutoPlaylistDetailViewProps = {
   playlistId: string;
   allTracksById: Map<string, Track>;
   onBack: () => void;
-  onPlayTrack: (playlist: Playlist) => void;
+  onPlayTrack: (playlist: Playlist, options?: { shuffle?: boolean }) => void;
 };
-
-function formatDuration(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = Math.floor(seconds % 60);
-  if (h > 0) return `${h}h ${m}m`;
-  if (m > 0) return `${m}m ${s}s`;
-  return `${s}s`;
-}
 
 export function AutoPlaylistDetailView({
   playlistId,
@@ -53,9 +46,9 @@ export function AutoPlaylistDetailView({
 
   const totalDuration = useMemo(() => tracks.reduce((sum, t) => sum + t.duration, 0), [tracks]);
 
-  function handlePlayAll(): void {
-    if (!detail || tracks.length === 0) return;
-    const fakePlaylist: Playlist = {
+  const syntheticPlaylist = useMemo<Playlist | null>(() => {
+    if (!detail) return null;
+    return {
       id: detail.id,
       name: detail.name,
       authorId: "system",
@@ -68,48 +61,13 @@ export function AutoPlaylistDetailView({
       listenCount: 0,
       collaborators: []
     };
-    onPlayTrack(fakePlaylist);
-  }
+  }, [detail, tracks]);
 
-  function handleShufflePlay(): void {
-    if (!detail || tracks.length === 0) return;
-    const shuffled = [...tracks].sort(() => Math.random() - 0.5);
-    const fakePlaylist: Playlist = {
-      id: detail.id,
-      name: detail.name,
-      authorId: "system",
-      visibility: "public",
-      trackIds: shuffled.map((t) => t.id),
-      description: "",
-      cover: null,
-      hearts: [],
-      heartCount: 0,
-      listenCount: 0,
-      collaborators: []
-    };
-    onPlayTrack(fakePlaylist);
-  }
-
-  function handlePlayFromTrack(track: Track): void {
-    if (!detail || tracks.length === 0) return;
-    const idx = tracks.indexOf(track);
-    if (idx < 0) return;
-    const reordered = [...tracks.slice(idx), ...tracks.slice(0, idx)];
-    const fakePlaylist: Playlist = {
-      id: detail.id,
-      name: detail.name,
-      authorId: "system",
-      visibility: "public",
-      trackIds: reordered.map((t) => t.id),
-      description: "",
-      cover: null,
-      hearts: [],
-      heartCount: 0,
-      listenCount: 0,
-      collaborators: []
-    };
-    onPlayTrack(fakePlaylist);
-  }
+  const { handlePlayAll, handleShufflePlay, handlePlayFromTrack } = usePlaylistDetailPlayback({
+    playlist: syntheticPlaylist,
+    tracks,
+    onPlay: onPlayTrack
+  });
 
   if (loading) {
     return (
@@ -198,7 +156,7 @@ export function AutoPlaylistDetailView({
                 Auto-generated
               </span>
               <span>{detail.trackCount} track{detail.trackCount !== 1 ? "s" : ""}</span>
-              {totalDuration > 0 ? <span>{formatDuration(totalDuration)}</span> : null}
+              {totalDuration > 0 ? <span>{formatDurationCompact(totalDuration)}</span> : null}
               <span>Generated {new Date(detail.generatedAt).toLocaleDateString()}</span>
             </div>
 
@@ -234,47 +192,7 @@ export function AutoPlaylistDetailView({
         </div>
       </div>
 
-      {/* Track list */}
-      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
-        {tracks.length === 0 ? (
-          <p className="px-5 py-4 text-sm text-flaque-steel">No playable tracks.</p>
-        ) : (
-          <ul>
-            {tracks.map((track, index) => (
-              <li
-                key={track.id}
-                className="flex cursor-pointer items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
-                role="button"
-                tabIndex={0}
-                onClick={() => handlePlayFromTrack(track)}
-                onKeyDown={(e) => { if (e.key === "Enter") handlePlayFromTrack(track); }}
-              >
-                <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
-                <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
-                  <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
-                    {track.tags.extra?.lyrics ? (
-                      <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
-                        L
-                      </span>
-                    ) : null}
-                    <span className="truncate">{getTrackDisplayTitle(track)}</span>
-                  </p>
-                  <p className="truncate text-xs text-flaque-steel">
-                    {getTrackDisplayArtist(track) ?? "Unknown artist"}
-                    {track.tags.album ? ` \u00b7 ${track.tags.album}` : ""}
-                  </p>
-                </div>
-                <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
-                  {formatDuration(track.duration)}
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+      <PlaylistTrackList tracks={tracks} onTrackPlay={handlePlayFromTrack} />
     </section>
   );
 }

--- a/frontend/src/components/ForYouPlaylistDetailView.tsx
+++ b/frontend/src/components/ForYouPlaylistDetailView.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { coverUrl, getForYouPlaylistDetail } from "../api";
-import type { ForYouPlaylistDetail, Playlist, Track } from "../types";
+import type { ArtistEntry, ForYouPlaylistDetail, Playlist, Track } from "../types";
+import { normalizeText } from "../utils/appUtils";
+import { getArtistPhotoSrc } from "../utils/covers";
 import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
 
 export type ForYouPlaylistDetailViewProps = {
   playlistId: string;
   allTracksById: Map<string, Track>;
+  artists: ArtistEntry[];
   onBack: () => void;
   onPlayTrack: (playlist: Playlist) => void;
   onDismiss: (playlistId: string) => Promise<void>;
@@ -24,6 +27,7 @@ function formatDuration(seconds: number): string {
 export function ForYouPlaylistDetailView({
   playlistId,
   allTracksById,
+  artists,
   onBack,
   onPlayTrack,
   onDismiss
@@ -93,6 +97,27 @@ export function ForYouPlaylistDetailView({
     onPlayTrack(fakePlaylist);
   }
 
+  function handlePlayFromTrack(track: Track): void {
+    if (!detail || tracks.length === 0) return;
+    const idx = tracks.indexOf(track);
+    if (idx < 0) return;
+    const reordered = [...tracks.slice(idx), ...tracks.slice(0, idx)];
+    const fakePlaylist: Playlist = {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: reordered.map((t) => t.id),
+      description: "",
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+    onPlayTrack(fakePlaylist);
+  }
+
   async function handleDismiss(): Promise<void> {
     if (!detail || dismissing) return;
     setDismissing(true);
@@ -135,23 +160,36 @@ export function ForYouPlaylistDetailView({
     );
   }
 
+  const seedArtistEntry = artists.find(
+    (entry) => normalizeText(entry.name) === normalizeText(detail.seedArtist)
+  );
+  const seedArtistPhoto = seedArtistEntry ? getArtistPhotoSrc(seedArtistEntry) : null;
+
   return (
     <section className="m-4 space-y-4">
       {backButton}
 
       {/* Header card */}
-      <div className="rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/80 to-purple-50/60 p-5 shadow-panel backdrop-blur-sm">
+      <div className="rounded-2xl p-5">
         <div className="flex flex-col gap-5 sm:flex-row">
            {/* Seed artist visual */}
-           <div className="relative h-48 w-48 shrink-0 items-center justify-center self-center overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-100/80 to-purple-100/60 sm:self-start">
-             <div className="text-center px-3">
-               <svg className="mx-auto h-8 w-8 text-indigo-400/70" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+           <div className="group relative h-48 w-48 shrink-0 self-center overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-100/80 to-purple-100/60 sm:self-start">
+             {seedArtistPhoto ? (
+               <img
+                 src={seedArtistPhoto}
+                 alt={detail.seedArtist}
+                 className="absolute inset-0 h-full w-full object-cover"
+                 loading="lazy"
+               />
+             ) : null}
+             <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/30 px-3 text-center">
+               <svg className="h-8 w-8 text-white drop-shadow" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-                   d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                   d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
                </svg>
-               <p className="mt-2 font-display text-lg font-bold text-flaque-ink/70 leading-tight">{detail.seedArtist}</p>
+               <p className="mt-2 font-display text-lg font-bold leading-tight text-white drop-shadow">{detail.seedArtist}</p>
              </div>
-             
+
              {/* Play button overlay */}
              <button
                type="button"
@@ -159,7 +197,7 @@ export function ForYouPlaylistDetailView({
                onClick={handlePlayAll}
                aria-label={`Play ${detail.name}`}
              >
-               <svg className="h-10 w-10 text-[#ffffff] drop-shadow-md" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+               <svg className="h-12 w-12 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
                  <path d="M8 6v12l10-6-10-6z" />
                </svg>
              </button>
@@ -196,8 +234,12 @@ export function ForYouPlaylistDetailView({
                 className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
                 onClick={handleShufflePlay}
               >
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4" />
+                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+                  <path d="M16 3h5v5" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M4 20l8-8" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M21 3l-7 7" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M4 4l6 6" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M15 16l2 2" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
                 Shuffle
               </button>
@@ -227,7 +269,11 @@ export function ForYouPlaylistDetailView({
             {tracks.map((track, index) => (
               <li
                 key={track.id}
-                className="flex items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+                className="flex cursor-pointer items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+                role="button"
+                tabIndex={0}
+                onClick={() => handlePlayFromTrack(track)}
+                onKeyDown={(e) => { if (e.key === "Enter") handlePlayFromTrack(track); }}
               >
                 <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
                 <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">

--- a/frontend/src/components/ForYouPlaylistDetailView.tsx
+++ b/frontend/src/components/ForYouPlaylistDetailView.tsx
@@ -1,28 +1,21 @@
 import { useEffect, useMemo, useState } from "react";
 
-import { coverUrl, getForYouPlaylistDetail } from "../api";
+import { getForYouPlaylistDetail } from "../api";
+import { usePlaylistDetailPlayback } from "../hooks/usePlaylistDetailPlayback";
 import type { ArtistEntry, ForYouPlaylistDetail, Playlist, Track } from "../types";
 import { normalizeText } from "../utils/appUtils";
 import { getArtistPhotoSrc } from "../utils/covers";
-import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+import { formatDurationCompact } from "../utils/format";
+import { PlaylistTrackList } from "./PlaylistTrackList";
 
 export type ForYouPlaylistDetailViewProps = {
   playlistId: string;
   allTracksById: Map<string, Track>;
   artists: ArtistEntry[];
   onBack: () => void;
-  onPlayTrack: (playlist: Playlist) => void;
+  onPlayTrack: (playlist: Playlist, options?: { shuffle?: boolean }) => void;
   onDismiss: (playlistId: string) => Promise<void>;
 };
-
-function formatDuration(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = Math.floor(seconds % 60);
-  if (h > 0) return `${h}h ${m}m`;
-  if (m > 0) return `${m}m ${s}s`;
-  return `${s}s`;
-}
 
 export function ForYouPlaylistDetailView({
   playlistId,
@@ -60,9 +53,9 @@ export function ForYouPlaylistDetailView({
 
   const totalDuration = useMemo(() => tracks.reduce((sum, t) => sum + t.duration, 0), [tracks]);
 
-  function handlePlayAll(): void {
-    if (!detail || tracks.length === 0) return;
-    const fakePlaylist: Playlist = {
+  const syntheticPlaylist = useMemo<Playlist | null>(() => {
+    if (!detail) return null;
+    return {
       id: detail.id,
       name: detail.name,
       authorId: "system",
@@ -75,48 +68,13 @@ export function ForYouPlaylistDetailView({
       listenCount: 0,
       collaborators: []
     };
-    onPlayTrack(fakePlaylist);
-  }
+  }, [detail, tracks]);
 
-  function handleShufflePlay(): void {
-    if (!detail || tracks.length === 0) return;
-    const shuffled = [...tracks].sort(() => Math.random() - 0.5);
-    const fakePlaylist: Playlist = {
-      id: detail.id,
-      name: detail.name,
-      authorId: "system",
-      visibility: "public",
-      trackIds: shuffled.map((t) => t.id),
-      description: "",
-      cover: null,
-      hearts: [],
-      heartCount: 0,
-      listenCount: 0,
-      collaborators: []
-    };
-    onPlayTrack(fakePlaylist);
-  }
-
-  function handlePlayFromTrack(track: Track): void {
-    if (!detail || tracks.length === 0) return;
-    const idx = tracks.indexOf(track);
-    if (idx < 0) return;
-    const reordered = [...tracks.slice(idx), ...tracks.slice(0, idx)];
-    const fakePlaylist: Playlist = {
-      id: detail.id,
-      name: detail.name,
-      authorId: "system",
-      visibility: "public",
-      trackIds: reordered.map((t) => t.id),
-      description: "",
-      cover: null,
-      hearts: [],
-      heartCount: 0,
-      listenCount: 0,
-      collaborators: []
-    };
-    onPlayTrack(fakePlaylist);
-  }
+  const { handlePlayAll, handleShufflePlay, handlePlayFromTrack } = usePlaylistDetailPlayback({
+    playlist: syntheticPlaylist,
+    tracks,
+    onPlay: onPlayTrack
+  });
 
   async function handleDismiss(): Promise<void> {
     if (!detail || dismissing) return;
@@ -212,7 +170,7 @@ export function ForYouPlaylistDetailView({
                 Made for you
               </span>
               <span>{detail.trackCount} track{detail.trackCount !== 1 ? "s" : ""}</span>
-              {totalDuration > 0 ? <span>{formatDuration(totalDuration)}</span> : null}
+              {totalDuration > 0 ? <span>{formatDurationCompact(totalDuration)}</span> : null}
               <span>Generated {new Date(detail.generatedAt).toLocaleDateString()}</span>
             </div>
 
@@ -260,47 +218,7 @@ export function ForYouPlaylistDetailView({
         </div>
       </div>
 
-      {/* Track list */}
-      <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
-        {tracks.length === 0 ? (
-          <p className="px-5 py-4 text-sm text-flaque-steel">No playable tracks.</p>
-        ) : (
-          <ul>
-            {tracks.map((track, index) => (
-              <li
-                key={track.id}
-                className="flex cursor-pointer items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
-                role="button"
-                tabIndex={0}
-                onClick={() => handlePlayFromTrack(track)}
-                onKeyDown={(e) => { if (e.key === "Enter") handlePlayFromTrack(track); }}
-              >
-                <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
-                <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
-                  <img src={coverUrl(track.id)} alt="" className="h-full w-full object-cover" loading="lazy" />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
-                    {track.tags.extra?.lyrics ? (
-                      <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
-                        L
-                      </span>
-                    ) : null}
-                    <span className="truncate">{getTrackDisplayTitle(track)}</span>
-                  </p>
-                  <p className="truncate text-xs text-flaque-steel">
-                    {getTrackDisplayArtist(track) ?? "Unknown artist"}
-                    {track.tags.album ? ` \u00b7 ${track.tags.album}` : ""}
-                  </p>
-                </div>
-                <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
-                  {formatDuration(track.duration)}
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+      <PlaylistTrackList tracks={tracks} onTrackPlay={handlePlayFromTrack} />
     </section>
   );
 }

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -36,6 +36,7 @@ function createPlaylist(input: {
 const defaultProps = {
   manageablePlaylists: [] as Playlist[],
   allTracksById: new Map(),
+  artists: [],
   user: { id: "user-1", username: "Alice", email: "alice@test.local", role: "user" as const },
   onPatchPlaylist: vi.fn().mockResolvedValue(undefined),
   onDeletePlaylist: vi.fn().mockResolvedValue(undefined),

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -1,14 +1,17 @@
-import { FormEvent, useState } from "react";
+import { FormEvent, useMemo, useState } from "react";
 
 import defaultCoverImage from "../assets/default-cover.png";
 import { coverUrl, playlistCoverUrl } from "../api";
-import type { AutoPlaylistSummary, ForYouPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
+import type { ArtistEntry, AutoPlaylistSummary, ForYouPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
+import { normalizeText } from "../utils/appUtils";
+import { getArtistPhotoSrc } from "../utils/covers";
 
 export type LibraryPlaylistSectionProps = {
   availablePlaylists: Playlist[];
   manageablePlaylists: Playlist[];
   ownerNameById: Record<string, string>;
   allTracksById: Map<string, Track>;
+  artists: ArtistEntry[];
   user: User;
   onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
@@ -218,6 +221,7 @@ export function LibraryPlaylistSection({
   manageablePlaylists,
   ownerNameById,
   allTracksById,
+  artists,
   user,
   onCreatePlaylist,
   onPlayPlaylist,
@@ -243,6 +247,14 @@ export function LibraryPlaylistSection({
   const popularPlaylists = availablePlaylists
     .filter((p) => p.visibility === "public" && p.authorId !== user.id)
     .sort((a, b) => b.heartCount - a.heartCount || b.listenCount - a.listenCount);
+
+  const artistByNormalizedName = useMemo(() => {
+    const map = new Map<string, ArtistEntry>();
+    for (const entry of artists) {
+      map.set(normalizeText(entry.name), entry);
+    }
+    return map;
+  }, [artists]);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
@@ -336,13 +348,13 @@ export function LibraryPlaylistSection({
       </section>
 
       {/* ── Made For You ────────────────────────────────────────── */}
-      <section className="rounded-xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/60 to-purple-50/40 p-5 shadow-panel backdrop-blur-sm">
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
         <div className="flex items-center justify-between">
           <SectionHeader title="Made for you" />
           {!loadingForYouPlaylists && forYouPlaylists.length > 0 && (
             <button
               type="button"
-              className="text-xs text-indigo-600 hover:text-indigo-800"
+              className="text-xs text-flaque-steel hover:text-flaque-ink"
               onClick={() => { void onRefreshForYouPlaylists?.(); }}
               title="Refresh recommendations"
             >
@@ -356,47 +368,59 @@ export function LibraryPlaylistSection({
           <p className="mt-2 text-sm text-flaque-steel">Loading recommendations...</p>
         ) : forYouPlaylists.length > 0 ? (
           <div className="mt-4 grid grid-cols-3 gap-2.5 sm:grid-cols-4 lg:grid-cols-6">
-            {forYouPlaylists.map((fy) => (
-              <div
-                key={fy.id}
-                className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-flaque-clay/60 bg-gradient-to-br from-indigo-50/80 to-purple-50/60 shadow-sm transition hover:shadow-md"
-                onClick={() => onNavigateToPlaylist(fy.id)}
-                role="link"
-                tabIndex={0}
-                onKeyDown={(e) => { if (e.key === "Enter") onNavigateToPlaylist(fy.id); }}
-              >
-                <div className="flex aspect-square w-full items-center justify-center bg-gradient-to-br from-indigo-100/60 to-purple-100/40">
-                  <div className="text-center px-3">
-                    <svg className="mx-auto h-8 w-8 text-indigo-400/60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-                        d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-                    </svg>
-                    <p className="mt-1 font-display text-sm font-bold text-flaque-ink/70 leading-tight">{fy.seedArtist}</p>
-                  </div>
-                </div>
-                <div className="p-3">
-                  <p className="truncate text-sm font-semibold text-flaque-ink">{fy.name}</p>
-                  <p className="mt-0.5 text-xs text-flaque-steel">
-                    {fy.trackCount} track{fy.trackCount !== 1 ? "s" : ""}
-                  </p>
-                </div>
-
-                {/* Dismiss button */}
-                <button
-                  type="button"
-                  className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-flaque-steel opacity-0 shadow-sm transition hover:bg-white hover:text-red-500 group-hover:opacity-100"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void onDismissForYouPlaylist(fy.id);
-                  }}
-                  aria-label={`Hide ${fy.name}`}
+            {forYouPlaylists.map((fy) => {
+              const artistEntry = artistByNormalizedName.get(normalizeText(fy.seedArtist));
+              const artistPhoto = artistEntry ? getArtistPhotoSrc(artistEntry) : null;
+              return (
+                <div
+                  key={fy.id}
+                  className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-sm transition hover:shadow-md"
+                  onClick={() => onNavigateToPlaylist(fy.id)}
+                  role="link"
+                  tabIndex={0}
+                  onKeyDown={(e) => { if (e.key === "Enter") onNavigateToPlaylist(fy.id); }}
                 >
-                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              </div>
-            ))}
+                  <div className="relative aspect-square w-full overflow-hidden bg-gradient-to-br from-indigo-100/60 to-purple-100/40">
+                    {artistPhoto ? (
+                      <img
+                        src={artistPhoto}
+                        alt={fy.seedArtist}
+                        className="absolute inset-0 h-full w-full object-cover"
+                        loading="lazy"
+                      />
+                    ) : null}
+                    <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/30 px-3 text-center">
+                      <svg className="h-8 w-8 text-white drop-shadow" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                          d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                      </svg>
+                      <p className="mt-1 font-display text-sm font-bold leading-tight text-white drop-shadow">{fy.seedArtist}</p>
+                    </div>
+                  </div>
+                  <div className="p-2">
+                    <p className="truncate text-xs font-semibold text-flaque-ink">{fy.name}</p>
+                    <p className="mt-0.5 text-xs text-flaque-steel">
+                      {fy.trackCount} track{fy.trackCount !== 1 ? "s" : ""}
+                    </p>
+                  </div>
+
+                  {/* Dismiss button */}
+                  <button
+                    type="button"
+                    className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-white/80 text-flaque-steel opacity-0 shadow-sm transition hover:bg-white hover:text-red-500 group-hover:opacity-100"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void onDismissForYouPlaylist(fy.id);
+                    }}
+                    aria-label={`Hide ${fy.name}`}
+                  >
+                    <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+              );
+            })}
           </div>
         ) : (
           <p className="mt-2 text-sm text-flaque-steel">No recommendations yet. Listen to more music!</p>

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -14,7 +14,7 @@ export type LibraryPlaylistSectionProps = {
   artists: ArtistEntry[];
   user: User;
   onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
-  onPlayPlaylist: (playlist: Playlist) => void;
+  onPlayPlaylist: (playlist: Playlist, options?: { shuffle?: boolean }) => void;
   onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<Playlist>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onNavigateToPlaylist: (playlistId: string) => void;

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -769,8 +769,12 @@ export function PlaylistDetailView({
                     className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
                     onClick={handleShufflePlay}
                   >
-                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4h4l3 9 3-9h4M4 20h4l3-9 3 9h4" />
+                    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+                      <path d="M16 3h5v5" strokeLinecap="round" strokeLinejoin="round" />
+                      <path d="M4 20l8-8" strokeLinecap="round" strokeLinejoin="round" />
+                      <path d="M21 3l-7 7" strokeLinecap="round" strokeLinejoin="round" />
+                      <path d="M4 4l6 6" strokeLinecap="round" strokeLinejoin="round" />
+                      <path d="M15 16l2 2" strokeLinecap="round" strokeLinejoin="round" />
                     </svg>
                     Shuffle
                   </button>

--- a/frontend/src/components/PlaylistDetailView.tsx
+++ b/frontend/src/components/PlaylistDetailView.tsx
@@ -19,8 +19,11 @@ import { CSS } from "@dnd-kit/utilities";
 
 import defaultCoverImage from "../assets/default-cover.png";
 import { coverUrl, deletePlaylistCover, getUsers, playlistCoverUrl, uploadPlaylistCover } from "../api";
+import { usePlaylistDetailPlayback } from "../hooks/usePlaylistDetailPlayback";
 import type { Playlist, PlaylistVisibility, Track, User } from "../types";
+import { formatDurationCompact } from "../utils/format";
 import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+import { PlaylistTrackList } from "./PlaylistTrackList";
 
 export type PlaylistDetailViewProps = {
   playlistId: string;
@@ -30,7 +33,7 @@ export type PlaylistDetailViewProps = {
   ownerNameById: Record<string, string>;
   user: User;
   onBack: () => void;
-  onPlay: (playlist: Playlist) => void;
+  onPlay: (playlist: Playlist, options?: { shuffle?: boolean }) => void;
   onPlayTrack?: (track: Track, queueSource: Track[]) => void;
   onPatch: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<Playlist>;
   onNavigate: (playlistId: string) => void;
@@ -40,15 +43,6 @@ export type PlaylistDetailViewProps = {
 };
 
 // ── Helpers ────────────────────────────────────────────────────────
-
-function formatDuration(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = Math.floor(seconds % 60);
-  if (h > 0) return `${h}h ${m}m`;
-  if (m > 0) return `${m}m ${s}s`;
-  return `${s}s`;
-}
 
 function getPlaylistMosaicTracks(trackIds: string[], allTracksById: Map<string, Track>): Track[] {
   const seen = new Set<string>();
@@ -382,40 +376,32 @@ export function PlaylistDetailView({
     );
   }
 
+  const playback = usePlaylistDetailPlayback({
+    playlist: playlist ?? null,
+    tracks,
+    onPlay,
+    onPlayTrack
+  });
+
+  function reportListenOnce(): void {
+    if (!playlist || listenReportedRef.current) return;
+    listenReportedRef.current = true;
+    void onReportListen(playlist.id);
+  }
+
   function handlePlayAll(): void {
-    if (!playlist) return;
-    if (!listenReportedRef.current) {
-      listenReportedRef.current = true;
-      void onReportListen(playlist.id);
-    }
-    onPlay(playlist);
+    reportListenOnce();
+    playback.handlePlayAll();
   }
 
   function handlePlayTrack(track: Track): void {
-    if (!playlist) return;
-    if (!listenReportedRef.current) {
-      listenReportedRef.current = true;
-      void onReportListen(playlist.id);
-    }
-    if (onPlayTrack) {
-      onPlayTrack(track, tracks);
-    } else {
-      const idx = tracks.indexOf(track);
-      const reordered = [...tracks.slice(idx), ...tracks.slice(0, idx)];
-      const syntheticPlaylist: Playlist = { ...playlist, trackIds: reordered.map((t) => t.id) };
-      onPlay(syntheticPlaylist);
-    }
+    reportListenOnce();
+    playback.handlePlayFromTrack(track);
   }
 
   function handleShufflePlay(): void {
-    if (!playlist || tracks.length === 0) return;
-    if (!listenReportedRef.current) {
-      listenReportedRef.current = true;
-      void onReportListen(playlist.id);
-    }
-    const shuffled = [...tracks].sort(() => Math.random() - 0.5);
-    const shuffledPlaylist: Playlist = { ...playlist, trackIds: shuffled.map((t) => t.id) };
-    onPlay(shuffledPlaylist);
+    reportListenOnce();
+    playback.handleShufflePlay();
   }
 
   async function handleHeart(): Promise<void> {
@@ -608,7 +594,7 @@ export function PlaylistDetailView({
             {/* Stats line */}
             <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-flaque-steel">
               <span>{(editing ? editTrackIds : playlist.trackIds).length} track{(editing ? editTrackIds : playlist.trackIds).length !== 1 ? "s" : ""}</span>
-              {totalDuration > 0 && !editing ? <span>{formatDuration(totalDuration)}</span> : null}
+              {totalDuration > 0 && !editing ? <span>{formatDurationCompact(totalDuration)}</span> : null}
               {!editing && playlist.listenCount > 0 ? (
                 <span className="flex items-center gap-0.5">
                   <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -844,52 +830,7 @@ export function PlaylistDetailView({
           )}
         </div>
       ) : (
-        <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
-          {tracks.length === 0 ? (
-            <p className="px-5 py-4 text-sm text-flaque-steel">No playable tracks.</p>
-          ) : (
-            <ul>
-              {tracks.map((track, index) => (
-                <li
-                  key={track.id}
-                  className="flex cursor-pointer items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
-                  onClick={() => handlePlayTrack(track)}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(e) => { if (e.key === "Enter") handlePlayTrack(track); }}
-                >
-                  <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
-                  <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
-                    <img
-                      src={coverUrl(track.id)}
-                      alt=""
-                      className="h-full w-full object-cover"
-                      loading="lazy"
-                      onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
-                    />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
-                      {track.tags.extra?.lyrics ? (
-                        <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
-                          L
-                        </span>
-                      ) : null}
-                      <span className="truncate">{getTrackDisplayTitle(track)}</span>
-                    </p>
-                    <p className="truncate text-xs text-flaque-steel">
-                      {getTrackDisplayArtist(track) ?? "Unknown artist"}
-                      {track.tags.album ? ` \u00b7 ${track.tags.album}` : ""}
-                    </p>
-                  </div>
-                  <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
-                    {formatDuration(track.duration)}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
+        <PlaylistTrackList tracks={tracks} onTrackPlay={handlePlayTrack} />
       )}
     </section>
   );

--- a/frontend/src/components/PlaylistTrackList.tsx
+++ b/frontend/src/components/PlaylistTrackList.tsx
@@ -1,0 +1,70 @@
+import { coverUrl } from "../api";
+import defaultCoverImage from "../assets/default-cover.png";
+import type { Track } from "../types";
+import { formatDurationCompact } from "../utils/format";
+import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+
+type PlaylistTrackListProps = {
+  tracks: Track[];
+  onTrackPlay: (track: Track) => void;
+  emptyMessage?: string;
+};
+
+/**
+ * Framed track list shared by PlaylistDetailView, AutoPlaylistDetailView,
+ * and ForYouPlaylistDetailView. Each row plays from that track on click.
+ */
+export function PlaylistTrackList({
+  tracks,
+  onTrackPlay,
+  emptyMessage = "No playable tracks."
+}: PlaylistTrackListProps): JSX.Element {
+  return (
+    <div className="rounded-2xl border border-flaque-clay/60 bg-white/85 shadow-panel backdrop-blur-sm">
+      {tracks.length === 0 ? (
+        <p className="px-5 py-4 text-sm text-flaque-steel">{emptyMessage}</p>
+      ) : (
+        <ul>
+          {tracks.map((track, index) => (
+            <li
+              key={track.id}
+              className="flex cursor-pointer items-center gap-3 border-b border-flaque-clay/20 px-4 py-2.5 last:border-b-0 transition hover:bg-flaque-cream/30"
+              role="button"
+              tabIndex={0}
+              onClick={() => onTrackPlay(track)}
+              onKeyDown={(e) => { if (e.key === "Enter") onTrackPlay(track); }}
+            >
+              <span className="w-6 shrink-0 text-right text-xs text-flaque-steel/50">{index + 1}</span>
+              <div className="h-9 w-9 shrink-0 overflow-hidden rounded-lg">
+                <img
+                  src={coverUrl(track.id)}
+                  alt=""
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                  onError={(e) => { e.currentTarget.src = defaultCoverImage; }}
+                />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="flex items-center gap-1 truncate text-sm font-medium text-flaque-ink">
+                  {track.tags.extra?.lyrics ? (
+                    <span className="shrink-0 rounded px-1 py-px font-mono text-[9px] font-bold leading-none text-flaque-steel/70 ring-1 ring-flaque-clay/60">
+                      L
+                    </span>
+                  ) : null}
+                  <span className="truncate">{getTrackDisplayTitle(track)}</span>
+                </p>
+                <p className="truncate text-xs text-flaque-steel">
+                  {getTrackDisplayArtist(track) ?? "Unknown artist"}
+                  {track.tags.album ? ` · ${track.tags.album}` : ""}
+                </p>
+              </div>
+              <span className="shrink-0 font-mono text-[11px] text-flaque-steel/60">
+                {formatDurationCompact(track.duration)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/PlaylistsSection.test.tsx
+++ b/frontend/src/components/PlaylistsSection.test.tsx
@@ -43,6 +43,7 @@ function baseProps(overrides: Partial<PlaylistsSectionProps> = {}): PlaylistsSec
     manageablePlaylists: [],
     ownerNameById: {},
     allTracksById: new Map<string, Track>(),
+    artists: [],
     user: USER,
     onCreatePlaylist: vi.fn(),
     onPlayPlaylist: vi.fn(),

--- a/frontend/src/components/PlaylistsSection.tsx
+++ b/frontend/src/components/PlaylistsSection.tsx
@@ -1,4 +1,4 @@
-import type { AutoPlaylistSummary, ForYouPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
+import type { ArtistEntry, AutoPlaylistSummary, ForYouPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
 import { AutoPlaylistDetailView } from "./AutoPlaylistDetailView";
 import { ForYouPlaylistDetailView } from "./ForYouPlaylistDetailView";
 import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
@@ -11,6 +11,7 @@ export type PlaylistsSectionProps = {
   manageablePlaylists: Playlist[];
   ownerNameById: Record<string, string>;
   allTracksById: Map<string, Track>;
+  artists: ArtistEntry[];
   user: User;
   onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   onPlayPlaylist: (playlist: Playlist) => void;
@@ -33,6 +34,7 @@ export function PlaylistsSection({
   manageablePlaylists,
   ownerNameById,
   allTracksById,
+  artists,
   user,
   onCreatePlaylist,
   onPlayPlaylist,
@@ -52,6 +54,7 @@ export function PlaylistsSection({
       <ForYouPlaylistDetailView
         playlistId={playlistDetailId}
         allTracksById={allTracksById}
+        artists={artists}
         onBack={() => onPlaylistDetailNavigate(null)}
         onPlayTrack={onPlayPlaylist}
         onDismiss={onDismissForYouPlaylist}
@@ -96,6 +99,7 @@ export function PlaylistsSection({
       manageablePlaylists={manageablePlaylists}
       ownerNameById={ownerNameById}
       allTracksById={allTracksById}
+      artists={artists}
       user={user}
       onCreatePlaylist={onCreatePlaylist}
       onPlayPlaylist={onPlayPlaylist}

--- a/frontend/src/components/PlaylistsSection.tsx
+++ b/frontend/src/components/PlaylistsSection.tsx
@@ -14,7 +14,7 @@ export type PlaylistsSectionProps = {
   artists: ArtistEntry[];
   user: User;
   onCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
-  onPlayPlaylist: (playlist: Playlist) => void;
+  onPlayPlaylist: (playlist: Playlist, options?: { shuffle?: boolean }) => void;
   onPatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<Playlist>;
   onDeletePlaylist: (playlistId: string) => Promise<void>;
   onHeartPlaylist: (playlistId: string) => Promise<{ hearted: boolean; heartCount: number }>;

--- a/frontend/src/hooks/usePlaybackCommands.ts
+++ b/frontend/src/hooks/usePlaybackCommands.ts
@@ -10,6 +10,7 @@ type UsePlaybackCommandsArgs = {
   selectedTrackRefreshed: Track | null;
   refreshedQueue: Track[];
   shuffleEnabled: boolean;
+  setShuffleEnabled: Dispatch<SetStateAction<boolean>>;
   allTracks: Track[];
   filters: LibraryFilters;
   allTracksById: Map<string, Track>;
@@ -21,10 +22,14 @@ type UsePlaybackCommandsArgs = {
   setAppNotice: Dispatch<SetStateAction<AppNotice | null>>;
 };
 
+export type PlayPlaylistOptions = {
+  shuffle?: boolean;
+};
+
 type UsePlaybackCommandsResult = {
   requestTrackPlaybackWithStatus: (track: Track, queueSource?: Track[]) => void;
   handleReplayRecentTrack: (track: Track) => void;
-  handlePlayPlaylist: (playlist: Playlist) => void;
+  handlePlayPlaylist: (playlist: Playlist, options?: PlayPlaylistOptions) => void;
   handlePlayAlbum: (album: AlbumEntry) => void;
   handleNavigateTrack: (direction: "next" | "previous", wrap?: boolean) => Promise<void>;
 };
@@ -36,6 +41,7 @@ export function usePlaybackCommands({
   selectedTrackRefreshed,
   refreshedQueue,
   shuffleEnabled,
+  setShuffleEnabled,
   allTracks,
   filters,
   allTracksById,
@@ -56,7 +62,7 @@ export function usePlaybackCommands({
     replayRecentTrack(track);
   }, [replayRecentTrack, setPlayerStatusMessage]);
 
-  const handlePlayPlaylist = useCallback((playlist: Playlist): void => {
+  const handlePlayPlaylist = useCallback((playlist: Playlist, options?: PlayPlaylistOptions): void => {
     const playlistTracks = playlist.trackIds
       .map((trackId) => allTracksById.get(trackId))
       .filter((track): track is Track => Boolean(track));
@@ -67,8 +73,16 @@ export function usePlaybackCommands({
     }
 
     setLibraryError(null);
+
+    if (options?.shuffle) {
+      setShuffleEnabled(true);
+      const startIndex = Math.floor(Math.random() * playlistTracks.length);
+      requestTrackPlaybackWithStatus(playlistTracks[startIndex], playlistTracks);
+      return;
+    }
+
     requestTrackPlaybackWithStatus(playlistTracks[0], playlistTracks);
-  }, [allTracksById, requestTrackPlaybackWithStatus, setLibraryError]);
+  }, [allTracksById, requestTrackPlaybackWithStatus, setLibraryError, setShuffleEnabled]);
 
   const handlePlayAlbum = useCallback(async (album: AlbumEntry): Promise<void> => {
     try {

--- a/frontend/src/hooks/usePlaylistDetailPlayback.ts
+++ b/frontend/src/hooks/usePlaylistDetailPlayback.ts
@@ -1,0 +1,52 @@
+import { useCallback } from "react";
+
+import type { Playlist, Track } from "../types";
+
+type UsePlaylistDetailPlaybackArgs = {
+  playlist: Playlist | null;
+  tracks: Track[];
+  onPlay: (playlist: Playlist, options?: { shuffle?: boolean }) => void;
+  onPlayTrack?: (track: Track, queueSource: Track[]) => void;
+};
+
+type UsePlaylistDetailPlaybackResult = {
+  handlePlayAll: () => void;
+  handleShufflePlay: () => void;
+  handlePlayFromTrack: (track: Track) => void;
+};
+
+/**
+ * Shared play / shuffle / play-from-track handlers for playlist detail views.
+ * Works with both real playlists (PlaylistDetailView) and synthetic ones
+ * (Auto / For-You) by accepting a Playlist-shaped meta object.
+ */
+export function usePlaylistDetailPlayback({
+  playlist,
+  tracks,
+  onPlay,
+  onPlayTrack
+}: UsePlaylistDetailPlaybackArgs): UsePlaylistDetailPlaybackResult {
+  const handlePlayAll = useCallback((): void => {
+    if (!playlist) return;
+    onPlay(playlist);
+  }, [playlist, onPlay]);
+
+  const handleShufflePlay = useCallback((): void => {
+    if (!playlist) return;
+    onPlay(playlist, { shuffle: true });
+  }, [playlist, onPlay]);
+
+  const handlePlayFromTrack = useCallback((track: Track): void => {
+    if (!playlist) return;
+    if (onPlayTrack) {
+      onPlayTrack(track, tracks);
+      return;
+    }
+    const idx = tracks.indexOf(track);
+    if (idx < 0) return;
+    const reordered = [...tracks.slice(idx), ...tracks.slice(0, idx)];
+    onPlay({ ...playlist, trackIds: reordered.map((t) => t.id) });
+  }, [playlist, tracks, onPlay, onPlayTrack]);
+
+  return { handlePlayAll, handleShufflePlay, handlePlayFromTrack };
+}

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -15,6 +15,15 @@ export function formatDurationHuman(totalSeconds: number): string {
   return `${m}m`;
 }
 
+export function formatDurationCompact(totalSeconds: number): string {
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = Math.floor(totalSeconds % 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
 export function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;


### PR DESCRIPTION
## Summary
- **Made for you polish**: align section/cards with the other playlist sections (`bg-white/85`), use the seed-artist photo as the playlist visual with name+heart overlaid; transparent header in detail view; shuffle icon unified with the audio player; tracks clickable to play. Same shuffle icon swap applied to the regular `PlaylistDetailView`.
- **Shuffle coherence**: pressing Shuffle on any playlist (regular / auto / for-you) now enables the player's shuffle toggle and starts from a random track in the original queue order. Toggling shuffle off on the player then continues sequentially in the playlist's original order from the currently playing track.
- **Refactor**: extracted the duplicated track list and play handlers shared by the three detail views — new `<PlaylistTrackList>` component, new `usePlaylistDetailPlayback` hook, and `formatDurationCompact` moved into `utils/format`. `PlaylistDetailView`'s edit mode (drag/drop, cover upload, collaborators, etc.) is untouched.

## Test plan
- [ ] Library → Playlists view: Made for you section/cards visually match Auto/Popular/My Playlists sections; artist photo shows behind name+heart on cards
- [ ] Open a Made-for-you playlist: header has no panel chrome (matches regular playlist detail); artist photo behind heart+name in the cover slot
- [ ] Shuffle icon in regular, auto, and for-you detail views matches the audio player
- [ ] Press Shuffle on any playlist: player's shuffle toggle lights up; pressing it again disables shuffle and "next" continues in the playlist's original order from the current track
- [ ] Click a track in any playlist: plays from that track; queue rotates so the rest follows in order
- [ ] Edit mode in regular playlists still works (drag/drop reorder, cover upload, save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)