### PR TITLE
fix(for-you): resolve seed artist photos when tags use feat./ft./';'

### DIFF
--- a/frontend/src/components/ForYouPlaylistDetailView.tsx
+++ b/frontend/src/components/ForYouPlaylistDetailView.tsx
@@ -6,6 +6,7 @@ import type { ArtistEntry, ForYouPlaylistDetail, Playlist, Track } from "../type
 import { normalizeText } from "../utils/appUtils";
 import { getArtistPhotoSrc } from "../utils/covers";
 import { formatDurationCompact } from "../utils/format";
+import { extractPrimaryArtist } from "../utils/tracks";
 import { PlaylistTrackList } from "./PlaylistTrackList";
 
 export type ForYouPlaylistDetailViewProps = {
@@ -118,9 +119,13 @@ export function ForYouPlaylistDetailView({
     );
   }
 
-  const seedArtistEntry = artists.find(
-    (entry) => normalizeText(entry.name) === normalizeText(detail.seedArtist)
-  );
+  const seedArtistTarget = normalizeText(detail.seedArtist);
+  const seedArtistPrimary = normalizeText(extractPrimaryArtist(detail.seedArtist));
+  const seedArtistEntry = artists.find((entry) => {
+    const candidate = normalizeText(entry.name);
+    if (candidate === seedArtistTarget) return true;
+    return normalizeText(extractPrimaryArtist(entry.name)) === seedArtistPrimary;
+  });
   const seedArtistPhoto = seedArtistEntry ? getArtistPhotoSrc(seedArtistEntry) : null;
 
   return (

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -5,6 +5,7 @@ import { coverUrl, playlistCoverUrl } from "../api";
 import type { ArtistEntry, AutoPlaylistSummary, ForYouPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
 import { normalizeText } from "../utils/appUtils";
 import { getArtistPhotoSrc } from "../utils/covers";
+import { extractPrimaryArtist } from "../utils/tracks";
 
 export type LibraryPlaylistSectionProps = {
   availablePlaylists: Playlist[];
@@ -252,6 +253,7 @@ export function LibraryPlaylistSection({
     const map = new Map<string, ArtistEntry>();
     for (const entry of artists) {
       map.set(normalizeText(entry.name), entry);
+      map.set(normalizeText(extractPrimaryArtist(entry.name)), entry);
     }
     return map;
   }, [artists]);
@@ -369,7 +371,9 @@ export function LibraryPlaylistSection({
         ) : forYouPlaylists.length > 0 ? (
           <div className="mt-4 grid grid-cols-3 gap-2.5 sm:grid-cols-4 lg:grid-cols-6">
             {forYouPlaylists.map((fy) => {
-              const artistEntry = artistByNormalizedName.get(normalizeText(fy.seedArtist));
+              const artistEntry =
+                artistByNormalizedName.get(normalizeText(fy.seedArtist)) ??
+                artistByNormalizedName.get(normalizeText(extractPrimaryArtist(fy.seedArtist)));
               const artistPhoto = artistEntry ? getArtistPhotoSrc(artistEntry) : null;
               return (
                 <div

--- a/frontend/src/utils/tracks.ts
+++ b/frontend/src/utils/tracks.ts
@@ -149,6 +149,18 @@ function extractLyricsFromExtra(extra: Record<string, TrackTagExtraValue> | unde
   return undefined;
 }
 
+const ARTIST_SEPARATOR_PATTERN = /\s*;\s*|\s+feat\.\s+|\s+ft\.\s+/i;
+
+/**
+ * Strip collaboration markers ("; ", " feat. ", " ft. ") and return the
+ * primary artist name. Mirrors the backend's extractPrimaryArtist so we can
+ * cross-match playlist seed artists against the library artist index.
+ */
+export function extractPrimaryArtist(name: string): string {
+  const primary = name.split(ARTIST_SEPARATOR_PATTERN)[0]?.trim();
+  return primary || name;
+}
+
 export function getTrackDisplayArtist(track: Pick<Track, "tags">): string | undefined {
   const directArtist = normalizeTagText(track.tags.artist);
   if (directArtist) {


### PR DESCRIPTION
## Summary
For-you cards and detail view kept showing the gradient + heart+name overlay instead of the seed artist's photo.

**Root cause**: the for-you backend stores \`seedArtist\` as the raw \`track.tags.artist\` value (e.g. \`"Artist A; Artist B"\`, \`"Artist A feat. B"\`), while the library artists list (\`/api/artists\`, which carries the \`photo\` and \`previewTrackId\` fields) stores the result of \`extractPrimaryArtist\` — just \`"Artist A"\`. A direct name match missed any artist whose tracks include collab markers, so the artist entry was \`null\` and \`getArtistPhotoSrc\` was never called.

**Fix**: add \`extractPrimaryArtist\` to the frontend (mirroring the backend regex \`/\\s*;\\s*|\\s+feat\\.\\s+|\\s+ft\\.\\s+/i\`) and fall back to a primary-name match after the exact match, in both \`LibraryPlaylistSection\` (cards) and \`ForYouPlaylistDetailView\` (detail).

## Test plan
- [ ] Open Library → Playlists; for-you cards show the seed artist photo behind the heart+name overlay
- [ ] Open a for-you playlist; detail view header has the artist photo behind the heart+name+play button
- [ ] Artists with \`feat.\` / \`ft.\` / \`;\` in their track tags resolve to a photo
- [ ] Artists without collab markers still resolve correctly (exact-name match path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)