### PR TITLE
Playlist algorithm overhaul: trace observability, rank-based for-you, personal mixes, embeddings

### DIFF
--- a/backend/src/api/playCountRoutes.ts
+++ b/backend/src/api/playCountRoutes.ts
@@ -3,6 +3,7 @@ import { Router } from "express";
 import { requireAuth } from "../auth/middleware";
 import type { IndexStore } from "../services/indexer/indexStore";
 import { incrementPlayCount, getUserPlayStats } from "../services/activity/playCountStore";
+import { recordSkip } from "../services/activity/skipStore";
 import { AppError } from "../utils/AppError";
 import { createLogger } from "../utils/logger";
 
@@ -29,6 +30,30 @@ export function createPlayCountRouter(indexStore: IndexStore): Router {
 
       await incrementPlayCount(userId, trackId);
       log.debug("Play recorded", { userId, trackId });
+      res.status(204).end();
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/tracks/:id/skip", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        return next(new AppError("Authentication required", 401));
+      }
+
+      const trackId = req.params.id;
+      if (!trackId) {
+        return next(new AppError("Track id is required", 400));
+      }
+
+      if (!indexStore.hasTrack(trackId)) {
+        return next(new AppError("Track not found", 404));
+      }
+
+      await recordSkip(userId, trackId);
+      log.debug("Skip recorded", { userId, trackId });
       res.status(204).end();
     } catch (error) {
       next(error);

--- a/backend/src/api/playlistRoutes.test.ts
+++ b/backend/src/api/playlistRoutes.test.ts
@@ -622,6 +622,51 @@ describe("playlistRoutes", () => {
 
   // ── PUT (full update) ────────────────────────────────────────────
 
+  // ── Personal mixes ──────────────────────────────────────────────
+
+  it("returns an empty personal list before regen", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-personal-empty-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const res = await apiRequest("/api/playlists/personal", {
+      method: "GET",
+      headers: { Cookie: cookie }
+    });
+    expect(res.status).toBe(200);
+    expect(res.payload).toEqual({ playlists: [] });
+  });
+
+  it("returns 404 when personal trace is missing", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-personal-trace-empty-", indexStore });
+    const cookie = await login("admin", "admin-secret-123");
+
+    const res = await apiRequest("/api/playlists/personal/trace/admin", {
+      method: "GET",
+      headers: { Cookie: cookie }
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("blocks non-admins from the personal trace endpoint", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-personal-trace-authz-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+    const aliceCookie = await login("alice", "alice-password");
+    const res = await apiRequest("/api/playlists/personal/trace/alice", {
+      method: "GET",
+      headers: { Cookie: aliceCookie }
+    });
+    expect(res.status).toBe(403);
+  });
+
   // ── Admin trace endpoints ────────────────────────────────────────
 
   it("returns 404 when no auto trace exists yet", async () => {

--- a/backend/src/api/playlistRoutes.test.ts
+++ b/backend/src/api/playlistRoutes.test.ts
@@ -622,6 +622,70 @@ describe("playlistRoutes", () => {
 
   // ── PUT (full update) ────────────────────────────────────────────
 
+  // ── Admin trace endpoints ────────────────────────────────────────
+
+  it("returns 404 when no auto trace exists yet", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-trace-auto-empty-", indexStore });
+    const adminCookie = await login("admin", "admin-secret-123");
+
+    const res = await apiRequest("/api/playlists/automatic/trace", {
+      method: "GET",
+      headers: { Cookie: adminCookie }
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("blocks non-admins from auto trace endpoint", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-trace-auto-authz-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const aliceCookie = await login("alice", "alice-password");
+    const res = await apiRequest("/api/playlists/automatic/trace", {
+      method: "GET",
+      headers: { Cookie: aliceCookie }
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when no for-you trace exists for a user", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({ tempDirPrefix: "flaque-playlist-trace-fy-empty-", indexStore });
+    const adminCookie = await login("admin", "admin-secret-123");
+
+    const res = await apiRequest("/api/playlists/for-you/admin/trace", {
+      method: "GET",
+      headers: { Cookie: adminCookie }
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("blocks non-admins from for-you trace endpoint", async () => {
+    indexStore = makeFakeIndexStore(defaultTracks);
+    await setupTestServer({
+      tempDirPrefix: "flaque-playlist-trace-fy-authz-",
+      indexStore,
+      beforeInit: async () => {
+        const { createUser } = await import("../auth/db");
+        createUser("alice", "alice-password", "user", "alice@test.local");
+      }
+    });
+
+    const aliceCookie = await login("alice", "alice-password");
+    const res = await apiRequest("/api/playlists/for-you/alice/trace", {
+      method: "GET",
+      headers: { Cookie: aliceCookie }
+    });
+    expect(res.status).toBe(403);
+  });
+
   it("rejects PUT from non-owner", async () => {
     indexStore = makeFakeIndexStore(defaultTracks);
     await setupTestServer({

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -13,14 +13,16 @@ import {
   updateAutoPlaylistConfig,
   loadAutoPlaylists,
   getAutoPlaylistById,
-  regenerateAutoPlaylists
+  regenerateAutoPlaylists,
+  loadAutoTrace
 } from "../services/playlists/autoPlaylistService";
 import {
   loadForYouPlaylists,
   getForYouPlaylistById,
   regenerateForYouPlaylists,
   dismissForYouPlaylist,
-  getUserDismissals
+  getUserDismissals,
+  loadForYouTrace
 } from "../services/playlists/forYouPlaylistService";
 import {
   canEditPlaylist,
@@ -110,6 +112,19 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
     }
   });
 
+  // GET /playlists/automatic/trace — admin diagnostic (must come before /:id)
+  router.get("/automatic/trace", requireAuth, requireAdmin, async (_req, res, next) => {
+    try {
+      const trace = await loadAutoTrace();
+      if (!trace) {
+        return next(new AppError("No auto-playlist trace available", 404));
+      }
+      res.json(trace);
+    } catch (error) {
+      next(error);
+    }
+  });
+
   // GET /playlists/automatic/:id
   router.get("/automatic/:id", requireAuth, async (req, res, next) => {
     try {
@@ -139,9 +154,9 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
       const allTracks = indexStore.getSnapshot().tracks;
       const playlists = await regenerateAutoPlaylists(allTracks);
       log.info(`Admin triggered auto playlist regeneration: ${playlists.length} playlist(s)`);
-      res.json({ 
-        regenerated: playlists.length, 
-        playlists: playlists.map((p) => ({ id: p.id, name: p.name, trackCount: p.trackCount })) 
+      res.json({
+        regenerated: playlists.length,
+        playlists: playlists.map((p) => ({ id: p.id, name: p.name, trackCount: p.trackCount }))
       });
     } catch (error) {
       next(error);
@@ -255,6 +270,23 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
           trackCount: p.trackCount
         }))
       });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // GET /playlists/for-you/:userId/trace — admin diagnostic
+  router.get("/for-you/:userId/trace", requireAuth, requireAdmin, async (req, res, next) => {
+    try {
+      const userId = req.params.userId;
+      if (!userId) {
+        return next(new AppError("userId is required", 400));
+      }
+      const trace = await loadForYouTrace(userId);
+      if (!trace) {
+        return next(new AppError("No for-you trace available for this user", 404));
+      }
+      res.json(trace);
     } catch (error) {
       next(error);
     }

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -101,10 +101,13 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
           name: p.name,
           genre: p.genre,
           decade: p.decade,
+          axis: p.axis,
+          tempo: p.tempo,
           trackCount: p.trackCount,
           generatedAt: p.generatedAt,
           colors: p.colors,
-          gradientAngle: p.gradientAngle
+          gradientAngle: p.gradientAngle,
+          mosaicCovers: p.mosaicCovers
         }))
       });
     } catch (error) {

--- a/backend/src/api/playlistRoutes.ts
+++ b/backend/src/api/playlistRoutes.ts
@@ -25,6 +25,12 @@ import {
   loadForYouTrace
 } from "../services/playlists/forYouPlaylistService";
 import {
+  loadPersonalPlaylists,
+  getPersonalPlaylistById,
+  regeneratePersonalPlaylists,
+  loadPersonalTrace
+} from "../services/playlists/personalPlaylistService";
+import {
   canEditPlaylist,
   canManagePlaylist,
   canViewPlaylist,
@@ -290,6 +296,86 @@ export function createPlaylistRouter(indexStore: IndexStore): Router {
         return next(new AppError("No for-you trace available for this user", 404));
       }
       res.json(trace);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // ===== PERSONAL MIXES =====
+
+  // GET /playlists/personal
+  router.get("/personal", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) return next(new AppError("Authentication required", 401));
+      const playlists = await loadPersonalPlaylists(userId);
+      res.json({
+        playlists: playlists.map((p) => ({
+          id: p.id,
+          variant: p.variant,
+          name: p.name,
+          description: p.description,
+          trackCount: p.trackCount,
+          generatedAt: p.generatedAt,
+          colors: p.colors,
+          gradientAngle: p.gradientAngle,
+          mosaicCovers: p.mosaicCovers
+        }))
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // GET /playlists/personal/trace/:userId — admin diagnostic (must come before /:id)
+  router.get("/personal/trace/:userId", requireAuth, requireAdmin, async (req, res, next) => {
+    try {
+      const userId = req.params.userId;
+      if (!userId) return next(new AppError("userId is required", 400));
+      const trace = await loadPersonalTrace(userId);
+      if (!trace) return next(new AppError("No personal trace available for this user", 404));
+      res.json(trace);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // POST /playlists/personal/regenerate
+  router.post("/personal/regenerate", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) return next(new AppError("Authentication required", 401));
+      const playlists = await regeneratePersonalPlaylists(userId, indexStore);
+      log.info(`User ${userId} triggered personal regeneration: ${playlists.length} playlist(s)`);
+      res.json({
+        regenerated: playlists.length,
+        playlists: playlists.map((p) => ({
+          id: p.id,
+          variant: p.variant,
+          name: p.name,
+          trackCount: p.trackCount
+        }))
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // GET /playlists/personal/:id
+  router.get("/personal/:id", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) return next(new AppError("Authentication required", 401));
+      const id = req.params.id;
+      if (!id) return next(new AppError("Playlist id is required", 400));
+
+      const playlist = await getPersonalPlaylistById(userId, id);
+      if (!playlist) return next(new AppError("Personal playlist not found", 404));
+
+      const tracks = playlist.trackIds
+        .map((trackId) => indexStore.getTrackById(trackId))
+        .filter((t) => t !== undefined);
+      res.json({ playlist, tracks });
     } catch (error) {
       next(error);
     }

--- a/backend/src/api/uploadRoutes.ts
+++ b/backend/src/api/uploadRoutes.ts
@@ -6,6 +6,7 @@ import { Router, type NextFunction, type Response } from "express";
 
 import { requireAuth } from "../auth/middleware";
 import { appendTrackActivityLogEntries } from "../services/activity/trackActivityStore";
+import { computeAndSaveEmbedding } from "../services/embeddings/audioEmbeddingService";
 import { enrichTrackGenre } from "../services/genre/genreEnrichmentService";
 import { mergeTrackMetadataOverrides } from "../services/indexer/metadataOverrideStore";
 import { IndexStore } from "../services/indexer/indexStore";
@@ -262,6 +263,7 @@ async function ingestUploadedFiles(
         void enrichTrackGenre(track.id, artist, title).catch(() => {});
       }
     }
+    void computeAndSaveEmbedding(track.id, track.path).catch(() => {});
   }
 
   const deduplicated = results.filter((r) => !r.isNew).length;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -15,6 +15,7 @@ import { migratePerUserUploadsToSharedMusic } from "./services/storage/storageSe
 import { startBackupScheduler } from "./services/backup/backupService";
 import { startVersionCheckSchedule } from "./services/versionCheck";
 import { ensureBaseDirectories } from "./utils/fs";
+import { backfillMissingEmbeddings } from "./services/embeddings/audioEmbeddingService";
 import { checkAndRegenerateOnBoot } from "./services/playlists/autoPlaylistService";
 import { checkAndRegenerateForYouOnBoot } from "./services/playlists/forYouPlaylistService";
 import { checkAndRegeneratePersonalOnBoot } from "./services/playlists/personalPlaylistService";
@@ -99,6 +100,14 @@ async function bootstrap(): Promise<void> {
   await Promise.all(
     listUsers().map((user) => checkAndRegeneratePersonalOnBoot(user.id, indexStore))
   );
+
+  // Audio embedding backfill: trickles through any tracks missing an
+  // embedding sidecar. Fire-and-forget — never blocks startup.
+  void backfillMissingEmbeddings(
+    indexStore.getSnapshot().tracks.map((t) => ({ id: t.id, path: t.path }))
+  ).catch((error: unknown) => {
+    log.warn("Embedding backfill failed", { error: String(error) });
+  });
 }
 
 bootstrap().catch((error: unknown) => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -17,6 +17,7 @@ import { startVersionCheckSchedule } from "./services/versionCheck";
 import { ensureBaseDirectories } from "./utils/fs";
 import { checkAndRegenerateOnBoot } from "./services/playlists/autoPlaylistService";
 import { checkAndRegenerateForYouOnBoot } from "./services/playlists/forYouPlaylistService";
+import { checkAndRegeneratePersonalOnBoot } from "./services/playlists/personalPlaylistService";
 import { listUsers } from "./auth/db";
 
 const SESSION_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
@@ -94,6 +95,9 @@ async function bootstrap(): Promise<void> {
   void checkAndRegenerateOnBoot(indexStore.getSnapshot().tracks);
   await Promise.all(
     listUsers().map((user) => checkAndRegenerateForYouOnBoot(user.id, indexStore))
+  );
+  await Promise.all(
+    listUsers().map((user) => checkAndRegeneratePersonalOnBoot(user.id, indexStore))
   );
 }
 

--- a/backend/src/services/activity/skipStore.test.ts
+++ b/backend/src/services/activity/skipStore.test.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let tmpDir: string;
+
+vi.mock("../../utils/paths", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../utils/paths")>();
+  return {
+    ...original,
+    get usersStorageRoot() {
+      return tmpDir;
+    }
+  };
+});
+
+import { getRecentSkipCounts, getUserSkipCounts, recordSkip } from "./skipStore";
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "skips-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("skipStore", () => {
+  it("records the first skip with count=1 and a timestamp", async () => {
+    await recordSkip("user-1", "track-a");
+    const skips = await getUserSkipCounts("user-1");
+    expect(skips["track-a"]?.count).toBe(1);
+    expect(skips["track-a"]?.lastSkippedAt ?? "").toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("accumulates concurrent skips without losing any", async () => {
+    await Promise.all(Array.from({ length: 30 }, () => recordSkip("user-1", "track-a")));
+    const skips = await getUserSkipCounts("user-1");
+    expect(skips["track-a"]?.count).toBe(30);
+  });
+
+  it("isolates skips between users", async () => {
+    await recordSkip("user-1", "track-a");
+    await recordSkip("user-2", "track-a");
+    await recordSkip("user-2", "track-a");
+
+    expect((await getUserSkipCounts("user-1"))["track-a"]?.count).toBe(1);
+    expect((await getUserSkipCounts("user-2"))["track-a"]?.count).toBe(2);
+  });
+
+  it("filters out entries older than the recent window", async () => {
+    const userPath = path.join(tmpDir, "user-1");
+    await fs.mkdir(userPath, { recursive: true });
+    const old = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+    const recent = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    await fs.writeFile(
+      path.join(userPath, "skips.json"),
+      JSON.stringify({
+        tracks: {
+          "track-old": { count: 5, lastSkippedAt: old },
+          "track-recent": { count: 2, lastSkippedAt: recent }
+        }
+      })
+    );
+
+    const recentOnly = await getRecentSkipCounts("user-1", 60);
+    expect(recentOnly["track-recent"]?.count).toBe(2);
+    expect(recentOnly["track-old"]).toBeUndefined();
+  });
+});

--- a/backend/src/services/activity/skipStore.ts
+++ b/backend/src/services/activity/skipStore.ts
@@ -1,0 +1,68 @@
+import path from "node:path";
+
+import { readJsonFile, updateJsonFile } from "../../utils/fs";
+import { usersStorageRoot } from "../../utils/paths";
+
+type TrackSkip = {
+  count: number;
+  lastSkippedAt: string;
+};
+
+type SkipsFile = {
+  tracks: Record<string, TrackSkip>;
+};
+
+function skipsPath(userId: string): string {
+  return path.join(usersStorageRoot, userId, "skips.json");
+}
+
+async function readSkips(userId: string): Promise<SkipsFile> {
+  const filePath = skipsPath(userId);
+  const data = await readJsonFile<SkipsFile>(filePath, { tracks: {} });
+  if (!data || typeof data !== "object" || !data.tracks) {
+    return { tracks: {} };
+  }
+  return data;
+}
+
+export async function recordSkip(userId: string, trackId: string): Promise<void> {
+  await updateJsonFile<SkipsFile>(
+    skipsPath(userId),
+    { tracks: {} },
+    (current) => {
+      const tracks = current?.tracks && typeof current.tracks === "object" ? { ...current.tracks } : {};
+      const existing = tracks[trackId];
+      tracks[trackId] = {
+        count: (existing?.count ?? 0) + 1,
+        lastSkippedAt: new Date().toISOString()
+      };
+      return { tracks };
+    }
+  );
+}
+
+export async function getUserSkipCounts(userId: string): Promise<Record<string, TrackSkip>> {
+  const data = await readSkips(userId);
+  return data.tracks;
+}
+
+export type RecentSkipEntry = {
+  count: number;
+  lastSkippedAt: string;
+};
+
+export async function getRecentSkipCounts(
+  userId: string,
+  withinDays: number
+): Promise<Record<string, RecentSkipEntry>> {
+  const all = await getUserSkipCounts(userId);
+  const cutoff = Date.now() - withinDays * 24 * 60 * 60 * 1000;
+  const out: Record<string, RecentSkipEntry> = {};
+  for (const [trackId, entry] of Object.entries(all)) {
+    const ts = Date.parse(entry.lastSkippedAt);
+    if (Number.isFinite(ts) && ts >= cutoff) {
+      out[trackId] = { count: entry.count, lastSkippedAt: entry.lastSkippedAt };
+    }
+  }
+  return out;
+}

--- a/backend/src/services/embeddings/audioEmbeddingService.test.ts
+++ b/backend/src/services/embeddings/audioEmbeddingService.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let tmpDir: string;
+
+vi.mock("../../utils/paths", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../utils/paths")>();
+  return {
+    ...original,
+    get dataRoot() {
+      return path.join(tmpDir, "data");
+    }
+  };
+});
+
+import { EMBEDDING_VERSION } from "./audioFeatures";
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "embeddings-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("audioEmbeddingService storage", () => {
+  it("round-trips an embedding via save/load", async () => {
+    const { saveEmbedding, loadEmbedding } = await import("./audioEmbeddingService");
+    const vec = Array.from({ length: 32 }, (_, i) => i / 32);
+    await saveEmbedding({
+      trackId: "track-a",
+      version: EMBEDDING_VERSION,
+      computedAt: "2026-05-03T00:00:00Z",
+      vec
+    });
+
+    const loaded = await loadEmbedding("track-a");
+    expect(loaded?.trackId).toBe("track-a");
+    expect(loaded?.vec.length).toBe(32);
+    expect(loaded?.vec[0]).toBeCloseTo(0, 9);
+  });
+
+  it("returns null when no embedding file exists", async () => {
+    const { loadEmbedding } = await import("./audioEmbeddingService");
+    expect(await loadEmbedding("missing")).toBeNull();
+  });
+
+  it("returns null when the persisted version doesn't match", async () => {
+    const { saveEmbedding, loadEmbedding } = await import("./audioEmbeddingService");
+    await saveEmbedding({
+      trackId: "track-old",
+      version: EMBEDDING_VERSION + 99,
+      computedAt: "2026-05-03T00:00:00Z",
+      vec: Array(32).fill(0.1)
+    });
+    expect(await loadEmbedding("track-old")).toBeNull();
+  });
+
+  it("returns null when the persisted vector has the wrong dimension", async () => {
+    const { saveEmbedding, loadEmbedding } = await import("./audioEmbeddingService");
+    await saveEmbedding({
+      trackId: "track-bad",
+      version: EMBEDDING_VERSION,
+      computedAt: "2026-05-03T00:00:00Z",
+      vec: [0.1, 0.2]
+    });
+    expect(await loadEmbedding("track-bad")).toBeNull();
+  });
+
+  it("hasEmbedding reports true only after a valid save", async () => {
+    const { saveEmbedding, hasEmbedding } = await import("./audioEmbeddingService");
+    expect(await hasEmbedding("track-c")).toBe(false);
+
+    await saveEmbedding({
+      trackId: "track-c",
+      version: EMBEDDING_VERSION,
+      computedAt: "2026-05-03T00:00:00Z",
+      vec: Array(32).fill(0.1)
+    });
+    expect(await hasEmbedding("track-c")).toBe(true);
+  });
+});

--- a/backend/src/services/embeddings/audioEmbeddingService.ts
+++ b/backend/src/services/embeddings/audioEmbeddingService.ts
@@ -12,6 +12,7 @@
  */
 
 import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
 import path from "node:path";
 
 import { resolveTrackAbsolutePath } from "../storage/storageService";
@@ -106,11 +107,21 @@ function decodeToPcm(absolutePath: string): Promise<Float32Array> {
         reject(new Error(`ffmpeg exited with code ${code}: ${stderr.trim()}`));
         return;
       }
-      // Concatenate into one contiguous buffer aligned to 4-byte boundary.
-      const combined = Buffer.concat(chunks, totalBytes);
-      const usable = combined.length - (combined.length % 4);
-      const samples = new Float32Array(combined.buffer, combined.byteOffset, usable / 4);
-      resolve(new Float32Array(samples));
+      // Buffer.concat's underlying ArrayBuffer offset isn't guaranteed to be
+      // 4-byte aligned, which is required to construct a Float32Array view.
+      // Copy bytes into a fresh, naturally aligned ArrayBuffer instead.
+      const usable = totalBytes - (totalBytes % 4);
+      const aligned = new ArrayBuffer(usable);
+      const dst = new Uint8Array(aligned);
+      let offset = 0;
+      for (const chunk of chunks) {
+        const remaining = usable - offset;
+        if (remaining <= 0) break;
+        const len = Math.min(chunk.length, remaining);
+        dst.set(chunk.subarray(0, len), offset);
+        offset += len;
+      }
+      resolve(new Float32Array(aligned));
     });
   });
 }
@@ -192,9 +203,30 @@ export async function backfillMissingEmbeddings(
   let skipped = 0;
   let failed = 0;
 
+  // Build a Set of trackIds that already have a current-version sidecar.
+  // We readdir once (avoiding stat-per-track for tracks that lack a file)
+  // and then read only the existing sidecars to drop stale-version ones.
+  await ensureDir(EMBEDDINGS_DIR);
+  const validIds = new Set<string>();
+  const entries = await fs.readdir(EMBEDDINGS_DIR).catch(() => [] as string[]);
+  const existingFilenames = entries.filter((f) => f.endsWith(".json"));
+  let cursor = 0;
+  const workers: Promise<void>[] = [];
+  for (let w = 0; w < 8; w++) {
+    workers.push((async () => {
+      while (true) {
+        const i = cursor++;
+        if (i >= existingFilenames.length) return;
+        const id = existingFilenames[i]!.slice(0, -".json".length);
+        if (await loadEmbedding(id)) validIds.add(id);
+      }
+    })());
+  }
+  await Promise.all(workers);
+
   for (let i = 0; i < tracks.length; i++) {
     const track = tracks[i]!;
-    if (await hasEmbedding(track.id)) {
+    if (validIds.has(track.id)) {
       skipped++;
       continue;
     }

--- a/backend/src/services/embeddings/audioEmbeddingService.ts
+++ b/backend/src/services/embeddings/audioEmbeddingService.ts
@@ -1,0 +1,217 @@
+/**
+ * Audio embedding service. Decodes a track via ffmpeg → 16 kHz mono PCM,
+ * runs the DSP pipeline in audioFeatures.ts, and persists the resulting
+ * 32-dim vector as a sidecar JSON next to the track's id.
+ *
+ * Storage:  data/embeddings/<trackId>.json
+ * Shape:    { trackId, version, computedAt, vec: number[] }
+ *
+ * Embeddings are best-effort: a failure here never breaks the upload or
+ * playlist generation. The ranker treats a missing embedding as a neutral
+ * (skipped) feature.
+ */
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+import { resolveTrackAbsolutePath } from "../storage/storageService";
+import { dataRoot } from "../../utils/paths";
+import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
+import { createLogger } from "../../utils/logger";
+import {
+  EMBEDDING_DIM,
+  EMBEDDING_VERSION,
+  SAMPLE_RATE,
+  computeFeatureVector
+} from "./audioFeatures";
+
+const log = createLogger("audio-embeddings");
+
+export const EMBEDDINGS_DIR = path.join(dataRoot, "embeddings");
+
+export type AudioEmbedding = {
+  trackId: string;
+  version: number;
+  computedAt: string;
+  vec: number[];
+};
+
+function embeddingPath(trackId: string): string {
+  return path.join(EMBEDDINGS_DIR, `${trackId}.json`);
+}
+
+// ── Storage ───────────────────────────────────────────────────────
+
+export async function loadEmbedding(trackId: string): Promise<AudioEmbedding | null> {
+  const data = await readJsonFile<AudioEmbedding>(
+    embeddingPath(trackId),
+    null as unknown as AudioEmbedding
+  );
+  if (!data || !Array.isArray(data.vec) || data.vec.length !== EMBEDDING_DIM) return null;
+  if (data.version !== EMBEDDING_VERSION) return null;
+  return data;
+}
+
+export async function saveEmbedding(embedding: AudioEmbedding): Promise<void> {
+  await ensureDir(EMBEDDINGS_DIR);
+  await writeJsonAtomic(embeddingPath(embedding.trackId), embedding);
+}
+
+// ── Decode ────────────────────────────────────────────────────────
+
+/**
+ * Decode an audio file to mono 16 kHz Float32 PCM via ffmpeg. Returns the
+ * raw samples as a Float32Array.
+ *
+ * Implementation note: ffmpeg's `f32le` output writes little-endian floats
+ * to stdout. We accumulate buffers and reinterpret the final byte sequence
+ * as a Float32Array, which on little-endian hosts is a zero-copy view.
+ */
+function decodeToPcm(absolutePath: string): Promise<Float32Array> {
+  return new Promise((resolve, reject) => {
+    const ffmpeg = spawn(
+      "ffmpeg",
+      [
+        "-v", "error",
+        "-i", absolutePath,
+        "-vn",
+        "-ac", "1",
+        "-ar", String(SAMPLE_RATE),
+        "-f", "f32le",
+        "-"
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] }
+    );
+
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    let stderr = "";
+
+    ffmpeg.stdout.on("data", (chunk: Buffer) => {
+      chunks.push(chunk);
+      totalBytes += chunk.length;
+    });
+
+    ffmpeg.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+      if (stderr.length > 4096) stderr = stderr.slice(-4096);
+    });
+
+    ffmpeg.on("error", (err) => {
+      reject(new Error(`ffmpeg failed to start: ${err.message}`));
+    });
+
+    ffmpeg.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`ffmpeg exited with code ${code}: ${stderr.trim()}`));
+        return;
+      }
+      // Concatenate into one contiguous buffer aligned to 4-byte boundary.
+      const combined = Buffer.concat(chunks, totalBytes);
+      const usable = combined.length - (combined.length % 4);
+      const samples = new Float32Array(combined.buffer, combined.byteOffset, usable / 4);
+      resolve(new Float32Array(samples));
+    });
+  });
+}
+
+// ── Concurrency control ───────────────────────────────────────────
+
+const MAX_CONCURRENT = 2;
+let active = 0;
+const queue: Array<() => void> = [];
+
+async function withSlot<T>(fn: () => Promise<T>): Promise<T> {
+  if (active >= MAX_CONCURRENT) {
+    await new Promise<void>((r) => queue.push(r));
+  }
+  active++;
+  try {
+    return await fn();
+  } finally {
+    active--;
+    const next = queue.shift();
+    if (next) next();
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────
+
+/** Compute and persist an embedding for a track. Returns null on any failure. */
+export async function computeAndSaveEmbedding(
+  trackId: string,
+  trackRelativePath: string
+): Promise<AudioEmbedding | null> {
+  let absolutePath: string;
+  try {
+    absolutePath = resolveTrackAbsolutePath(trackRelativePath);
+  } catch (error) {
+    log.warn("Cannot resolve track path", { trackId, error: String(error) });
+    return null;
+  }
+
+  return withSlot(async () => {
+    try {
+      const samples = await decodeToPcm(absolutePath);
+      const vec = computeFeatureVector(samples);
+      if (!vec) {
+        log.debug("Track too short for embedding", { trackId });
+        return null;
+      }
+      const embedding: AudioEmbedding = {
+        trackId,
+        version: EMBEDDING_VERSION,
+        computedAt: new Date().toISOString(),
+        vec: Array.from(vec)
+      };
+      await saveEmbedding(embedding);
+      return embedding;
+    } catch (error) {
+      log.warn("Embedding computation failed", { trackId, error: String(error) });
+      return null;
+    }
+  });
+}
+
+export async function hasEmbedding(trackId: string): Promise<boolean> {
+  const existing = await loadEmbedding(trackId);
+  return existing !== null;
+}
+
+/**
+ * Background backfill: compute embeddings for any track that doesn't have
+ * one yet. Trickles through serially (modulo the concurrency slot) so it
+ * doesn't dominate ffmpeg capacity that transcoding might want.
+ */
+export async function backfillMissingEmbeddings(
+  tracks: Array<{ id: string; path: string }>,
+  options: { logEvery?: number } = {}
+): Promise<{ computed: number; skipped: number; failed: number }> {
+  const logEvery = options.logEvery ?? 50;
+  let computed = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (let i = 0; i < tracks.length; i++) {
+    const track = tracks[i]!;
+    if (await hasEmbedding(track.id)) {
+      skipped++;
+      continue;
+    }
+    const result = await computeAndSaveEmbedding(track.id, track.path);
+    if (result) computed++;
+    else failed++;
+
+    if ((i + 1) % logEvery === 0) {
+      log.info(
+        `Embedding backfill progress: ${i + 1}/${tracks.length} ` +
+          `(computed=${computed} skipped=${skipped} failed=${failed})`
+      );
+    }
+  }
+
+  log.info(
+    `Embedding backfill complete: computed=${computed} skipped=${skipped} failed=${failed}`
+  );
+  return { computed, skipped, failed };
+}

--- a/backend/src/services/embeddings/audioFeatures.test.ts
+++ b/backend/src/services/embeddings/audioFeatures.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EMBEDDING_DIM,
+  FRAME_SIZE,
+  HOP_SIZE,
+  SAMPLE_RATE,
+  computeFeatureVector,
+  cosineSimilarity,
+  fft,
+  meanVector
+} from "./audioFeatures";
+
+function sineWave(freq: number, durationSec: number, amplitude = 0.7): Float32Array {
+  const n = Math.floor(SAMPLE_RATE * durationSec);
+  const out = new Float32Array(n);
+  for (let i = 0; i < n; i++) {
+    out[i] = amplitude * Math.sin((2 * Math.PI * freq * i) / SAMPLE_RATE);
+  }
+  return out;
+}
+
+function whiteNoise(durationSec: number, amplitude = 0.3, seed = 1): Float32Array {
+  const n = Math.floor(SAMPLE_RATE * durationSec);
+  const out = new Float32Array(n);
+  // Deterministic PRNG so tests are reproducible.
+  let state = seed >>> 0;
+  for (let i = 0; i < n; i++) {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    out[i] = ((state / 0xffffffff) * 2 - 1) * amplitude;
+  }
+  return out;
+}
+
+describe("FFT", () => {
+  it("recovers a known frequency bin from a sine wave", () => {
+    // Sine at exactly bin 32 of a 1024-point FFT at 16kHz: 32 * 16000 / 1024 = 500Hz.
+    const freq = 500;
+    const real = new Float32Array(FRAME_SIZE);
+    const imag = new Float32Array(FRAME_SIZE);
+    for (let i = 0; i < FRAME_SIZE; i++) {
+      real[i] = Math.sin((2 * Math.PI * freq * i) / SAMPLE_RATE);
+    }
+    fft(real, imag);
+
+    const half = FRAME_SIZE / 2 + 1;
+    let maxBin = 0;
+    let maxMag = 0;
+    for (let k = 0; k < half; k++) {
+      const m = Math.sqrt(real[k]! * real[k]! + imag[k]! * imag[k]!);
+      if (m > maxMag) {
+        maxMag = m;
+        maxBin = k;
+      }
+    }
+
+    const dominantFreq = (maxBin * SAMPLE_RATE) / FRAME_SIZE;
+    expect(Math.abs(dominantFreq - freq)).toBeLessThan(SAMPLE_RATE / FRAME_SIZE);
+  });
+});
+
+describe("computeFeatureVector", () => {
+  it("returns null on signals shorter than one frame", () => {
+    const tiny = new Float32Array(FRAME_SIZE - 1);
+    expect(computeFeatureVector(tiny)).toBeNull();
+  });
+
+  it("produces a vector of EMBEDDING_DIM that is L2-unit-normalized", () => {
+    const sig = sineWave(1000, 1.0);
+    const vec = computeFeatureVector(sig);
+    expect(vec).not.toBeNull();
+    expect(vec!.length).toBe(EMBEDDING_DIM);
+    let sumSq = 0;
+    for (const v of vec!) sumSq += v * v;
+    expect(sumSq).toBeGreaterThan(0.99);
+    expect(sumSq).toBeLessThan(1.01);
+  });
+
+  it("is deterministic for the same input", () => {
+    const sig = sineWave(1500, 1.0);
+    const a = computeFeatureVector(sig)!;
+    const b = computeFeatureVector(sig)!;
+    for (let i = 0; i < a.length; i++) {
+      expect(Math.abs(a[i]! - b[i]!)).toBeLessThan(1e-9);
+    }
+  });
+
+  it("treats two close pure tones as more similar than tone vs. noise", () => {
+    const tone1 = computeFeatureVector(sineWave(1000, 1.5))!;
+    const tone2 = computeFeatureVector(sineWave(1100, 1.5))!;
+    const noise = computeFeatureVector(whiteNoise(1.5))!;
+
+    const toneToTone = cosineSimilarity(tone1, tone2);
+    const toneToNoise = cosineSimilarity(tone1, noise);
+    expect(toneToTone).toBeGreaterThan(toneToNoise);
+  });
+
+  it("uses HOP_SIZE worth of frames given a known signal length", () => {
+    // Doesn't directly assert frame count, but exercises the boundary —
+    // a signal exactly FRAME_SIZE long gives one frame.
+    const oneFrame = new Float32Array(FRAME_SIZE);
+    for (let i = 0; i < FRAME_SIZE; i++) {
+      oneFrame[i] = Math.sin((2 * Math.PI * 800 * i) / SAMPLE_RATE);
+    }
+    const vec = computeFeatureVector(oneFrame);
+    expect(vec).not.toBeNull();
+    // With one frame, std dimensions should be ~0 (no variance).
+    // MFCC stds are at indices 13..25.
+    for (let i = 13; i < 26; i++) {
+      expect(vec![i]!).toBeCloseTo(0, 5);
+    }
+    void HOP_SIZE; // referenced for clarity; constant is exported.
+  });
+});
+
+describe("cosineSimilarity", () => {
+  it("returns 1 for identical vectors", () => {
+    const a = [1, 2, 3, 4];
+    expect(cosineSimilarity(a, a)).toBeCloseTo(1, 6);
+  });
+
+  it("returns 0 for orthogonal vectors", () => {
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0, 6);
+  });
+
+  it("returns -1 for antiparallel vectors", () => {
+    expect(cosineSimilarity([1, 2, 3], [-1, -2, -3])).toBeCloseTo(-1, 6);
+  });
+
+  it("returns 0 when either vector is all zeros", () => {
+    expect(cosineSimilarity([0, 0, 0], [1, 2, 3])).toBe(0);
+  });
+
+  it("returns 0 on length mismatch", () => {
+    expect(cosineSimilarity([1, 2], [1, 2, 3])).toBe(0);
+  });
+});
+
+describe("meanVector", () => {
+  it("returns the L2-normalized mean of input vectors", () => {
+    const m = meanVector([
+      [1, 0, 0],
+      [0, 1, 0]
+    ])!;
+    expect(m.length).toBe(3);
+    let sq = 0;
+    for (const v of m) sq += v * v;
+    expect(sq).toBeCloseTo(1, 6);
+    // Mean direction is (0.5, 0.5, 0); after normalization, equal nonzero coords.
+    expect(m[0]).toBeCloseTo(m[1]!, 6);
+    expect(m[2]).toBeCloseTo(0, 6);
+  });
+
+  it("returns null on an empty list", () => {
+    expect(meanVector([])).toBeNull();
+  });
+});

--- a/backend/src/services/embeddings/audioFeatures.ts
+++ b/backend/src/services/embeddings/audioFeatures.ts
@@ -1,0 +1,337 @@
+/**
+ * Lightweight DSP feature extraction for audio embeddings. Pure functions —
+ * no I/O, no ffmpeg, just signal-in / vector-out. Kept separate from the
+ * orchestration service so the math is unit-testable with synthetic signals.
+ *
+ * The pipeline takes a mono Float32Array at a known sample rate and returns
+ * a fixed-length feature vector summarizing the track's timbre and dynamics:
+ *
+ *   13× MFCC mean
+ *   13× MFCC std
+ *    1× spectral centroid mean
+ *    1× spectral centroid std
+ *    1× spectral rolloff mean
+ *    1× spectral flatness mean
+ *    1× zero-crossing rate mean
+ *    1× RMS mean
+ *
+ * 32-dimensional vector. Each dimension is L2-normalized at the end so that
+ * cosine similarity is a meaningful comparator between two embeddings.
+ */
+
+export const SAMPLE_RATE = 16000;
+export const FRAME_SIZE = 1024;
+export const HOP_SIZE = 512;
+export const NUM_MEL_FILTERS = 40;
+export const NUM_MFCC_COEFFS = 13;
+export const EMBEDDING_DIM = 32;
+export const EMBEDDING_VERSION = 1;
+
+// ── Window ─────────────────────────────────────────────────────────
+
+const HANN = (() => {
+  const w = new Float32Array(FRAME_SIZE);
+  for (let i = 0; i < FRAME_SIZE; i++) {
+    w[i] = 0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (FRAME_SIZE - 1));
+  }
+  return w;
+})();
+
+// ── FFT (Cooley-Tukey, in-place radix-2) ──────────────────────────
+
+export function fft(real: Float32Array, imag: Float32Array): void {
+  const n = real.length;
+  // Bit-reverse permutation.
+  let j = 0;
+  for (let i = 1; i < n; i++) {
+    let bit = n >> 1;
+    while (j & bit) {
+      j ^= bit;
+      bit >>= 1;
+    }
+    j ^= bit;
+    if (i < j) {
+      const tr = real[i]!;
+      const ti = imag[i]!;
+      real[i] = real[j]!;
+      imag[i] = imag[j]!;
+      real[j] = tr;
+      imag[j] = ti;
+    }
+  }
+  // Butterflies.
+  for (let size = 2; size <= n; size <<= 1) {
+    const half = size >> 1;
+    const angleStep = (-2 * Math.PI) / size;
+    for (let block = 0; block < n; block += size) {
+      for (let k = 0; k < half; k++) {
+        const angle = angleStep * k;
+        const wr = Math.cos(angle);
+        const wi = Math.sin(angle);
+        const idx = block + k;
+        const jdx = idx + half;
+        const tre = real[jdx]! * wr - imag[jdx]! * wi;
+        const tim = real[jdx]! * wi + imag[jdx]! * wr;
+        real[jdx] = real[idx]! - tre;
+        imag[jdx] = imag[idx]! - tim;
+        real[idx] = real[idx]! + tre;
+        imag[idx] = imag[idx]! + tim;
+      }
+    }
+  }
+}
+
+// ── Mel filterbank ────────────────────────────────────────────────
+
+function hzToMel(hz: number): number {
+  return 2595 * Math.log10(1 + hz / 700);
+}
+
+function melToHz(mel: number): number {
+  return 700 * (10 ** (mel / 2595) - 1);
+}
+
+function buildMelFilterbank(
+  numFilters: number,
+  fftSize: number,
+  sampleRate: number
+): Float32Array[] {
+  const halfFft = fftSize / 2 + 1;
+  const melMin = hzToMel(0);
+  const melMax = hzToMel(sampleRate / 2);
+  const points: number[] = [];
+  for (let i = 0; i <= numFilters + 1; i++) {
+    points.push(melMin + ((melMax - melMin) * i) / (numFilters + 1));
+  }
+  const bins = points
+    .map(melToHz)
+    .map((hz) => Math.floor(((fftSize + 1) * hz) / sampleRate));
+
+  const filters: Float32Array[] = [];
+  for (let m = 1; m <= numFilters; m++) {
+    const filter = new Float32Array(halfFft);
+    const lo = bins[m - 1]!;
+    const ce = bins[m]!;
+    const hi = bins[m + 1]!;
+    for (let k = lo; k < ce; k++) {
+      filter[k] = ce === lo ? 0 : (k - lo) / (ce - lo);
+    }
+    for (let k = ce; k < hi; k++) {
+      filter[k] = hi === ce ? 0 : (hi - k) / (hi - ce);
+    }
+    filters.push(filter);
+  }
+  return filters;
+}
+
+const MEL_FILTERS = buildMelFilterbank(NUM_MEL_FILTERS, FRAME_SIZE, SAMPLE_RATE);
+
+// ── DCT-II (used to decorrelate the log-mel into MFCC) ────────────
+
+function dctII(input: Float32Array, numCoeffs: number): Float32Array {
+  const N = input.length;
+  const out = new Float32Array(numCoeffs);
+  const factor = Math.PI / N;
+  for (let k = 0; k < numCoeffs; k++) {
+    let sum = 0;
+    for (let n = 0; n < N; n++) {
+      sum += input[n]! * Math.cos(factor * (n + 0.5) * k);
+    }
+    out[k] = sum;
+  }
+  return out;
+}
+
+// ── Per-frame features ────────────────────────────────────────────
+
+type FrameFeatures = {
+  mfcc: Float32Array;
+  centroid: number;
+  rolloff: number;
+  flatness: number;
+  rms: number;
+  zcr: number;
+};
+
+function frameFeatures(frame: Float32Array): FrameFeatures {
+  const N = frame.length;
+  const real = new Float32Array(N);
+  const imag = new Float32Array(N);
+  for (let i = 0; i < N; i++) real[i] = frame[i]! * HANN[i]!;
+  fft(real, imag);
+
+  const half = N / 2 + 1;
+  const mag = new Float32Array(half);
+  let totalEnergy = 0;
+  for (let k = 0; k < half; k++) {
+    const re = real[k]!;
+    const im = imag[k]!;
+    const m = Math.sqrt(re * re + im * im);
+    mag[k] = m;
+    totalEnergy += m;
+  }
+
+  // Spectral centroid (Hz, weighted by magnitude).
+  let weightedFreq = 0;
+  for (let k = 0; k < half; k++) {
+    weightedFreq += ((k * SAMPLE_RATE) / N) * mag[k]!;
+  }
+  const centroid = totalEnergy > 0 ? weightedFreq / totalEnergy : 0;
+
+  // Spectral rolloff (frequency under which 85% of energy lies).
+  const rolloffThreshold = totalEnergy * 0.85;
+  let cumulative = 0;
+  let rolloff = SAMPLE_RATE / 2;
+  for (let k = 0; k < half; k++) {
+    cumulative += mag[k]!;
+    if (cumulative >= rolloffThreshold) {
+      rolloff = (k * SAMPLE_RATE) / N;
+      break;
+    }
+  }
+
+  // Spectral flatness (geometric mean / arithmetic mean of magnitude spectrum,
+  // skipping DC). Pure tones → ~0, white noise → ~1.
+  let logSum = 0;
+  let arithSum = 0;
+  let valid = 0;
+  for (let k = 1; k < half; k++) {
+    const m = mag[k]!;
+    if (m > 1e-10) {
+      logSum += Math.log(m);
+      arithSum += m;
+      valid++;
+    }
+  }
+  const flatness =
+    valid > 0 && arithSum > 0
+      ? Math.exp(logSum / valid) / (arithSum / valid)
+      : 0;
+
+  // Mel filterbank → log → DCT → MFCC.
+  const melEnergies = new Float32Array(NUM_MEL_FILTERS);
+  for (let m = 0; m < NUM_MEL_FILTERS; m++) {
+    const filter = MEL_FILTERS[m]!;
+    let energy = 0;
+    for (let k = 0; k < half; k++) {
+      energy += mag[k]! * mag[k]! * filter[k]!;
+    }
+    melEnergies[m] = Math.log(energy + 1e-10);
+  }
+  const mfcc = dctII(melEnergies, NUM_MFCC_COEFFS);
+
+  // Time-domain features.
+  let sumSq = 0;
+  let zeroCrossings = 0;
+  for (let i = 0; i < N; i++) {
+    const s = frame[i]!;
+    sumSq += s * s;
+    if (i > 0 && (frame[i - 1]! >= 0) !== (s >= 0)) zeroCrossings++;
+  }
+  const rms = Math.sqrt(sumSq / N);
+  const zcr = zeroCrossings / N;
+
+  return { mfcc, centroid, rolloff, flatness, rms, zcr };
+}
+
+// ── Whole-track aggregation ────────────────────────────────────────
+
+function meanStd(values: number[]): { mean: number; std: number } {
+  if (values.length === 0) return { mean: 0, std: 0 };
+  let sum = 0;
+  for (const v of values) sum += v;
+  const mean = sum / values.length;
+  let sqDiff = 0;
+  for (const v of values) sqDiff += (v - mean) ** 2;
+  const std = Math.sqrt(sqDiff / values.length);
+  return { mean, std };
+}
+
+function l2Normalize(vec: Float32Array): Float32Array {
+  let sumSq = 0;
+  for (let i = 0; i < vec.length; i++) sumSq += vec[i]! * vec[i]!;
+  const norm = Math.sqrt(sumSq);
+  if (norm < 1e-10) return vec;
+  for (let i = 0; i < vec.length; i++) vec[i] = vec[i]! / norm;
+  return vec;
+}
+
+/**
+ * Compute the full feature vector from a mono PCM signal at SAMPLE_RATE.
+ * Returns a length-EMBEDDING_DIM vector, L2-normalized so cosine similarity
+ * works directly. Returns null if the signal is shorter than one frame.
+ */
+export function computeFeatureVector(samples: Float32Array): Float32Array | null {
+  if (samples.length < FRAME_SIZE) return null;
+
+  const mfccByCoeff: number[][] = Array.from({ length: NUM_MFCC_COEFFS }, () => []);
+  const centroids: number[] = [];
+  const rolloffs: number[] = [];
+  const flatnesses: number[] = [];
+  const rmsValues: number[] = [];
+  const zcrs: number[] = [];
+
+  // Pre-allocate the frame buffer once.
+  const frame = new Float32Array(FRAME_SIZE);
+  for (let start = 0; start + FRAME_SIZE <= samples.length; start += HOP_SIZE) {
+    for (let i = 0; i < FRAME_SIZE; i++) frame[i] = samples[start + i]!;
+    const f = frameFeatures(frame);
+    for (let c = 0; c < NUM_MFCC_COEFFS; c++) mfccByCoeff[c]!.push(f.mfcc[c]!);
+    centroids.push(f.centroid);
+    rolloffs.push(f.rolloff);
+    flatnesses.push(f.flatness);
+    rmsValues.push(f.rms);
+    zcrs.push(f.zcr);
+  }
+
+  if (centroids.length === 0) return null;
+
+  const out = new Float32Array(EMBEDDING_DIM);
+  let idx = 0;
+  for (let c = 0; c < NUM_MFCC_COEFFS; c++) {
+    out[idx++] = meanStd(mfccByCoeff[c]!).mean;
+  }
+  for (let c = 0; c < NUM_MFCC_COEFFS; c++) {
+    out[idx++] = meanStd(mfccByCoeff[c]!).std;
+  }
+  const cm = meanStd(centroids);
+  out[idx++] = cm.mean;
+  out[idx++] = cm.std;
+  out[idx++] = meanStd(rolloffs).mean;
+  out[idx++] = meanStd(flatnesses).mean;
+  out[idx++] = meanStd(zcrs).mean;
+  out[idx++] = meanStd(rmsValues).mean;
+
+  return l2Normalize(out);
+}
+
+// ── Cosine similarity ─────────────────────────────────────────────
+
+export function cosineSimilarity(a: ArrayLike<number>, b: ArrayLike<number>): number {
+  if (a.length !== b.length) return 0;
+  let dot = 0;
+  let aSq = 0;
+  let bSq = 0;
+  for (let i = 0; i < a.length; i++) {
+    const av = a[i]!;
+    const bv = b[i]!;
+    dot += av * bv;
+    aSq += av * av;
+    bSq += bv * bv;
+  }
+  const denom = Math.sqrt(aSq) * Math.sqrt(bSq);
+  return denom > 0 ? dot / denom : 0;
+}
+
+/** Mean of a set of vectors, then L2-normalized. */
+export function meanVector(vectors: ArrayLike<number>[]): Float32Array | null {
+  if (vectors.length === 0) return null;
+  const dim = vectors[0]!.length;
+  const out = new Float32Array(dim);
+  for (const v of vectors) {
+    if (v.length !== dim) continue;
+    for (let i = 0; i < dim; i++) out[i] = out[i]! + v[i]!;
+  }
+  for (let i = 0; i < dim; i++) out[i] = out[i]! / vectors.length;
+  return l2Normalize(out);
+}

--- a/backend/src/services/embeddings/audioFeatures.ts
+++ b/backend/src/services/embeddings/audioFeatures.ts
@@ -25,7 +25,18 @@ export const HOP_SIZE = 512;
 export const NUM_MEL_FILTERS = 40;
 export const NUM_MFCC_COEFFS = 13;
 export const EMBEDDING_DIM = 32;
-export const EMBEDDING_VERSION = 1;
+export const EMBEDDING_VERSION = 2;
+
+/**
+ * Per-feature scaling so no single dimension dominates cosine similarity.
+ * Without this, raw centroid/rolloff (Hz, ~10²-10³) drown out MFCCs (~10¹)
+ * and 0..1 features (flatness/zcr/rms) under the final L2 normalization.
+ *
+ * Bump EMBEDDING_VERSION whenever these scales change — old embeddings on
+ * disk are no longer comparable.
+ */
+const NYQUIST = SAMPLE_RATE / 2;
+const MFCC_SCALE = 50;
 
 // ── Window ─────────────────────────────────────────────────────────
 
@@ -153,15 +164,20 @@ type FrameFeatures = {
   zcr: number;
 };
 
-function frameFeatures(frame: Float32Array): FrameFeatures {
+function frameFeatures(
+  frame: Float32Array,
+  real: Float32Array,
+  imag: Float32Array,
+  mag: Float32Array
+): FrameFeatures {
   const N = frame.length;
-  const real = new Float32Array(N);
-  const imag = new Float32Array(N);
-  for (let i = 0; i < N; i++) real[i] = frame[i]! * HANN[i]!;
+  for (let i = 0; i < N; i++) {
+    real[i] = frame[i]! * HANN[i]!;
+    imag[i] = 0;
+  }
   fft(real, imag);
 
   const half = N / 2 + 1;
-  const mag = new Float32Array(half);
   let totalEnergy = 0;
   for (let k = 0; k < half; k++) {
     const re = real[k]!;
@@ -271,11 +287,14 @@ export function computeFeatureVector(samples: Float32Array): Float32Array | null
   const rmsValues: number[] = [];
   const zcrs: number[] = [];
 
-  // Pre-allocate the frame buffer once.
+  // Pre-allocate working buffers once for the whole track.
   const frame = new Float32Array(FRAME_SIZE);
+  const real = new Float32Array(FRAME_SIZE);
+  const imag = new Float32Array(FRAME_SIZE);
+  const mag = new Float32Array(FRAME_SIZE / 2 + 1);
   for (let start = 0; start + FRAME_SIZE <= samples.length; start += HOP_SIZE) {
     for (let i = 0; i < FRAME_SIZE; i++) frame[i] = samples[start + i]!;
-    const f = frameFeatures(frame);
+    const f = frameFeatures(frame, real, imag, mag);
     for (let c = 0; c < NUM_MFCC_COEFFS; c++) mfccByCoeff[c]!.push(f.mfcc[c]!);
     centroids.push(f.centroid);
     rolloffs.push(f.rolloff);
@@ -286,18 +305,15 @@ export function computeFeatureVector(samples: Float32Array): Float32Array | null
 
   if (centroids.length === 0) return null;
 
+  const mfccStats = mfccByCoeff.map(meanStd);
   const out = new Float32Array(EMBEDDING_DIM);
   let idx = 0;
-  for (let c = 0; c < NUM_MFCC_COEFFS; c++) {
-    out[idx++] = meanStd(mfccByCoeff[c]!).mean;
-  }
-  for (let c = 0; c < NUM_MFCC_COEFFS; c++) {
-    out[idx++] = meanStd(mfccByCoeff[c]!).std;
-  }
+  for (let c = 0; c < NUM_MFCC_COEFFS; c++) out[idx++] = mfccStats[c]!.mean / MFCC_SCALE;
+  for (let c = 0; c < NUM_MFCC_COEFFS; c++) out[idx++] = mfccStats[c]!.std / MFCC_SCALE;
   const cm = meanStd(centroids);
-  out[idx++] = cm.mean;
-  out[idx++] = cm.std;
-  out[idx++] = meanStd(rolloffs).mean;
+  out[idx++] = cm.mean / NYQUIST;
+  out[idx++] = cm.std / NYQUIST;
+  out[idx++] = meanStd(rolloffs).mean / NYQUIST;
   out[idx++] = meanStd(flatnesses).mean;
   out[idx++] = meanStd(zcrs).mean;
   out[idx++] = meanStd(rmsValues).mean;

--- a/backend/src/services/playlists/autoPlaylistService.test.ts
+++ b/backend/src/services/playlists/autoPlaylistService.test.ts
@@ -34,10 +34,13 @@ vi.mock("../genre/genreSynonymService", () => ({
 import type { Track } from "../../types/library";
 import {
   generateAutoPlaylists,
+  generateAutoPlaylistsWithTrace,
   getAutoPlaylistById,
   getAutoPlaylistConfig,
   loadAutoPlaylists,
+  loadAutoTrace,
   needsRegeneration,
+  regenerateAutoPlaylists,
   saveAutoPlaylists,
   updateAutoPlaylistConfig
 } from "./autoPlaylistService";
@@ -174,6 +177,36 @@ describe("autoPlaylistService", () => {
       const loaded = await loadAutoPlaylists();
       expect(loaded).toHaveLength(1);
       expect(loaded[0]?.genre).toBe("Jazz");
+    });
+  });
+
+  describe("trace", () => {
+    it("returns trace data alongside playlists, including rejected groups", async () => {
+      await updateAutoPlaylistConfig({ minTracksPerPlaylist: 8, tracksPerPlaylist: 20 });
+      const tracks = [
+        ...tracksForGroup("Rock", 1975, 10, "rock70s"),
+        ...tracksForGroup("Jazz", 1965, 3, "jazz60s")
+      ];
+      const { playlists, trace } = await generateAutoPlaylistsWithTrace(tracks);
+      expect(playlists).toHaveLength(1);
+      expect(trace.totalCandidateTracks).toBe(13);
+      expect(trace.totalGroups).toBe(2);
+      expect(trace.qualifyingGroups).toBe(1);
+      expect(trace.generatedPlaylists).toBe(1);
+      const jazz = trace.groups.find((g) => g.genre === "Jazz");
+      expect(jazz).toBeDefined();
+      expect(jazz!.selected).toBe(false);
+      expect(jazz!.rejection).toBe("below-min-tracks");
+    });
+
+    it("regenerateAutoPlaylists persists a loadable trace", async () => {
+      await updateAutoPlaylistConfig({ minTracksPerPlaylist: 4, tracksPerPlaylist: 10 });
+      const tracks = tracksForGroup("Rock", 1975, 6, "r");
+      await regenerateAutoPlaylists(tracks);
+      const trace = await loadAutoTrace();
+      expect(trace).not.toBeNull();
+      expect(trace!.generatedPlaylists).toBe(1);
+      expect(trace!.durationMs).toBeGreaterThanOrEqual(0);
     });
   });
 

--- a/backend/src/services/playlists/autoPlaylistService.test.ts
+++ b/backend/src/services/playlists/autoPlaylistService.test.ts
@@ -292,6 +292,21 @@ describe("autoPlaylistService", () => {
       expect(trace!.generatedPlaylists).toBe(1);
       expect(trace!.durationMs).toBeGreaterThanOrEqual(0);
     });
+
+    it("produces identical playlists on repeat runs with the same input", async () => {
+      await updateAutoPlaylistConfig({ minTracksPerPlaylist: 6, tracksPerPlaylist: 20 });
+      const tracks = tracksForGroup("Rock", 1975, 12, "r");
+      const a = await generateAutoPlaylists(tracks);
+      const b = await generateAutoPlaylists(tracks);
+      expect(a.length).toBe(b.length);
+      expect(a.length).toBeGreaterThan(0);
+      for (let i = 0; i < a.length; i++) {
+        expect(a[i]!.id).toBe(b[i]!.id);
+        expect(a[i]!.trackIds).toEqual(b[i]!.trackIds);
+        expect(a[i]!.colors).toEqual(b[i]!.colors);
+        expect(a[i]!.gradientAngle).toBe(b[i]!.gradientAngle);
+      }
+    });
   });
 
   describe("needsRegeneration", () => {

--- a/backend/src/services/playlists/autoPlaylistService.test.ts
+++ b/backend/src/services/playlists/autoPlaylistService.test.ts
@@ -33,6 +33,7 @@ vi.mock("../genre/genreSynonymService", () => ({
 
 import type { Track } from "../../types/library";
 import {
+  bpmBucket,
   generateAutoPlaylists,
   generateAutoPlaylistsWithTrace,
   getAutoPlaylistById,
@@ -40,6 +41,7 @@ import {
   loadAutoPlaylists,
   loadAutoTrace,
   needsRegeneration,
+  pickMosaicCovers,
   regenerateAutoPlaylists,
   saveAutoPlaylists,
   updateAutoPlaylistConfig
@@ -177,6 +179,88 @@ describe("autoPlaylistService", () => {
       const loaded = await loadAutoPlaylists();
       expect(loaded).toHaveLength(1);
       expect(loaded[0]?.genre).toBe("Jazz");
+    });
+  });
+
+  describe("bpmBucket", () => {
+    it("returns null for missing or non-positive BPM", () => {
+      expect(bpmBucket(undefined)).toBeNull();
+      expect(bpmBucket(0)).toBeNull();
+      expect(bpmBucket(-30)).toBeNull();
+      expect(bpmBucket(NaN)).toBeNull();
+    });
+
+    it("buckets boundaries at 90/120/140", () => {
+      expect(bpmBucket(60)).toBe("slow");
+      expect(bpmBucket(89)).toBe("slow");
+      expect(bpmBucket(90)).toBe("mid");
+      expect(bpmBucket(119)).toBe("mid");
+      expect(bpmBucket(120)).toBe("driving");
+      expect(bpmBucket(139)).toBe("driving");
+      expect(bpmBucket(140)).toBe("fast");
+      expect(bpmBucket(180)).toBe("fast");
+    });
+  });
+
+  describe("pickMosaicCovers", () => {
+    it("returns empty array when no track has a cover", () => {
+      const tracks = tracksForGroup("Rock", 1975, 5, "r");
+      expect(pickMosaicCovers(tracks)).toEqual([]);
+    });
+
+    it("picks up to N distinct covers, preferring distinct albums", () => {
+      const tracks: Track[] = [
+        makeTrack({ id: "t1", cover: "/cov/a.jpg", tags: { album: "Album A" } }),
+        makeTrack({ id: "t2", cover: "/cov/a.jpg", tags: { album: "Album A" } }), // dup cover, dup album
+        makeTrack({ id: "t3", cover: "/cov/b.jpg", tags: { album: "Album B" } }),
+        makeTrack({ id: "t4", cover: "/cov/c.jpg", tags: { album: "Album C" } }),
+        makeTrack({ id: "t5", cover: "/cov/d.jpg", tags: { album: "Album D" } }),
+        makeTrack({ id: "t6", cover: "/cov/e.jpg", tags: { album: "Album E" } })
+      ];
+      const result = pickMosaicCovers(tracks, 4);
+      expect(result).toEqual(["/cov/a.jpg", "/cov/b.jpg", "/cov/c.jpg", "/cov/d.jpg"]);
+    });
+  });
+
+  describe("multi-axis generation", () => {
+    it("creates tempo-axis playlists when BPM is present", async () => {
+      await updateAutoPlaylistConfig({ minTracksPerPlaylist: 4, tracksPerPlaylist: 20 });
+      const tracks = Array.from({ length: 6 }, (_, i) =>
+        makeTrack({
+          id: `r-${i}`,
+          tags: { artist: `a-${i}`, album: `a-${i}`, genre: ["Rock"], year: 1975, bpm: 130 }
+        })
+      );
+      const { playlists, trace } = await generateAutoPlaylistsWithTrace(tracks);
+
+      const tempo = playlists.find((p) => p.axis === "genre-tempo");
+      const decade = playlists.find((p) => p.axis === "decade-genre");
+      expect(tempo).toBeDefined();
+      expect(tempo!.tempo).toBe("driving");
+      expect(tempo!.name).toBe("Driving Rock");
+      expect(decade).toBeDefined();
+      expect(decade!.name).toBe("70s Rock");
+
+      const axes = new Set(trace.groups.map((g) => g.axis));
+      expect(axes.has("decade-genre")).toBe(true);
+      expect(axes.has("genre-tempo")).toBe(true);
+    });
+
+    it("places a track tagged with multiple genres in each group", async () => {
+      await updateAutoPlaylistConfig({ minTracksPerPlaylist: 4, tracksPerPlaylist: 20 });
+      const tracks: Track[] = [];
+      for (let i = 0; i < 5; i++) {
+        tracks.push(makeTrack({
+          id: `t-${i}`,
+          tags: { artist: `a-${i}`, album: `al-${i}`, genre: ["Rock", "Blues"], year: 1975 }
+        }));
+      }
+      const playlists = await generateAutoPlaylists(tracks);
+      const rock = playlists.find((p) => p.name === "70s Rock");
+      const blues = playlists.find((p) => p.name === "70s Blues");
+      expect(rock).toBeDefined();
+      expect(blues).toBeDefined();
+      expect(rock!.trackIds.sort()).toEqual(blues!.trackIds.sort());
     });
   });
 

--- a/backend/src/services/playlists/autoPlaylistService.ts
+++ b/backend/src/services/playlists/autoPlaylistService.ts
@@ -19,16 +19,25 @@ const REGENERATION_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000;
 
 // ── Types ──────────────────────────────────────────────────────────
 
+export type AutoAxis = "decade-genre" | "genre-tempo";
+
+export type TempoBucket = "slow" | "mid" | "driving" | "fast";
+
 export type AutoPlaylist = {
   id: string;
   name: string;
   genre: string;
+  /** Present for decade-genre axis playlists. 0 for genre-tempo axis. */
   decade: number;
+  axis?: AutoAxis;
+  tempo?: TempoBucket;
   trackIds: string[];
   trackCount: number;
   generatedAt: string;
   colors: [string, string, string];
   gradientAngle: number;
+  /** Up to 4 cover paths picked from representative tracks; empty if none. */
+  mosaicCovers?: string[];
 };
 
 export type AutoPlaylistConfig = {
@@ -143,6 +152,61 @@ function randomGradientColors(): [string, string, string] {
   }) as [string, string, string];
 }
 
+/**
+ * Bucket a BPM into one of four tempo bands. Boundaries follow the common
+ * guideline: slow up to 89 BPM (ballads), mid 90-119 (pop/midtempo), driving
+ * 120-139 (dance/rock), fast 140+ (drum & bass / punk / fast house).
+ */
+export function bpmBucket(bpm: number | undefined): TempoBucket | null {
+  if (typeof bpm !== "number" || !Number.isFinite(bpm) || bpm <= 0) return null;
+  if (bpm < 90) return "slow";
+  if (bpm < 120) return "mid";
+  if (bpm < 140) return "driving";
+  return "fast";
+}
+
+const TEMPO_LABELS: Record<TempoBucket, string> = {
+  slow: "Slow",
+  mid: "Midtempo",
+  driving: "Driving",
+  fast: "Fast"
+};
+
+/**
+ * Pick up to N distinct album covers from the playlist's tracks for a mosaic.
+ * Prefers covers from different albums and returns them in deterministic order
+ * (by appearance in the input). Returns an empty array if no track has a cover.
+ */
+export function pickMosaicCovers(tracks: Track[], max = 4): string[] {
+  const seen = new Set<string>();
+  const seenAlbums = new Set<string>();
+  const covers: string[] = [];
+
+  for (const track of tracks) {
+    if (covers.length >= max) break;
+    const cover = track.cover;
+    if (!cover || seen.has(cover)) continue;
+    const albumKey = (track.tags.album ?? "").toLowerCase();
+    if (albumKey && seenAlbums.has(albumKey)) continue;
+    covers.push(cover);
+    seen.add(cover);
+    if (albumKey) seenAlbums.add(albumKey);
+  }
+
+  // Second pass: if we still need more, accept duplicate albums but distinct covers.
+  if (covers.length < max) {
+    for (const track of tracks) {
+      if (covers.length >= max) break;
+      const cover = track.cover;
+      if (!cover || seen.has(cover)) continue;
+      covers.push(cover);
+      seen.add(cover);
+    }
+  }
+
+  return covers;
+}
+
 export type AutoGenerationResult = {
   playlists: AutoPlaylist[];
   trace: AutoTrace;
@@ -153,40 +217,80 @@ export async function generateAutoPlaylists(tracks: Track[]): Promise<AutoPlayli
   return result.playlists;
 }
 
+type GroupBucket = {
+  key: string;
+  axis: AutoAxis;
+  genre: string;
+  decade: number;
+  tempo?: TempoBucket;
+  tracks: ScoredTrack[];
+};
+
+function makeScored(track: Track): ScoredTrack {
+  return {
+    track,
+    artist: (track.tags.artist ?? "").toLowerCase(),
+    album: (track.tags.album ?? "").toLowerCase()
+  };
+}
+
 export async function generateAutoPlaylistsWithTrace(tracks: Track[]): Promise<AutoGenerationResult> {
   const config = await getAutoPlaylistConfig();
   const builder = new AutoTraceBuilder();
 
-  const groups = new Map<string, { genre: string; decade: number; tracks: ScoredTrack[] }>();
-  let candidateCount = 0;
+  const groups = new Map<string, GroupBucket>();
+  // A track contributes to the candidate count if it can land in *any* group
+  // (i.e. has at least one genre and at least one of year or BPM).
+  const candidateTrackIds = new Set<string>();
 
   for (const track of tracks) {
     const genres = track.tags.genre;
+    if (!genres || genres.length === 0) continue;
+
     const year = track.tags.year;
-    if (!genres || genres.length === 0 || !year) continue;
-    candidateCount++;
+    const tempo = bpmBucket(track.tags.bpm);
+    if (!year && !tempo) continue;
 
-    const primaryGenre = normalizeGenreLabel(genres[0]!);
-    const decade = Math.floor(year / 10) * 10;
-    const key = `${decade}:${primaryGenre.toLowerCase()}`;
+    candidateTrackIds.add(track.id);
+    const scored = makeScored(track);
 
-    let group = groups.get(key);
-    if (!group) {
-      group = { genre: primaryGenre, decade, tracks: [] };
-      groups.set(key, group);
+    // Iterate every genre on the track (multi-presence). Tracks tagged with
+    // multiple genres show up in each corresponding group instead of being
+    // bound to genres[0].
+    const seenGenreKeys = new Set<string>();
+    for (const rawGenre of genres) {
+      const genre = normalizeGenreLabel(rawGenre);
+      const genreKey = genre.toLowerCase();
+      if (seenGenreKeys.has(genreKey)) continue;
+      seenGenreKeys.add(genreKey);
+
+      if (year) {
+        const decade = Math.floor(year / 10) * 10;
+        const key = `decade-genre|${decade}|${genreKey}`;
+        let group = groups.get(key);
+        if (!group) {
+          group = { key, axis: "decade-genre", genre, decade, tracks: [] };
+          groups.set(key, group);
+        }
+        group.tracks.push(scored);
+      }
+
+      if (tempo) {
+        const key = `genre-tempo|${genreKey}|${tempo}`;
+        let group = groups.get(key);
+        if (!group) {
+          group = { key, axis: "genre-tempo", genre, decade: 0, tempo, tracks: [] };
+          groups.set(key, group);
+        }
+        group.tracks.push(scored);
+      }
     }
-
-    group.tracks.push({
-      track,
-      artist: (track.tags.artist ?? "").toLowerCase(),
-      album: (track.tags.album ?? "").toLowerCase()
-    });
   }
 
-  builder.setTotalCandidateTracks(candidateCount);
+  builder.setTotalCandidateTracks(candidateTrackIds.size);
   builder.setTotalGroups(groups.size);
 
-  const allGroups = Array.from(groups.entries()).map(([key, g]) => ({ key, ...g }));
+  const allGroups = [...groups.values()];
   const qualifying = allGroups
     .filter((g) => g.tracks.length >= config.minTracksPerPlaylist)
     .sort((a, b) => b.tracks.length - a.tracks.length);
@@ -196,6 +300,36 @@ export async function generateAutoPlaylistsWithTrace(tracks: Track[]): Promise<A
   const selectedKeys = new Set(selected.map((g) => g.key));
   builder.setQualifyingGroups(qualifying.length);
 
+  const generatedAt = new Date().toISOString();
+  const playlists: AutoPlaylist[] = [];
+  const mosaicCountByKey = new Map<string, number>();
+
+  for (const group of selected) {
+    const name =
+      group.axis === "decade-genre"
+        ? `${toDecadeLabel(group.decade)} ${group.genre}`
+        : `${TEMPO_LABELS[group.tempo!]} ${group.genre}`;
+    const id = `auto:${slugify(name)}`;
+    const selectedTracks = selectDiverseTracks(group.tracks, config.tracksPerPlaylist);
+    const mosaic = pickMosaicCovers(selectedTracks);
+    mosaicCountByKey.set(group.key, mosaic.length);
+
+    playlists.push({
+      id,
+      name,
+      genre: group.genre,
+      decade: group.decade,
+      axis: group.axis,
+      ...(group.tempo ? { tempo: group.tempo } : {}),
+      trackIds: selectedTracks.map((t) => t.id),
+      trackCount: selectedTracks.length,
+      generatedAt,
+      colors: randomGradientColors(),
+      gradientAngle: Math.floor(Math.random() * 360),
+      ...(mosaic.length > 0 ? { mosaicCovers: mosaic } : {})
+    });
+  }
+
   for (const g of allGroups) {
     let rejection: string | undefined;
     if (g.tracks.length < config.minTracksPerPlaylist) rejection = "below-min-tracks";
@@ -203,33 +337,14 @@ export async function generateAutoPlaylistsWithTrace(tracks: Track[]): Promise<A
 
     builder.recordGroup({
       key: g.key,
+      axis: g.axis,
       genre: g.genre,
       decade: g.decade,
+      ...(g.tempo ? { tempo: g.tempo } : {}),
       trackCount: g.tracks.length,
       selected: selectedKeys.has(g.key),
+      ...(mosaicCountByKey.has(g.key) ? { mosaicCoverCount: mosaicCountByKey.get(g.key) } : {}),
       ...(rejection ? { rejection } : {})
-    });
-  }
-
-  const generatedAt = new Date().toISOString();
-  const playlists: AutoPlaylist[] = [];
-
-  for (const group of selected) {
-    const decadeLabel = toDecadeLabel(group.decade);
-    const name = `${decadeLabel} ${group.genre}`;
-    const id = `auto:${slugify(name)}`;
-    const selectedTracks = selectDiverseTracks(group.tracks, config.tracksPerPlaylist);
-
-    playlists.push({
-      id,
-      name,
-      genre: group.genre,
-      decade: group.decade,
-      trackIds: selectedTracks.map((t) => t.id),
-      trackCount: selectedTracks.length,
-      generatedAt,
-      colors: randomGradientColors(),
-      gradientAngle: Math.floor(Math.random() * 360)
     });
   }
 

--- a/backend/src/services/playlists/autoPlaylistService.ts
+++ b/backend/src/services/playlists/autoPlaylistService.ts
@@ -6,11 +6,13 @@ import { dataRoot } from "../../utils/paths";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
 import { normalizeGenreLabel } from "../genre/genreSynonymService";
 import type { Track } from "../../types/library";
+import { AutoTraceBuilder, type AutoTrace } from "./playlistTrace";
 
 const log = createLogger("auto-playlists");
 
 const AUTO_PLAYLISTS_DIR = path.join(dataRoot, "auto-playlists");
 const META_FILE = path.join(AUTO_PLAYLISTS_DIR, "_meta.json");
+const TRACE_FILE = path.join(AUTO_PLAYLISTS_DIR, "_trace.json");
 const CONFIG_FILE = path.join(dataRoot, "config", "auto-playlist-config.json");
 
 const REGENERATION_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000;
@@ -141,15 +143,28 @@ function randomGradientColors(): [string, string, string] {
   }) as [string, string, string];
 }
 
+export type AutoGenerationResult = {
+  playlists: AutoPlaylist[];
+  trace: AutoTrace;
+};
+
 export async function generateAutoPlaylists(tracks: Track[]): Promise<AutoPlaylist[]> {
+  const result = await generateAutoPlaylistsWithTrace(tracks);
+  return result.playlists;
+}
+
+export async function generateAutoPlaylistsWithTrace(tracks: Track[]): Promise<AutoGenerationResult> {
   const config = await getAutoPlaylistConfig();
+  const builder = new AutoTraceBuilder();
 
   const groups = new Map<string, { genre: string; decade: number; tracks: ScoredTrack[] }>();
+  let candidateCount = 0;
 
   for (const track of tracks) {
     const genres = track.tags.genre;
     const year = track.tags.year;
     if (!genres || genres.length === 0 || !year) continue;
+    candidateCount++;
 
     const primaryGenre = normalizeGenreLabel(genres[0]!);
     const decade = Math.floor(year / 10) * 10;
@@ -168,18 +183,38 @@ export async function generateAutoPlaylists(tracks: Track[]): Promise<AutoPlayli
     });
   }
 
-  let qualifyingGroups = Array.from(groups.values())
+  builder.setTotalCandidateTracks(candidateCount);
+  builder.setTotalGroups(groups.size);
+
+  const allGroups = Array.from(groups.entries()).map(([key, g]) => ({ key, ...g }));
+  const qualifying = allGroups
     .filter((g) => g.tracks.length >= config.minTracksPerPlaylist)
     .sort((a, b) => b.tracks.length - a.tracks.length);
 
-  if (config.maxPlaylists > 0) {
-    qualifyingGroups = qualifyingGroups.slice(0, config.maxPlaylists);
+  const cutoff = config.maxPlaylists > 0 ? config.maxPlaylists : qualifying.length;
+  const selected = qualifying.slice(0, cutoff);
+  const selectedKeys = new Set(selected.map((g) => g.key));
+  builder.setQualifyingGroups(qualifying.length);
+
+  for (const g of allGroups) {
+    let rejection: string | undefined;
+    if (g.tracks.length < config.minTracksPerPlaylist) rejection = "below-min-tracks";
+    else if (!selectedKeys.has(g.key)) rejection = "above-max-playlists";
+
+    builder.recordGroup({
+      key: g.key,
+      genre: g.genre,
+      decade: g.decade,
+      trackCount: g.tracks.length,
+      selected: selectedKeys.has(g.key),
+      ...(rejection ? { rejection } : {})
+    });
   }
 
   const generatedAt = new Date().toISOString();
   const playlists: AutoPlaylist[] = [];
 
-  for (const group of qualifyingGroups) {
+  for (const group of selected) {
     const decadeLabel = toDecadeLabel(group.decade);
     const name = `${decadeLabel} ${group.genre}`;
     const id = `auto:${slugify(name)}`;
@@ -198,7 +233,8 @@ export async function generateAutoPlaylists(tracks: Track[]): Promise<AutoPlayli
     });
   }
 
-  return playlists;
+  builder.setGeneratedPlaylists(playlists.length);
+  return { playlists, trace: builder.build() };
 }
 
 // ── Storage ────────────────────────────────────────────────────────
@@ -208,7 +244,7 @@ export async function saveAutoPlaylists(playlists: AutoPlaylist[]): Promise<void
 
   const existing = await fs.readdir(AUTO_PLAYLISTS_DIR).catch(() => []);
   for (const file of existing) {
-    if (file.endsWith(".json") && file !== "_meta.json") {
+    if (file.endsWith(".json") && file !== "_meta.json" && file !== "_trace.json") {
       await fs.unlink(path.join(AUTO_PLAYLISTS_DIR, file)).catch(() => {});
     }
   }
@@ -224,6 +260,17 @@ export async function saveAutoPlaylists(playlists: AutoPlaylist[]): Promise<void
   log.info(`Saved ${playlists.length} auto playlist(s)`);
 }
 
+export async function saveAutoTrace(trace: AutoTrace): Promise<void> {
+  await ensureDir(AUTO_PLAYLISTS_DIR);
+  await writeJsonAtomic(TRACE_FILE, trace);
+}
+
+export async function loadAutoTrace(): Promise<AutoTrace | null> {
+  const data = await readJsonFile<AutoTrace>(TRACE_FILE, null as unknown as AutoTrace);
+  if (!data || typeof data !== "object" || typeof data.durationMs !== "number") return null;
+  return data;
+}
+
 export async function loadAutoPlaylists(): Promise<AutoPlaylist[]> {
   await ensureDir(AUTO_PLAYLISTS_DIR);
 
@@ -231,7 +278,7 @@ export async function loadAutoPlaylists(): Promise<AutoPlaylist[]> {
   const playlists: AutoPlaylist[] = [];
 
   for (const file of files) {
-    if (!file.endsWith(".json") || file === "_meta.json") continue;
+    if (!file.endsWith(".json") || file === "_meta.json" || file === "_trace.json") continue;
     const data = await readJsonFile<AutoPlaylist>(
       path.join(AUTO_PLAYLISTS_DIR, file),
       null as unknown as AutoPlaylist
@@ -265,9 +312,13 @@ export async function needsRegeneration(): Promise<boolean> {
 
 export async function regenerateAutoPlaylists(tracks: Track[]): Promise<AutoPlaylist[]> {
   log.info("Regenerating auto playlists...");
-  const playlists = await generateAutoPlaylists(tracks);
+  const { playlists, trace } = await generateAutoPlaylistsWithTrace(tracks);
   await saveAutoPlaylists(playlists);
-  log.info(`Generated ${playlists.length} auto playlist(s)`);
+  await saveAutoTrace(trace);
+  log.info(
+    `auto: candidates=${trace.totalCandidateTracks} groups=${trace.totalGroups} ` +
+      `qualifying=${trace.qualifyingGroups} playlists=${playlists.length} durationMs=${trace.durationMs}`
+  );
   return playlists;
 }
 

--- a/backend/src/services/playlists/autoPlaylistService.ts
+++ b/backend/src/services/playlists/autoPlaylistService.ts
@@ -84,6 +84,32 @@ export async function updateAutoPlaylistConfig(patch: Partial<AutoPlaylistConfig
   return next;
 }
 
+// ── Deterministic PRNG ─────────────────────────────────────────────
+
+/**
+ * Small FNV-1a + mulberry32 combo so a string seed yields a reproducible
+ * stream of pseudo-random numbers. Used everywhere we want jitter without
+ * the regen-to-regen drift of Math.random().
+ */
+function fnv1a(seed: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i++) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+function seededRng(seed: string): () => number {
+  let t = fnv1a(seed);
+  return () => {
+    t = (t + 0x6d2b79f5) >>> 0;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r = (r + Math.imul(r ^ (r >>> 7), 61 | r)) ^ r;
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
 // ── Diversity selection ────────────────────────────────────────────
 
 type ScoredTrack = {
@@ -92,8 +118,18 @@ type ScoredTrack = {
   album: string;
 };
 
-function selectDiverseTracks(candidates: ScoredTrack[], maxTracks: number): Track[] {
-  const pool = [...candidates].sort(() => Math.random() - 0.5);
+function selectDiverseTracks(
+  candidates: ScoredTrack[],
+  maxTracks: number,
+  seed: string
+): Track[] {
+  const rng = seededRng(seed);
+  // Stable shuffle: seed-driven, plus a tie-breaker on track id so the input
+  // order doesn't leak into the result.
+  const pool = [...candidates]
+    .map((c) => ({ c, k: rng() }))
+    .sort((a, b) => a.k - b.k || a.c.track.id.localeCompare(b.c.track.id))
+    .map((x) => x.c);
   const selected: ScoredTrack[] = [];
 
   while (selected.length < maxTracks && pool.length > 0) {
@@ -113,7 +149,7 @@ function selectDiverseTracks(candidates: ScoredTrack[], maxTracks: number): Trac
       const recentArtists = selected.slice(-3).map((s) => s.artist);
       if (recentArtists.includes(candidate.artist)) score -= 250;
 
-      score += Math.random() * 40;
+      score += rng() * 40;
 
       if (score > bestScore) {
         bestScore = score;
@@ -141,15 +177,20 @@ function slugify(text: string): string {
     .replace(/^-|-$/g, "");
 }
 
-function randomGradientColors(): [string, string, string] {
-  const hue = Math.floor(Math.random() * 360);
-  const offsets = [0, 40 + Math.floor(Math.random() * 40), 160 + Math.floor(Math.random() * 80)];
+function gradientColorsFromSeed(seed: string): [string, string, string] {
+  const rng = seededRng(`${seed}|colors`);
+  const hue = Math.floor(rng() * 360);
+  const offsets = [0, 40 + Math.floor(rng() * 40), 160 + Math.floor(rng() * 80)];
   return offsets.map((offset) => {
     const h = (hue + offset) % 360;
-    const s = 55 + Math.floor(Math.random() * 25);
-    const l = 45 + Math.floor(Math.random() * 20);
+    const s = 55 + Math.floor(rng() * 25);
+    const l = 45 + Math.floor(rng() * 20);
     return `hsl(${h}, ${s}%, ${l}%)`;
   }) as [string, string, string];
+}
+
+function gradientAngleFromSeed(seed: string): number {
+  return Math.floor(seededRng(`${seed}|angle`)() * 360);
 }
 
 /**
@@ -310,7 +351,7 @@ export async function generateAutoPlaylistsWithTrace(tracks: Track[]): Promise<A
         ? `${toDecadeLabel(group.decade)} ${group.genre}`
         : `${TEMPO_LABELS[group.tempo!]} ${group.genre}`;
     const id = `auto:${slugify(name)}`;
-    const selectedTracks = selectDiverseTracks(group.tracks, config.tracksPerPlaylist);
+    const selectedTracks = selectDiverseTracks(group.tracks, config.tracksPerPlaylist, group.key);
     const mosaic = pickMosaicCovers(selectedTracks);
     mosaicCountByKey.set(group.key, mosaic.length);
 
@@ -324,8 +365,8 @@ export async function generateAutoPlaylistsWithTrace(tracks: Track[]): Promise<A
       trackIds: selectedTracks.map((t) => t.id),
       trackCount: selectedTracks.length,
       generatedAt,
-      colors: randomGradientColors(),
-      gradientAngle: Math.floor(Math.random() * 360),
+      colors: gradientColorsFromSeed(id),
+      gradientAngle: gradientAngleFromSeed(id),
       ...(mosaic.length > 0 ? { mosaicCovers: mosaic } : {})
     });
   }
@@ -399,8 +440,8 @@ export async function loadAutoPlaylists(): Promise<AutoPlaylist[]> {
       null as unknown as AutoPlaylist
     );
     if (data && data.id && data.trackIds) {
-      if (!data.colors) data.colors = randomGradientColors();
-      if (data.gradientAngle === undefined) data.gradientAngle = Math.floor(Math.random() * 360);
+      if (!data.colors) data.colors = gradientColorsFromSeed(data.id);
+      if (data.gradientAngle === undefined) data.gradientAngle = gradientAngleFromSeed(data.id);
       playlists.push(data);
     }
   }

--- a/backend/src/services/playlists/forYouPlaylistService.test.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.test.ts
@@ -44,17 +44,26 @@ function makeTrack(overrides: Partial<Track> & { id: string }): Track {
 function makeMockIndexStore(tracks: Track[]): IndexStore {
   const byId = new Map(tracks.map((t) => [t.id, t]));
   const byArtist = new Map<string, Track[]>();
+  const byAlbum = new Map<string, Track[]>();
   for (const t of tracks) {
     const artist = (t.tags.artist ?? "Unknown").toLowerCase();
-    const list = byArtist.get(artist) ?? [];
-    list.push(t);
-    byArtist.set(artist, list);
+    const aList = byArtist.get(artist) ?? [];
+    aList.push(t);
+    byArtist.set(artist, aList);
+
+    const album = (t.tags.album ?? "").toLowerCase();
+    if (album) {
+      const list = byAlbum.get(album) ?? [];
+      list.push(t);
+      byAlbum.set(album, list);
+    }
   }
 
   return {
     getSnapshot: () => ({ tracks, totalTracks: tracks.length, generatedAt: "", playlists: [] }),
     getTrackById: (id: string) => byId.get(id),
     getTracksByArtist: (artist: string) => byArtist.get(artist.toLowerCase()) ?? [],
+    getTracksByAlbum: (album: string) => byAlbum.get(album.toLowerCase()) ?? [],
     hasTrack: (id: string) => byId.has(id)
   } as unknown as IndexStore;
 }
@@ -116,11 +125,12 @@ describe("forYouPlaylistService", () => {
     const result = await generateForYouPlaylists("user-1", indexStore);
 
     expect(result.length).toBeGreaterThan(0);
-    expect(result.length).toBeLessThanOrEqual(3);
+    expect(result.length).toBeLessThanOrEqual(6);
 
     for (const playlist of result) {
       expect(playlist.id).toMatch(/^for-you:/);
-      expect(playlist.name).toMatch(/^Because you listen to /);
+      // Name varies depending on era spread, peer share, and artist count.
+      expect(playlist.name).toMatch(/(Because you listen to|More|Around|with|& friends)/);
       expect(playlist.trackIds.length).toBeGreaterThan(0);
     }
   });
@@ -216,5 +226,147 @@ describe("forYouPlaylistService", () => {
     expect(loaded.length).toBe(1);
     expect(loaded[0]!.id).toBe("for-you:pink-floyd");
     expect(loaded[0]!.trackIds).toEqual(["t1", "t2", "t3"]);
+  });
+
+  it("enforces the per-peer-artist cap inside a playlist", async () => {
+    const { generateForYouPlaylists } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    // Seed: Pink Floyd (10 tracks). Peer pool: One dominant peer artist with
+    // 30 candidate tracks, plus a few other peer artists. Without the cap the
+    // dominant peer would swallow the playlist; with cap=4 we expect ≤4 from any
+    // single peer.
+    const tracks: Track[] = [];
+    for (let i = 0; i < 10; i++) {
+      tracks.push(makeTrack({ id: `seed-${i}`, tags: { artist: "Pink Floyd", album: `pf-${i}`, genre: ["Rock"], year: 1973 } }));
+    }
+    for (let i = 0; i < 30; i++) {
+      tracks.push(makeTrack({ id: `dom-${i}`, tags: { artist: "Dominant Band", album: `db-${i}`, genre: ["Rock"], year: 1973 } }));
+    }
+    for (let i = 0; i < 6; i++) {
+      tracks.push(makeTrack({ id: `other-${i}`, tags: { artist: `Other ${i}`, album: `o-${i}`, genre: ["Rock"], year: 1973 } }));
+    }
+
+    const indexStore = makeMockIndexStore(tracks);
+    const dir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(dir);
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 10; i++) playCounts[`seed-${i}`] = { count: 5, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    // Spread plays across 3+ distinct artists so MIN_DISTINCT_ARTISTS is met.
+    playCounts["other-0"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["other-1"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["other-2"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    await writeJsonAtomic(path.join(dir, "play-counts.json"), { tracks: playCounts });
+
+    const result = await generateForYouPlaylists("user-1", indexStore);
+    const pinkFloyd = result.find((p) => p.seedArtist === "Pink Floyd");
+    expect(pinkFloyd).toBeDefined();
+
+    const artistCounts = new Map<string, number>();
+    for (const id of pinkFloyd!.trackIds) {
+      const t = tracks.find((tr) => tr.id === id)!;
+      const a = t.tags.artist!;
+      artistCounts.set(a, (artistCounts.get(a) ?? 0) + 1);
+    }
+    const dominantCount = artistCounts.get("Dominant Band") ?? 0;
+    expect(dominantCount).toBeLessThanOrEqual(4);
+  });
+
+  it("includes genreless tracks via year fallback", async () => {
+    const { generateForYouPlaylists } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    // Seed: Pink Floyd (Rock, 1973). A peer artist with no genre but the same era.
+    const tracks: Track[] = [];
+    for (let i = 0; i < 10; i++) {
+      tracks.push(makeTrack({ id: `seed-${i}`, tags: { artist: "Pink Floyd", album: `pf-${i}`, genre: ["Rock"], year: 1973 } }));
+    }
+    for (let i = 0; i < 8; i++) {
+      tracks.push(makeTrack({ id: `genreless-${i}`, tags: { artist: "Mystery Band", album: `m-${i}`, year: 1974 } }));
+    }
+    // Two extra non-overlapping artists so we hit MIN_DISTINCT_ARTISTS via plays.
+    for (let i = 0; i < 4; i++) {
+      tracks.push(makeTrack({ id: `other-${i}`, tags: { artist: "Other Band", album: `ob-${i}`, genre: ["Rock"], year: 1974 } }));
+    }
+    for (let i = 0; i < 4; i++) {
+      tracks.push(makeTrack({ id: `third-${i}`, tags: { artist: "Third Band", album: `tb-${i}`, genre: ["Rock"], year: 1974 } }));
+    }
+
+    const indexStore = makeMockIndexStore(tracks);
+    const dir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(dir);
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 10; i++) playCounts[`seed-${i}`] = { count: 3, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["other-0"] = { count: 2, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["other-1"] = { count: 2, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["third-0"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    await writeJsonAtomic(path.join(dir, "play-counts.json"), { tracks: playCounts });
+
+    const result = await generateForYouPlaylists("user-1", indexStore);
+    const pinkFloyd = result.find((p) => p.seedArtist === "Pink Floyd");
+    expect(pinkFloyd).toBeDefined();
+    const hasMystery = pinkFloyd!.trackIds.some((id) => id.startsWith("genreless-"));
+    expect(hasMystery).toBe(true);
+  });
+
+  it("trace records final-order with feature breakdowns", async () => {
+    const { regenerateForYouPlaylists, loadForYouTrace } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    const artists = ["Pink Floyd", "Led Zeppelin", "Deep Purple", "Black Sabbath"];
+    const tracks: Track[] = [];
+    for (let i = 0; i < 60; i++) {
+      const artist = artists[i % 4]!;
+      tracks.push(makeTrack({ id: `track-${i}`, tags: { artist, album: `${artist}-${i % 3}`, genre: ["Rock"], year: 1972 + (i % 6) } }));
+    }
+    const indexStore = makeMockIndexStore(tracks);
+    const dir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(dir);
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 30; i++) playCounts[`track-${i}`] = { count: 2, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    await writeJsonAtomic(path.join(dir, "play-counts.json"), { tracks: playCounts });
+
+    await regenerateForYouPlaylists("user-1", indexStore);
+    const trace = await loadForYouTrace("user-1");
+
+    expect(trace).not.toBeNull();
+    const successful = trace!.playlists.find((p) => p.playlistId !== null);
+    expect(successful).toBeDefined();
+    expect(successful!.finalOrder).toBeDefined();
+    expect(successful!.finalOrder!.length).toBeGreaterThan(0);
+    const sample = successful!.finalOrder![0]!;
+    expect(sample.features.genreOverlap).toBeGreaterThanOrEqual(0);
+    expect(sample.features.genreOverlap).toBeLessThanOrEqual(1);
+    expect(sample.features.yearProximity).toBeGreaterThanOrEqual(0);
+    expect(sample.features.yearProximity).toBeLessThanOrEqual(1);
+  });
+
+  it("dismissed seed is skipped at the seed-selection stage", async () => {
+    const { regenerateForYouPlaylists, dismissForYouPlaylist, loadForYouTrace } =
+      await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    const artists = ["Pink Floyd", "Led Zeppelin", "Deep Purple", "Black Sabbath"];
+    const tracks: Track[] = [];
+    for (let i = 0; i < 60; i++) {
+      const artist = artists[i % 4]!;
+      tracks.push(makeTrack({ id: `track-${i}`, tags: { artist, album: `${artist}-${i % 3}`, genre: ["Rock"], year: 1972 + (i % 6) } }));
+    }
+    const indexStore = makeMockIndexStore(tracks);
+    const dir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(dir);
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 30; i++) playCounts[`track-${i}`] = { count: 2, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    await writeJsonAtomic(path.join(dir, "play-counts.json"), { tracks: playCounts });
+
+    await dismissForYouPlaylist("user-1", "for-you:pink-floyd");
+    await regenerateForYouPlaylists("user-1", indexStore);
+
+    const trace = await loadForYouTrace("user-1");
+    expect(trace).not.toBeNull();
+    const skipped = trace!.seedSelection.skipped.find((s) => s.artist === "Pink Floyd");
+    expect(skipped?.reason).toBe("dismissed");
+    const chosenIncludesPF = trace!.seedSelection.chosen.includes("Pink Floyd");
+    expect(chosenIncludesPF).toBe(false);
   });
 });

--- a/backend/src/services/playlists/forYouPlaylistService.test.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.test.ts
@@ -341,6 +341,49 @@ describe("forYouPlaylistService", () => {
     expect(sample.features.yearProximity).toBeLessThanOrEqual(1);
   });
 
+  it("excludes tracks with 3+ recent skips from the candidate pool", async () => {
+    const { regenerateForYouPlaylists, loadForYouTrace } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    const artists = ["Pink Floyd", "Led Zeppelin", "Deep Purple", "Black Sabbath"];
+    const tracks: Track[] = [];
+    for (let i = 0; i < 60; i++) {
+      const artist = artists[i % 4]!;
+      tracks.push(
+        makeTrack({
+          id: `track-${i}`,
+          tags: { artist, album: `${artist}-${i % 3}`, genre: ["Rock"], year: 1972 + (i % 6) }
+        })
+      );
+    }
+    const indexStore = makeMockIndexStore(tracks);
+
+    const dir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(dir);
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 30; i++) playCounts[`track-${i}`] = { count: 2, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    await writeJsonAtomic(path.join(dir, "play-counts.json"), { tracks: playCounts });
+
+    // Mark a handful of peer-pool tracks as heavily skipped.
+    const recent = new Date().toISOString();
+    const skips: Record<string, { count: number; lastSkippedAt: string }> = {
+      "track-30": { count: 5, lastSkippedAt: recent },
+      "track-31": { count: 3, lastSkippedAt: recent },
+      "track-32": { count: 4, lastSkippedAt: recent }
+    };
+    await writeJsonAtomic(path.join(dir, "skips.json"), { tracks: skips });
+
+    await regenerateForYouPlaylists("user-1", indexStore);
+
+    const trace = await loadForYouTrace("user-1");
+    expect(trace).not.toBeNull();
+    for (const playlist of trace!.playlists) {
+      expect(playlist.finalTrackIds).not.toContain("track-30");
+      expect(playlist.finalTrackIds).not.toContain("track-31");
+      expect(playlist.finalTrackIds).not.toContain("track-32");
+    }
+  });
+
   it("dismissed seed is skipped at the seed-selection stage", async () => {
     const { regenerateForYouPlaylists, dismissForYouPlaylist, loadForYouTrace } =
       await import("./forYouPlaylistService");

--- a/backend/src/services/playlists/forYouPlaylistService.test.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.test.ts
@@ -5,8 +5,10 @@ import os from "node:os";
 
 let tmpDir: string;
 
-vi.mock("../../utils/paths", async () => {
+vi.mock("../../utils/paths", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../utils/paths")>();
   return {
+    ...original,
     get dataRoot() { return path.join(tmpDir, "data"); },
     get usersStorageRoot() { return path.join(tmpDir, "data", "storage", "users"); },
     get configRoot() { return path.join(tmpDir, "data", "config"); }
@@ -339,6 +341,41 @@ describe("forYouPlaylistService", () => {
     expect(sample.features.genreOverlap).toBeLessThanOrEqual(1);
     expect(sample.features.yearProximity).toBeGreaterThanOrEqual(0);
     expect(sample.features.yearProximity).toBeLessThanOrEqual(1);
+  });
+
+  it("uses embedding similarity in the trace, with a neutral score when no embeddings exist", async () => {
+    const { regenerateForYouPlaylists, loadForYouTrace } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    const artists = ["Pink Floyd", "Led Zeppelin", "Deep Purple", "Black Sabbath"];
+    const tracks: Track[] = [];
+    for (let i = 0; i < 60; i++) {
+      const artist = artists[i % 4]!;
+      tracks.push(
+        makeTrack({
+          id: `track-${i}`,
+          tags: { artist, album: `${artist}-${i % 3}`, genre: ["Rock"], year: 1972 + (i % 6) }
+        })
+      );
+    }
+    const indexStore = makeMockIndexStore(tracks);
+
+    const dir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(dir);
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 30; i++) playCounts[`track-${i}`] = { count: 2, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    await writeJsonAtomic(path.join(dir, "play-counts.json"), { tracks: playCounts });
+
+    await regenerateForYouPlaylists("user-1", indexStore);
+    const trace = await loadForYouTrace("user-1");
+    expect(trace).not.toBeNull();
+    const playlist = trace!.playlists.find((p) => p.finalOrder && p.finalOrder.length > 0);
+    expect(playlist).toBeDefined();
+    for (const entry of playlist!.finalOrder!) {
+      // No embeddings exist on disk, so non-seed candidates must get the
+      // neutral 0.5 score; seeds get 1.0 since they're the seed set.
+      expect([0.5, 1]).toContain(entry.features.embeddingSimilarity);
+    }
   });
 
   it("excludes tracks with 3+ recent skips from the candidate pool", async () => {

--- a/backend/src/services/playlists/forYouPlaylistService.test.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.test.ts
@@ -274,6 +274,48 @@ describe("forYouPlaylistService", () => {
     expect(dominantCount).toBeLessThanOrEqual(4);
   });
 
+  it("does not penalize a peer artist's album just because the name matches the seed's album", async () => {
+    const { regenerateForYouPlaylists, loadForYouTrace } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    // Seed: Pink Floyd's "Greatest Hits". Peer: another band whose album is also
+    // titled "Greatest Hits". Without the artist-qualified album key these
+    // collide and the peer would get the album-overlap penalty (-0.30).
+    const tracks: Track[] = [];
+    for (let i = 0; i < 10; i++) {
+      tracks.push(makeTrack({ id: `seed-${i}`, tags: { artist: "Pink Floyd", album: "Greatest Hits", genre: ["Rock"], year: 1973 } }));
+    }
+    for (let i = 0; i < 8; i++) {
+      tracks.push(makeTrack({ id: `peer-${i}`, tags: { artist: "Other Band", album: "Greatest Hits", genre: ["Rock"], year: 1973 } }));
+    }
+    for (let i = 0; i < 4; i++) {
+      tracks.push(makeTrack({ id: `third-${i}`, tags: { artist: "Third Band", album: `tb-${i}`, genre: ["Rock"], year: 1973 } }));
+    }
+
+    const indexStore = makeMockIndexStore(tracks);
+    const dir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(dir);
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 10; i++) playCounts[`seed-${i}`] = { count: 5, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    // MIN_DISTINCT_ARTISTS = 3, so make sure plays span 3+ distinct artists.
+    playCounts["peer-0"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["third-0"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    await writeJsonAtomic(path.join(dir, "play-counts.json"), { tracks: playCounts });
+
+    await regenerateForYouPlaylists("user-1", indexStore);
+    const trace = await loadForYouTrace("user-1");
+    expect(trace).not.toBeNull();
+    const pinkFloyd = trace!.playlists.find((p) => p.seed === "Pink Floyd");
+    expect(pinkFloyd).toBeDefined();
+
+    const allEntries = [...(pinkFloyd!.finalOrder ?? []), ...(pinkFloyd!.topRejections ?? [])];
+    const peerEntries = allEntries.filter((e) => e.trackId.startsWith("peer-"));
+    expect(peerEntries.length).toBeGreaterThan(0);
+    for (const entry of peerEntries) {
+      expect(entry.features.albumOverlapWithSeed).toBe(0);
+    }
+  });
+
   it("includes genreless tracks via year fallback", async () => {
     const { generateForYouPlaylists } = await import("./forYouPlaylistService");
     const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");

--- a/backend/src/services/playlists/forYouPlaylistService.test.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.test.ts
@@ -135,6 +135,67 @@ describe("forYouPlaylistService", () => {
     expect(dismissals.has("for-you:led-zeppelin")).toBe(false);
   });
 
+  it("writes a trace file with the expected shape on regenerate", async () => {
+    const { regenerateForYouPlaylists, loadForYouTrace } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    const artists = ["Pink Floyd", "Led Zeppelin", "Deep Purple", "Black Sabbath", "Jethro Tull"];
+    const tracks: Track[] = [];
+    for (let i = 0; i < 60; i++) {
+      const artist = artists[i % 5]!;
+      tracks.push(
+        makeTrack({
+          id: `track-${i}`,
+          tags: { artist, genre: ["Rock"], year: 1970 + (i % 10) }
+        })
+      );
+    }
+    const indexStore = makeMockIndexStore(tracks);
+
+    const playCountsDir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(playCountsDir);
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 30; i++) {
+      playCounts[`track-${i}`] = { count: 2, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    }
+    await writeJsonAtomic(path.join(playCountsDir, "play-counts.json"), { tracks: playCounts });
+
+    await regenerateForYouPlaylists("user-1", indexStore);
+
+    const trace = await loadForYouTrace("user-1");
+    expect(trace).not.toBeNull();
+    expect(trace!.userId).toBe("user-1");
+    expect(trace!.totalPlays).toBe(60);
+    expect(trace!.distinctArtists).toBeGreaterThanOrEqual(3);
+    expect(trace!.seedSelection.candidates.length).toBeGreaterThan(0);
+    expect(trace!.seedSelection.candidates[0]!.sources).toContain("top-artist");
+    expect(trace!.seedSelection.chosen.length).toBeGreaterThan(0);
+    expect(trace!.playlists.length).toBeGreaterThan(0);
+    for (const entry of trace!.playlists) {
+      expect(entry.profile.genres).toBeDefined();
+      expect(entry.candidatePoolSize).toBeGreaterThanOrEqual(0);
+      if (entry.playlistId) {
+        expect(entry.finalTrackIds.length).toBeGreaterThan(0);
+      }
+    }
+    expect(trace!.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("trace records skip reason when user is below thresholds", async () => {
+    const { regenerateForYouPlaylists, loadForYouTrace } = await import("./forYouPlaylistService");
+
+    const tracks = Array.from({ length: 5 }, (_, i) =>
+      makeTrack({ id: `t-${i}`, tags: { artist: `A${i}`, genre: ["Rock"], year: 2000 } })
+    );
+    const indexStore = makeMockIndexStore(tracks);
+
+    await regenerateForYouPlaylists("user-1", indexStore);
+    const trace = await loadForYouTrace("user-1");
+    expect(trace).not.toBeNull();
+    expect(trace!.skipReason).toBe("below-min-plays");
+    expect(trace!.playlists).toEqual([]);
+  });
+
   it("saves and loads for-you playlists", async () => {
     const { saveForYouPlaylists, loadForYouPlaylists } = await import("./forYouPlaylistService");
 

--- a/backend/src/services/playlists/forYouPlaylistService.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.ts
@@ -6,6 +6,7 @@ import { dataRoot, usersStorageRoot } from "../../utils/paths";
 import { ensureDir, readJsonFile, updateJsonFile, writeJsonAtomic } from "../../utils/fs";
 import { normalizeGenreLabel } from "../genre/genreSynonymService";
 import { getUserPlayCounts } from "../activity/playCountStore";
+import { getRecentSkipCounts } from "../activity/skipStore";
 import type { IndexStore } from "../indexer/indexStore";
 import type { Track } from "../../types/library";
 import { ForYouTraceBuilder, type ForYouTrace, type ScoredTrackTrace } from "./playlistTrace";
@@ -16,6 +17,7 @@ import {
   noveltyScore,
   scoreFeatures,
   yearProximity,
+  SKIP_HARD_FILTER_THRESHOLD,
   type CandidateFeatures
 } from "./forYouRanker";
 
@@ -35,6 +37,7 @@ const TOP_REJECTIONS_RECORDED = 5;
 const RECENT_PLAYS_WINDOW_DAYS = 30;
 const ALBUM_DEPTH_WINDOW_DAYS = 60;
 const ALBUM_DEPTH_THRESHOLD = 0.7;
+const RECENT_SKIPS_WINDOW_DAYS = 60;
 
 // Candidate-pool fallbacks (broaden the pool beyond strict genre+year match)
 const GENRE_JACCARD_FLOOR = 0.2;
@@ -97,12 +100,14 @@ type SignalMaps = {
   artistLifetimePlays: Map<string, number>;
   artistRecentPlays: Map<string, number>;
   trackRecentPlays: Map<string, number>;
+  trackRecentSkips: Map<string, number>;
   maxArtistLifetimePlays: number;
   albumDepthArtists: Map<string, number>; // artist (lowercase) → score contribution from album-deep
 };
 
 function computeSignals(
   playCounts: Record<string, PlayCountEntry>,
+  recentSkipCounts: Record<string, { count: number }>,
   indexStore: IndexStore
 ): SignalMaps {
   const now = Date.now();
@@ -163,10 +168,16 @@ function computeSignals(
     albumDepthArtists.set(artistKey, (albumDepthArtists.get(artistKey) ?? 0) + contribution);
   }
 
+  const trackRecentSkips = new Map<string, number>();
+  for (const [trackId, entry] of Object.entries(recentSkipCounts)) {
+    trackRecentSkips.set(trackId, entry.count);
+  }
+
   return {
     artistLifetimePlays,
     artistRecentPlays,
     trackRecentPlays,
+    trackRecentSkips,
     maxArtistLifetimePlays,
     albumDepthArtists
   };
@@ -285,7 +296,8 @@ function gatherCandidates(
   seedArtist: string,
   profile: { genres: string[]; minYear: number; maxYear: number },
   seedTracks: Track[],
-  allTracks: Track[]
+  allTracks: Track[],
+  trackRecentSkips: ReadonlyMap<string, number>
 ): Candidate[] {
   const seedArtistLower = seedArtist.toLowerCase();
   const seedGenres = new Set(profile.genres);
@@ -301,6 +313,8 @@ function gatherCandidates(
   for (const track of allTracks) {
     const trackArtist = (track.tags.artist ?? "").toLowerCase();
     if (!trackArtist || trackArtist === seedArtistLower) continue;
+
+    if ((trackRecentSkips.get(track.id) ?? 0) >= SKIP_HARD_FILTER_THRESHOLD) continue;
 
     let source: Candidate["source"] | null = null;
 
@@ -370,7 +384,8 @@ function computeFeatures(
     yearProximity: yearProximity(candidate.track.tags.year, midYear),
     libraryPopularity: logPopularity(lifetimePlays, signals.maxArtistLifetimePlays),
     novelty: noveltyScore(recentPlays),
-    albumOverlapWithSeed: candidate.album && seedAlbumKeys.has(candidate.album) ? 1 : 0
+    albumOverlapWithSeed: candidate.album && seedAlbumKeys.has(candidate.album) ? 1 : 0,
+    recentSkipCount: signals.trackRecentSkips.get(candidate.track.id) ?? 0
   };
 }
 
@@ -616,7 +631,7 @@ function buildForYouPlaylist(
   const seedGenres = new Set(profile.genres);
   const midYear = (profile.minYear + profile.maxYear) / 2;
 
-  const candidates = gatherCandidates(seedArtist, profile, seedTracks, allTracks);
+  const candidates = gatherCandidates(seedArtist, profile, seedTracks, allTracks, signals.trackRecentSkips);
   baseTrace.candidatePoolSize = candidates.length;
   baseTrace.peerTrackCount = candidates.length;
 
@@ -645,6 +660,7 @@ function buildForYouPlaylist(
 
   // Seed tracks: pick by lifetime play count first (favorites), fall back to insertion order.
   const seedRanked: RankedCandidate[] = seedTracks
+    .filter((t) => (signals.trackRecentSkips.get(t.id) ?? 0) < SKIP_HARD_FILTER_THRESHOLD)
     .map((t) => {
       const albumLower = (t.tags.album ?? "").toLowerCase();
       const trackPlays = signals.trackRecentPlays.get(t.id) ?? 0;
@@ -653,7 +669,8 @@ function buildForYouPlaylist(
         yearProximity: 1,
         libraryPopularity: logPopularity(lifetimePlays, signals.maxArtistLifetimePlays),
         novelty: noveltyScore(trackPlays),
-        albumOverlapWithSeed: 1
+        albumOverlapWithSeed: 1,
+        recentSkipCount: signals.trackRecentSkips.get(t.id) ?? 0
       };
       const rawScore = scoreFeatures(features);
       return {
@@ -735,10 +752,11 @@ export async function generateForYouPlaylistsWithTrace(
   const builder = new ForYouTraceBuilder(userId);
 
   const playCounts = await getUserPlayCounts(userId);
+  const recentSkips = await getRecentSkipCounts(userId, RECENT_SKIPS_WINDOW_DAYS);
   const entries = Object.entries(playCounts);
   const totalPlays = entries.reduce((sum, [, e]) => sum + e.count, 0);
 
-  const signals = computeSignals(playCounts, indexStore);
+  const signals = computeSignals(playCounts, recentSkips, indexStore);
   const distinctArtists = signals.artistLifetimePlays.size;
   builder.setStats(totalPlays, distinctArtists);
 

--- a/backend/src/services/playlists/forYouPlaylistService.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.ts
@@ -265,11 +265,23 @@ type Candidate = {
   source: "genre" | "album-artist" | "label" | "year-fallback";
 };
 
+/**
+ * Composite "<artist>::<album>" key used everywhere we deduplicate or cap on
+ * album. Keying on album name alone collides across artists ("Greatest Hits",
+ * self-titled debuts, etc.).
+ */
+function albumKey(artist: string | undefined, album: string | undefined): string {
+  const b = (album ?? "").toLowerCase().trim();
+  if (!b) return "";
+  const a = (artist ?? "").toLowerCase().trim();
+  return `${a}::${b}`;
+}
+
 function buildSeedAlbumKeys(seedTracks: Track[]): Set<string> {
   const set = new Set<string>();
   for (const t of seedTracks) {
-    const album = (t.tags.album ?? "").toLowerCase();
-    if (album) set.add(album);
+    const key = albumKey(t.tags.artist, t.tags.album);
+    if (key) set.add(key);
   }
   return set;
 }
@@ -355,7 +367,7 @@ function gatherCandidates(
       candidates.set(track.id, {
         track,
         artist: trackArtist,
-        album: (track.tags.album ?? "").toLowerCase(),
+        album: albumKey(track.tags.artist, track.tags.album),
         source
       });
     }
@@ -415,14 +427,26 @@ function rankCandidates(
     .sort((a, b) => b.score - a.score);
 }
 
+const EMBEDDING_LOAD_CONCURRENCY = 16;
+
 async function loadEmbeddingVectors(trackIds: string[]): Promise<Map<string, number[]>> {
   const out = new Map<string, number[]>();
-  await Promise.all(
-    trackIds.map(async (id) => {
-      const e = await loadEmbedding(id);
-      if (e) out.set(id, e.vec);
-    })
-  );
+  // Cap concurrent reads. With unbounded Promise.all over 1000+ candidates we
+  // were briefly opening that many file descriptors at once.
+  let cursor = 0;
+  const workers: Promise<void>[] = [];
+  for (let w = 0; w < EMBEDDING_LOAD_CONCURRENCY; w++) {
+    workers.push((async () => {
+      while (true) {
+        const i = cursor++;
+        if (i >= trackIds.length) return;
+        const id = trackIds[i]!;
+        const e = await loadEmbedding(id);
+        if (e) out.set(id, e.vec);
+      }
+    })());
+  }
+  await Promise.all(workers);
   return out;
 }
 
@@ -696,7 +720,6 @@ async function buildForYouPlaylist(
   const seedRanked: RankedCandidate[] = seedTracks
     .filter((t) => (signals.trackRecentSkips.get(t.id) ?? 0) < SKIP_HARD_FILTER_THRESHOLD)
     .map((t) => {
-      const albumLower = (t.tags.album ?? "").toLowerCase();
       const trackPlays = signals.trackRecentPlays.get(t.id) ?? 0;
       const features: CandidateFeatures = {
         genreOverlap: 1,
@@ -711,7 +734,7 @@ async function buildForYouPlaylist(
       return {
         track: t,
         artist: seedKey,
-        album: albumLower,
+        album: albumKey(t.tags.artist, t.tags.album),
         source: "genre" as const,
         features,
         rawScore,

--- a/backend/src/services/playlists/forYouPlaylistService.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.ts
@@ -5,10 +5,19 @@ import { createLogger } from "../../utils/logger";
 import { dataRoot, usersStorageRoot } from "../../utils/paths";
 import { ensureDir, readJsonFile, updateJsonFile, writeJsonAtomic } from "../../utils/fs";
 import { normalizeGenreLabel } from "../genre/genreSynonymService";
-import { getUserTopArtists, getUserPlayCounts } from "../activity/playCountStore";
+import { getUserPlayCounts } from "../activity/playCountStore";
 import type { IndexStore } from "../indexer/indexStore";
 import type { Track } from "../../types/library";
-import { ForYouTraceBuilder, type ForYouTrace } from "./playlistTrace";
+import { ForYouTraceBuilder, type ForYouTrace, type ScoredTrackTrace } from "./playlistTrace";
+import {
+  fnvJitter,
+  genreJaccard,
+  logPopularity,
+  noveltyScore,
+  scoreFeatures,
+  yearProximity,
+  type CandidateFeatures
+} from "./forYouRanker";
 
 const log = createLogger("for-you-playlists");
 
@@ -17,9 +26,19 @@ const REGENERATION_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000;
 
 const MIN_TOTAL_PLAYS = 20;
 const MIN_DISTINCT_ARTISTS = 3;
-const MAX_TOP_ARTISTS = 3;
+const MAX_SEEDS = 6;
 const TRACKS_PER_PLAYLIST = 25;
-const SEED_ARTIST_RATIO = 0.4;
+const MAX_PER_PEER_ARTIST = 4;
+const MAX_PER_ALBUM = 2;
+const TOP_REJECTIONS_RECORDED = 5;
+
+const RECENT_PLAYS_WINDOW_DAYS = 30;
+const ALBUM_DEPTH_WINDOW_DAYS = 60;
+const ALBUM_DEPTH_THRESHOLD = 0.7;
+
+// Candidate-pool fallbacks (broaden the pool beyond strict genre+year match)
+const GENRE_JACCARD_FLOOR = 0.2;
+const YEAR_FALLBACK_WINDOW = 7;
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -70,48 +89,412 @@ function slugify(text: string): string {
     .replace(/^-|-$/g, "");
 }
 
-// ── Diversity selection (reused from auto playlist service) ───────
+// ── Aggregate signals ─────────────────────────────────────────────
 
-type ScoredTrack = {
+type PlayCountEntry = { count: number; lastPlayedAt: string };
+
+type SignalMaps = {
+  artistLifetimePlays: Map<string, number>;
+  artistRecentPlays: Map<string, number>;
+  trackRecentPlays: Map<string, number>;
+  maxArtistLifetimePlays: number;
+  albumDepthArtists: Map<string, number>; // artist (lowercase) → score contribution from album-deep
+};
+
+function computeSignals(
+  playCounts: Record<string, PlayCountEntry>,
+  indexStore: IndexStore
+): SignalMaps {
+  const now = Date.now();
+  const recentCutoff = now - RECENT_PLAYS_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  const albumDepthCutoff = now - ALBUM_DEPTH_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+  const artistLifetimePlays = new Map<string, number>();
+  const artistRecentPlays = new Map<string, number>();
+  const trackRecentPlays = new Map<string, number>();
+  const albumPlaysInWindow = new Map<string, { artist: string; album: string; count: number }>();
+
+  for (const [trackId, entry] of Object.entries(playCounts)) {
+    const track = indexStore.getTrackById(trackId);
+    if (!track) continue;
+
+    const artistKey = (track.tags.artist ?? "").toLowerCase();
+    artistLifetimePlays.set(artistKey, (artistLifetimePlays.get(artistKey) ?? 0) + entry.count);
+
+    const playedAt = new Date(entry.lastPlayedAt).getTime();
+    if (!isNaN(playedAt) && playedAt >= recentCutoff) {
+      artistRecentPlays.set(artistKey, (artistRecentPlays.get(artistKey) ?? 0) + entry.count);
+      trackRecentPlays.set(trackId, entry.count);
+    }
+
+    const album = (track.tags.album ?? "").toLowerCase();
+    if (album && !isNaN(playedAt) && playedAt >= albumDepthCutoff) {
+      const albumKey = `${artistKey}::${album}`;
+      const existing = albumPlaysInWindow.get(albumKey);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        albumPlaysInWindow.set(albumKey, {
+          artist: track.tags.artist ?? "",
+          album: track.tags.album ?? "",
+          count: 1
+        });
+      }
+    }
+  }
+
+  let maxArtistLifetimePlays = 0;
+  for (const v of artistLifetimePlays.values()) {
+    if (v > maxArtistLifetimePlays) maxArtistLifetimePlays = v;
+  }
+
+  // Album-deep: artists where ≥ ALBUM_DEPTH_THRESHOLD of an album's tracks were
+  // played in the depth window. Skip tiny albums (≤3 tracks) where the threshold
+  // is trivially met.
+  const albumDepthArtists = new Map<string, number>();
+  for (const [, info] of albumPlaysInWindow) {
+    const albumTracks = indexStore.getTracksByAlbum(info.album);
+    if (albumTracks.length < 4) continue;
+    const ratio = info.count / albumTracks.length;
+    if (ratio < ALBUM_DEPTH_THRESHOLD) continue;
+    const artistKey = info.artist.toLowerCase();
+    if (!artistKey) continue;
+    const contribution = 0.4 * albumTracks.length;
+    albumDepthArtists.set(artistKey, (albumDepthArtists.get(artistKey) ?? 0) + contribution);
+  }
+
+  return {
+    artistLifetimePlays,
+    artistRecentPlays,
+    trackRecentPlays,
+    maxArtistLifetimePlays,
+    albumDepthArtists
+  };
+}
+
+// ── Seed selection ────────────────────────────────────────────────
+
+type SeedCandidate = {
+  artist: string;
+  score: number;
+  sources: string[];
+};
+
+/**
+ * Pick up to MAX_SEEDS distinct artists, drawn from three sources: lifetime
+ * top artists, rediscovered artists (high recency, not in lifetime top 5),
+ * and artists qualifying via album-deep listening.
+ */
+function selectSeeds(signals: SignalMaps, indexStore: IndexStore): SeedCandidate[] {
+  const byArtist = new Map<string, SeedCandidate>();
+
+  // Resolve canonical artist label (case-preserving) from any track for that key.
+  function canonicalArtist(artistKey: string): string {
+    if (!artistKey) return "";
+    const tracks = indexStore.getTracksByArtist(artistKey);
+    return tracks[0]?.tags.artist ?? artistKey;
+  }
+
+  // Source 1: top artists by lifetime plays.
+  const lifetimeRanked = [...signals.artistLifetimePlays.entries()]
+    .filter(([k]) => k !== "")
+    .sort((a, b) => b[1] - a[1]);
+
+  for (const [artistKey, plays] of lifetimeRanked.slice(0, 8)) {
+    const score = Math.log(1 + plays);
+    const entry = byArtist.get(artistKey);
+    if (entry) {
+      entry.score += score;
+      entry.sources.push("top-artist");
+    } else {
+      byArtist.set(artistKey, { artist: canonicalArtist(artistKey), score, sources: ["top-artist"] });
+    }
+  }
+
+  // Source 2: rediscovered — recently played but not in lifetime top 5.
+  const lifetimeTop5 = new Set(lifetimeRanked.slice(0, 5).map(([k]) => k));
+  for (const [artistKey, recent] of signals.artistRecentPlays) {
+    if (recent < 3) continue;
+    if (lifetimeTop5.has(artistKey)) continue;
+    if (!artistKey) continue;
+    const score = 0.5 * recent;
+    const entry = byArtist.get(artistKey);
+    if (entry) {
+      entry.score += score;
+      entry.sources.push("rediscovered");
+    } else {
+      byArtist.set(artistKey, { artist: canonicalArtist(artistKey), score, sources: ["rediscovered"] });
+    }
+  }
+
+  // Source 3: album-deep — heavy listening of a specific album in the window.
+  for (const [artistKey, contribution] of signals.albumDepthArtists) {
+    if (!artistKey) continue;
+    const entry = byArtist.get(artistKey);
+    if (entry) {
+      entry.score += contribution;
+      entry.sources.push("album-deep");
+    } else {
+      byArtist.set(artistKey, { artist: canonicalArtist(artistKey), score: contribution, sources: ["album-deep"] });
+    }
+  }
+
+  return [...byArtist.values()].sort((a, b) => b.score - a.score);
+}
+
+// ── Candidate gathering ───────────────────────────────────────────
+
+type Candidate = {
   track: Track;
   artist: string;
   album: string;
+  source: "genre" | "album-artist" | "label" | "year-fallback";
 };
 
-function selectDiverseTracks(candidates: ScoredTrack[], maxTracks: number): Track[] {
-  const pool = [...candidates].sort(() => Math.random() - 0.5);
-  const selected: ScoredTrack[] = [];
+function buildSeedAlbumKeys(seedTracks: Track[]): Set<string> {
+  const set = new Set<string>();
+  for (const t of seedTracks) {
+    const album = (t.tags.album ?? "").toLowerCase();
+    if (album) set.add(album);
+  }
+  return set;
+}
 
-  while (selected.length < maxTracks && pool.length > 0) {
-    let bestIndex = 0;
-    let bestScore = Number.NEGATIVE_INFINITY;
+function buildSeedLabels(seedTracks: Track[]): Set<string> {
+  const set = new Set<string>();
+  for (const t of seedTracks) {
+    if (!t.tags.label) continue;
+    for (const l of t.tags.label) {
+      const lower = l.toLowerCase().trim();
+      if (lower) set.add(lower);
+    }
+  }
+  return set;
+}
 
-    for (let i = 0; i < pool.length; i++) {
-      const candidate = pool[i]!;
-      let score = 100;
+function buildSeedAlbumArtists(seedTracks: Track[]): Set<string> {
+  const set = new Set<string>();
+  for (const t of seedTracks) {
+    const aa = (t.tags.albumArtist ?? "").toLowerCase();
+    if (aa) set.add(aa);
+  }
+  return set;
+}
 
-      const prev = selected[selected.length - 1];
-      if (prev) {
-        if (prev.artist === candidate.artist) score -= 1000;
-        if (prev.album === candidate.album) score -= 500;
-      }
+function gatherCandidates(
+  seedArtist: string,
+  profile: { genres: string[]; minYear: number; maxYear: number },
+  seedTracks: Track[],
+  allTracks: Track[]
+): Candidate[] {
+  const seedArtistLower = seedArtist.toLowerCase();
+  const seedGenres = new Set(profile.genres);
+  const seedLabels = buildSeedLabels(seedTracks);
+  const seedAlbumArtists = buildSeedAlbumArtists(seedTracks);
+  seedAlbumArtists.add(seedArtistLower);
+  const midYear = (profile.minYear + profile.maxYear) / 2;
+  const yearLow = midYear - YEAR_FALLBACK_WINDOW;
+  const yearHigh = midYear + YEAR_FALLBACK_WINDOW;
 
-      const recentArtists = selected.slice(-3).map((s) => s.artist);
-      if (recentArtists.includes(candidate.artist)) score -= 250;
+  const candidates = new Map<string, Candidate>();
 
-      score += Math.random() * 40;
+  for (const track of allTracks) {
+    const trackArtist = (track.tags.artist ?? "").toLowerCase();
+    if (!trackArtist || trackArtist === seedArtistLower) continue;
 
-      if (score > bestScore) {
-        bestScore = score;
-        bestIndex = i;
+    let source: Candidate["source"] | null = null;
+
+    const trackGenres = track.tags.genre ?? [];
+    if (trackGenres.length > 0 && genreJaccard(trackGenres, seedGenres) >= GENRE_JACCARD_FLOOR) {
+      source = "genre";
+    }
+
+    if (!source) {
+      const trackAlbumArtist = (track.tags.albumArtist ?? "").toLowerCase();
+      if (trackAlbumArtist && seedAlbumArtists.has(trackAlbumArtist)) {
+        source = "album-artist";
       }
     }
 
-    selected.push(pool[bestIndex]!);
-    pool.splice(bestIndex, 1);
+    if (!source && seedLabels.size > 0 && track.tags.label) {
+      for (const l of track.tags.label) {
+        if (seedLabels.has(l.toLowerCase().trim())) {
+          source = "label";
+          break;
+        }
+      }
+    }
+
+    if (!source) {
+      const year = track.tags.year;
+      if (year && year >= yearLow && year <= yearHigh) {
+        source = "year-fallback";
+      }
+    }
+
+    if (!source) continue;
+
+    if (!candidates.has(track.id)) {
+      candidates.set(track.id, {
+        track,
+        artist: trackArtist,
+        album: (track.tags.album ?? "").toLowerCase(),
+        source
+      });
+    }
   }
 
-  return selected.map((s) => s.track);
+  return [...candidates.values()];
+}
+
+// ── Scoring + selection ───────────────────────────────────────────
+
+type RankedCandidate = Candidate & {
+  features: CandidateFeatures;
+  rawScore: number;
+  score: number;
+};
+
+function computeFeatures(
+  candidate: Candidate,
+  seedGenres: ReadonlySet<string>,
+  midYear: number,
+  seedAlbumKeys: ReadonlySet<string>,
+  signals: SignalMaps
+): CandidateFeatures {
+  const lifetimePlays = signals.artistLifetimePlays.get(candidate.artist) ?? 0;
+  const recentPlays = signals.trackRecentPlays.get(candidate.track.id) ?? 0;
+
+  return {
+    genreOverlap: genreJaccard(candidate.track.tags.genre ?? [], seedGenres),
+    yearProximity: yearProximity(candidate.track.tags.year, midYear),
+    libraryPopularity: logPopularity(lifetimePlays, signals.maxArtistLifetimePlays),
+    novelty: noveltyScore(recentPlays),
+    albumOverlapWithSeed: candidate.album && seedAlbumKeys.has(candidate.album) ? 1 : 0
+  };
+}
+
+function rankCandidates(
+  candidates: Candidate[],
+  userId: string,
+  seedKey: string,
+  seedGenres: ReadonlySet<string>,
+  midYear: number,
+  seedAlbumKeys: ReadonlySet<string>,
+  signals: SignalMaps
+): RankedCandidate[] {
+  return candidates
+    .map((c) => {
+      const features = computeFeatures(c, seedGenres, midYear, seedAlbumKeys, signals);
+      const rawScore = scoreFeatures(features);
+      const jitter = fnvJitter(`${userId}|${seedKey}|${c.track.id}`);
+      return { ...c, features, rawScore, score: rawScore + jitter };
+    })
+    .sort((a, b) => b.score - a.score);
+}
+
+/**
+ * Greedy pick from a score-sorted list, enforcing per-artist and per-album
+ * caps across the whole playlist (not just the local window). Returns the
+ * picked items in score order; sequencing is handled separately.
+ */
+function pickWithCaps(
+  ranked: RankedCandidate[],
+  maxTracks: number,
+  perArtist: number,
+  perAlbum: number
+): { picked: RankedCandidate[]; passedOver: RankedCandidate[] } {
+  const picked: RankedCandidate[] = [];
+  const passedOver: RankedCandidate[] = [];
+  const artistCounts = new Map<string, number>();
+  const albumCounts = new Map<string, number>();
+
+  for (const c of ranked) {
+    if (picked.length >= maxTracks) {
+      passedOver.push(c);
+      continue;
+    }
+    const artistCount = artistCounts.get(c.artist) ?? 0;
+    const albumCount = c.album ? albumCounts.get(c.album) ?? 0 : 0;
+    if (artistCount >= perArtist) {
+      passedOver.push(c);
+      continue;
+    }
+    if (c.album && albumCount >= perAlbum) {
+      passedOver.push(c);
+      continue;
+    }
+    picked.push(c);
+    artistCounts.set(c.artist, artistCount + 1);
+    if (c.album) albumCounts.set(c.album, albumCount + 1);
+  }
+
+  return { picked, passedOver };
+}
+
+/**
+ * Sequence ordering pass. Preserves the chosen set; only swaps neighbors that
+ * share an album to spread albums apart. No randomness — deterministic given
+ * input order.
+ */
+function sequenceTracks(picked: RankedCandidate[]): RankedCandidate[] {
+  const result = [...picked];
+  for (let i = 1; i < result.length; i++) {
+    if (result[i]!.album && result[i]!.album === result[i - 1]!.album) {
+      // Find the next track with a different album to swap with.
+      for (let j = i + 1; j < result.length; j++) {
+        if (result[j]!.album !== result[i - 1]!.album) {
+          [result[i], result[j]] = [result[j]!, result[i]!];
+          break;
+        }
+      }
+    }
+  }
+  return result;
+}
+
+// ── Familiarity-driven seed/peer ratio ───────────────────────────
+
+function targetSeedShare(familiarity: number): number {
+  // High familiarity (well-known artist) → fewer seed tracks, more peers.
+  // Low familiarity → more seed tracks (user wants to hear the artist they liked).
+  const clamped = Math.max(0, Math.min(1, familiarity));
+  return 0.5 - 0.25 * clamped;
+}
+
+// ── Naming heuristic ─────────────────────────────────────────────
+
+function namePlaylist(
+  seedArtist: string,
+  distinctPeerArtists: number,
+  peerShare: number,
+  dominantDecade: number | null
+): string {
+  if (peerShare < 0.3) return `More ${seedArtist}`;
+  if (distinctPeerArtists <= 3) return `${seedArtist} & friends`;
+  if (dominantDecade !== null) {
+    const decadeLabel = `${dominantDecade % 100 === 0 ? dominantDecade : dominantDecade % 100}s`;
+    return `${decadeLabel} with ${seedArtist}`;
+  }
+  if (peerShare > 0.7) return `Around ${seedArtist}`;
+  return `Because you listen to ${seedArtist}`;
+}
+
+function dominantDecade(tracks: Track[]): number | null {
+  const counts = new Map<number, number>();
+  for (const t of tracks) {
+    if (!t.tags.year) continue;
+    const decade = Math.floor(t.tags.year / 10) * 10;
+    counts.set(decade, (counts.get(decade) ?? 0) + 1);
+  }
+  if (counts.size === 0) return null;
+  let best: { decade: number; count: number } | null = null;
+  let total = 0;
+  for (const [decade, count] of counts) {
+    total += count;
+    if (!best || count > best.count) best = { decade, count };
+  }
+  return best && best.count / total >= 0.6 ? best.decade : null;
 }
 
 // ── Dismissal store ───────────────────────────────────────────────
@@ -189,59 +572,28 @@ function getArtistProfile(
   };
 }
 
-function findPeerTracks(
-  seedArtist: string,
-  profile: { genres: string[]; minYear: number; maxYear: number },
-  allTracks: Track[]
-): ScoredTrack[] {
-  const yearLow = profile.minYear - 10;
-  const yearHigh = profile.maxYear + 10;
-  const genreSet = new Set(profile.genres);
-  const seedArtistLower = seedArtist.toLowerCase();
-  const peers: ScoredTrack[] = [];
-
-  for (const track of allTracks) {
-    const trackArtist = (track.tags.artist ?? "").toLowerCase();
-    if (trackArtist === seedArtistLower) continue;
-
-    const year = track.tags.year;
-    if (year && (year < yearLow || year > yearHigh)) continue;
-
-    const trackGenres = track.tags.genre;
-    if (!trackGenres || trackGenres.length === 0) continue;
-
-    const hasMatchingGenre = trackGenres.some(
-      (g) => genreSet.has(normalizeGenreLabel(g).toLowerCase())
-    );
-    if (!hasMatchingGenre) continue;
-
-    peers.push({
-      track,
-      artist: trackArtist,
-      album: (track.tags.album ?? "").toLowerCase()
-    });
-  }
-
-  return peers;
-}
-
-type BuildResult =
-  | { playlist: ForYouPlaylist; trace: BuildTrace }
-  | { playlist: null; trace: BuildTrace };
-
 type BuildTrace = {
   profile: { genres: string[]; minYear: number; maxYear: number };
   candidatePoolSize: number;
   seedTrackCount: number;
   peerTrackCount: number;
   finalTrackIds: string[];
+  finalOrder: ScoredTrackTrace[];
+  topRejections: ScoredTrackTrace[];
+  playlistName?: string;
   rejection?: string;
 };
+
+type BuildResult =
+  | { playlist: ForYouPlaylist; trace: BuildTrace }
+  | { playlist: null; trace: BuildTrace };
 
 function buildForYouPlaylist(
   seedArtist: string,
   indexStore: IndexStore,
-  allTracks: Track[]
+  allTracks: Track[],
+  signals: SignalMaps,
+  userId: string
 ): BuildResult {
   const profile = getArtistProfile(seedArtist, indexStore);
   const baseTrace: BuildTrace = {
@@ -249,7 +601,9 @@ function buildForYouPlaylist(
     candidatePoolSize: 0,
     seedTrackCount: 0,
     peerTrackCount: 0,
-    finalTrackIds: []
+    finalTrackIds: [],
+    finalOrder: [],
+    topRejections: []
   };
 
   if (profile.genres.length === 0) {
@@ -257,55 +611,104 @@ function buildForYouPlaylist(
   }
 
   const seedTracks = indexStore.getTracksByArtist(seedArtist);
-  const seedScored: ScoredTrack[] = seedTracks.map((t) => ({
-    track: t,
-    artist: (t.tags.artist ?? "").toLowerCase(),
-    album: (t.tags.album ?? "").toLowerCase()
-  }));
+  baseTrace.seedTrackCount = seedTracks.length;
+  const seedAlbumKeys = buildSeedAlbumKeys(seedTracks);
+  const seedGenres = new Set(profile.genres);
+  const midYear = (profile.minYear + profile.maxYear) / 2;
 
-  const peerTracks = findPeerTracks(seedArtist, profile, allTracks);
-  baseTrace.candidatePoolSize = peerTracks.length;
-  baseTrace.seedTrackCount = seedScored.length;
-  baseTrace.peerTrackCount = peerTracks.length;
+  const candidates = gatherCandidates(seedArtist, profile, seedTracks, allTracks);
+  baseTrace.candidatePoolSize = candidates.length;
+  baseTrace.peerTrackCount = candidates.length;
 
-  if (peerTracks.length < 3) {
+  if (candidates.length < 3) {
     return { playlist: null, trace: { ...baseTrace, rejection: "too-few-peers" } };
   }
 
-  const seedCount = Math.round(TRACKS_PER_PLAYLIST * SEED_ARTIST_RATIO);
-  const peerCount = TRACKS_PER_PLAYLIST - seedCount;
+  const seedKey = seedArtist.toLowerCase();
+  const ranked = rankCandidates(
+    candidates,
+    userId,
+    seedKey,
+    seedGenres,
+    midYear,
+    seedAlbumKeys,
+    signals
+  );
 
-  const selectedSeed = selectDiverseTracks(seedScored, seedCount);
-  const selectedPeers = selectDiverseTracks(peerTracks, peerCount);
+  const lifetimePlays = signals.artistLifetimePlays.get(seedKey) ?? 0;
+  const familiarity = signals.maxArtistLifetimePlays > 0
+    ? lifetimePlays / signals.maxArtistLifetimePlays
+    : 0;
+  const seedShare = targetSeedShare(familiarity);
+  const seedQuota = Math.min(seedTracks.length, Math.round(TRACKS_PER_PLAYLIST * seedShare));
+  const peerQuota = Math.max(0, TRACKS_PER_PLAYLIST - seedQuota);
 
-  const combined: ScoredTrack[] = [
-    ...selectedSeed.map((t) => ({
-      track: t,
-      artist: (t.tags.artist ?? "").toLowerCase(),
-      album: (t.tags.album ?? "").toLowerCase()
-    })),
-    ...selectedPeers.map((t) => ({
-      track: t,
-      artist: (t.tags.artist ?? "").toLowerCase(),
-      album: (t.tags.album ?? "").toLowerCase()
-    }))
-  ];
+  // Seed tracks: pick by lifetime play count first (favorites), fall back to insertion order.
+  const seedRanked: RankedCandidate[] = seedTracks
+    .map((t) => {
+      const albumLower = (t.tags.album ?? "").toLowerCase();
+      const trackPlays = signals.trackRecentPlays.get(t.id) ?? 0;
+      const features: CandidateFeatures = {
+        genreOverlap: 1,
+        yearProximity: 1,
+        libraryPopularity: logPopularity(lifetimePlays, signals.maxArtistLifetimePlays),
+        novelty: noveltyScore(trackPlays),
+        albumOverlapWithSeed: 1
+      };
+      const rawScore = scoreFeatures(features);
+      return {
+        track: t,
+        artist: seedKey,
+        album: albumLower,
+        source: "genre" as const,
+        features,
+        rawScore,
+        score: rawScore + fnvJitter(`${userId}|${seedKey}|seed|${t.id}`)
+      };
+    })
+    .sort((a, b) => b.score - a.score);
 
-  const finalTracks = selectDiverseTracks(combined, TRACKS_PER_PLAYLIST);
-  baseTrace.finalTrackIds = finalTracks.map((t) => t.id);
+  const seedPick = pickWithCaps(seedRanked, seedQuota, seedQuota, MAX_PER_ALBUM);
+  const peerPick = pickWithCaps(ranked, peerQuota, MAX_PER_PEER_ARTIST, MAX_PER_ALBUM);
 
-  if (finalTracks.length < 5) {
+  const combined = [...seedPick.picked, ...peerPick.picked];
+  if (combined.length < 5) {
+    baseTrace.finalTrackIds = combined.map((c) => c.track.id);
     return { playlist: null, trace: { ...baseTrace, rejection: "too-few-final-tracks" } };
   }
+
+  const sequenced = sequenceTracks(combined);
+  baseTrace.finalTrackIds = sequenced.map((c) => c.track.id);
+  baseTrace.finalOrder = sequenced.map((c) => ({
+    trackId: c.track.id,
+    artist: c.track.tags.artist ?? "",
+    score: c.score,
+    features: c.features,
+    source: c.source
+  }));
+  baseTrace.topRejections = peerPick.passedOver.slice(0, TOP_REJECTIONS_RECORDED).map((c) => ({
+    trackId: c.track.id,
+    artist: c.track.tags.artist ?? "",
+    score: c.score,
+    features: c.features,
+    source: c.source,
+    rejection: "cap-or-overflow"
+  }));
+
+  const distinctPeerArtists = new Set(peerPick.picked.map((c) => c.artist)).size;
+  const peerShare = combined.length > 0 ? peerPick.picked.length / combined.length : 0;
+  const decade = dominantDecade(sequenced.map((c) => c.track));
+  const name = namePlaylist(seedArtist, distinctPeerArtists, peerShare, decade);
+  baseTrace.playlistName = name;
 
   const id = `for-you:${slugify(seedArtist)}`;
   return {
     playlist: {
       id,
-      name: `Because you listen to ${seedArtist}`,
+      name,
       seedArtist,
-      trackIds: finalTracks.map((t) => t.id),
-      trackCount: finalTracks.length,
+      trackIds: sequenced.map((c) => c.track.id),
+      trackCount: sequenced.length,
       generatedAt: new Date().toISOString()
     },
     trace: baseTrace
@@ -335,17 +738,9 @@ export async function generateForYouPlaylistsWithTrace(
   const entries = Object.entries(playCounts);
   const totalPlays = entries.reduce((sum, [, e]) => sum + e.count, 0);
 
-  const topArtists = await getUserTopArtists(userId, MAX_TOP_ARTISTS + 5, indexStore);
-  const distinctArtists = topArtists.length;
+  const signals = computeSignals(playCounts, indexStore);
+  const distinctArtists = signals.artistLifetimePlays.size;
   builder.setStats(totalPlays, distinctArtists);
-
-  for (const entry of topArtists) {
-    builder.recordSeedCandidate({
-      artist: entry.artist,
-      score: entry.playCount,
-      sources: ["top-artist"]
-    });
-  }
 
   if (totalPlays < MIN_TOTAL_PLAYS) {
     log.debug(`User ${userId} has only ${totalPlays} plays, skipping for-you generation`);
@@ -359,35 +754,50 @@ export async function generateForYouPlaylistsWithTrace(
     return { playlists: [], trace: builder.build() };
   }
 
+  const seedCandidates = selectSeeds(signals, indexStore);
+  for (const candidate of seedCandidates) {
+    builder.recordSeedCandidate({
+      artist: candidate.artist,
+      score: candidate.score,
+      sources: candidate.sources
+    });
+  }
+
   const dismissals = await getUserDismissals(userId);
   const allTracks = indexStore.getSnapshot().tracks;
   const playlists: ForYouPlaylist[] = [];
+  let attemptedSeeds = 0;
 
-  for (const entry of topArtists.slice(0, MAX_TOP_ARTISTS)) {
-    const candidateId = `for-you:${slugify(entry.artist)}`;
-    if (dismissals.has(candidateId)) {
-      builder.recordSeedSkipped(entry.artist, "dismissed");
+  for (const candidate of seedCandidates) {
+    if (attemptedSeeds >= MAX_SEEDS) break;
+    const candidatePlaylistId = `for-you:${slugify(candidate.artist)}`;
+    if (dismissals.has(candidatePlaylistId)) {
+      builder.recordSeedSkipped(candidate.artist, "dismissed");
       continue;
     }
+    attemptedSeeds++;
 
-    const result = buildForYouPlaylist(entry.artist, indexStore, allTracks);
+    const result = buildForYouPlaylist(candidate.artist, indexStore, allTracks, signals, userId);
 
     if (result.playlist) {
       playlists.push(result.playlist);
-      builder.recordSeedChosen(entry.artist);
+      builder.recordSeedChosen(candidate.artist);
       builder.recordPlaylist({
-        seed: entry.artist,
+        seed: candidate.artist,
         playlistId: result.playlist.id,
+        playlistName: result.trace.playlistName,
         profile: result.trace.profile,
         candidatePoolSize: result.trace.candidatePoolSize,
         seedTrackCount: result.trace.seedTrackCount,
         peerTrackCount: result.trace.peerTrackCount,
-        finalTrackIds: result.trace.finalTrackIds
+        finalTrackIds: result.trace.finalTrackIds,
+        finalOrder: result.trace.finalOrder,
+        topRejections: result.trace.topRejections
       });
     } else {
-      builder.recordSeedSkipped(entry.artist, result.trace.rejection ?? "unknown");
+      builder.recordSeedSkipped(candidate.artist, result.trace.rejection ?? "unknown");
       builder.recordPlaylist({
-        seed: entry.artist,
+        seed: candidate.artist,
         playlistId: null,
         profile: result.trace.profile,
         candidatePoolSize: result.trace.candidatePoolSize,

--- a/backend/src/services/playlists/forYouPlaylistService.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.ts
@@ -8,6 +8,7 @@ import { normalizeGenreLabel } from "../genre/genreSynonymService";
 import { getUserTopArtists, getUserPlayCounts } from "../activity/playCountStore";
 import type { IndexStore } from "../indexer/indexStore";
 import type { Track } from "../../types/library";
+import { ForYouTraceBuilder, type ForYouTrace } from "./playlistTrace";
 
 const log = createLogger("for-you-playlists");
 
@@ -52,6 +53,10 @@ function userForYouDir(userId: string): string {
 
 function userForYouMetaPath(userId: string): string {
   return path.join(userForYouDir(userId), "_meta.json");
+}
+
+function userForYouTracePath(userId: string): string {
+  return path.join(userForYouDir(userId), "_trace.json");
 }
 
 function dismissedPath(userId: string): string {
@@ -220,13 +225,36 @@ function findPeerTracks(
   return peers;
 }
 
+type BuildResult =
+  | { playlist: ForYouPlaylist; trace: BuildTrace }
+  | { playlist: null; trace: BuildTrace };
+
+type BuildTrace = {
+  profile: { genres: string[]; minYear: number; maxYear: number };
+  candidatePoolSize: number;
+  seedTrackCount: number;
+  peerTrackCount: number;
+  finalTrackIds: string[];
+  rejection?: string;
+};
+
 function buildForYouPlaylist(
   seedArtist: string,
   indexStore: IndexStore,
   allTracks: Track[]
-): ForYouPlaylist | null {
+): BuildResult {
   const profile = getArtistProfile(seedArtist, indexStore);
-  if (profile.genres.length === 0) return null;
+  const baseTrace: BuildTrace = {
+    profile,
+    candidatePoolSize: 0,
+    seedTrackCount: 0,
+    peerTrackCount: 0,
+    finalTrackIds: []
+  };
+
+  if (profile.genres.length === 0) {
+    return { playlist: null, trace: { ...baseTrace, rejection: "no-genre-profile" } };
+  }
 
   const seedTracks = indexStore.getTracksByArtist(seedArtist);
   const seedScored: ScoredTrack[] = seedTracks.map((t) => ({
@@ -236,7 +264,13 @@ function buildForYouPlaylist(
   }));
 
   const peerTracks = findPeerTracks(seedArtist, profile, allTracks);
-  if (peerTracks.length < 3) return null;
+  baseTrace.candidatePoolSize = peerTracks.length;
+  baseTrace.seedTrackCount = seedScored.length;
+  baseTrace.peerTrackCount = peerTracks.length;
+
+  if (peerTracks.length < 3) {
+    return { playlist: null, trace: { ...baseTrace, rejection: "too-few-peers" } };
+  }
 
   const seedCount = Math.round(TRACKS_PER_PLAYLIST * SEED_ARTIST_RATIO);
   const peerCount = TRACKS_PER_PLAYLIST - seedCount;
@@ -258,38 +292,71 @@ function buildForYouPlaylist(
   ];
 
   const finalTracks = selectDiverseTracks(combined, TRACKS_PER_PLAYLIST);
-  if (finalTracks.length < 5) return null;
+  baseTrace.finalTrackIds = finalTracks.map((t) => t.id);
+
+  if (finalTracks.length < 5) {
+    return { playlist: null, trace: { ...baseTrace, rejection: "too-few-final-tracks" } };
+  }
 
   const id = `for-you:${slugify(seedArtist)}`;
   return {
-    id,
-    name: `Because you listen to ${seedArtist}`,
-    seedArtist,
-    trackIds: finalTracks.map((t) => t.id),
-    trackCount: finalTracks.length,
-    generatedAt: new Date().toISOString()
+    playlist: {
+      id,
+      name: `Because you listen to ${seedArtist}`,
+      seedArtist,
+      trackIds: finalTracks.map((t) => t.id),
+      trackCount: finalTracks.length,
+      generatedAt: new Date().toISOString()
+    },
+    trace: baseTrace
   };
 }
+
+export type GenerationResult = {
+  playlists: ForYouPlaylist[];
+  trace: ForYouTrace;
+};
 
 export async function generateForYouPlaylists(
   userId: string,
   indexStore: IndexStore
 ): Promise<ForYouPlaylist[]> {
+  const result = await generateForYouPlaylistsWithTrace(userId, indexStore);
+  return result.playlists;
+}
+
+export async function generateForYouPlaylistsWithTrace(
+  userId: string,
+  indexStore: IndexStore
+): Promise<GenerationResult> {
+  const builder = new ForYouTraceBuilder(userId);
+
   const playCounts = await getUserPlayCounts(userId);
   const entries = Object.entries(playCounts);
   const totalPlays = entries.reduce((sum, [, e]) => sum + e.count, 0);
 
-  if (totalPlays < MIN_TOTAL_PLAYS) {
-    log.debug(`User ${userId} has only ${totalPlays} plays, skipping for-you generation`);
-    return [];
-  }
-
   const topArtists = await getUserTopArtists(userId, MAX_TOP_ARTISTS + 5, indexStore);
   const distinctArtists = topArtists.length;
+  builder.setStats(totalPlays, distinctArtists);
+
+  for (const entry of topArtists) {
+    builder.recordSeedCandidate({
+      artist: entry.artist,
+      score: entry.playCount,
+      sources: ["top-artist"]
+    });
+  }
+
+  if (totalPlays < MIN_TOTAL_PLAYS) {
+    log.debug(`User ${userId} has only ${totalPlays} plays, skipping for-you generation`);
+    builder.setSkipReason("below-min-plays");
+    return { playlists: [], trace: builder.build() };
+  }
 
   if (distinctArtists < MIN_DISTINCT_ARTISTS) {
     log.debug(`User ${userId} has only ${distinctArtists} distinct artists, skipping`);
-    return [];
+    builder.setSkipReason("below-min-artists");
+    return { playlists: [], trace: builder.build() };
   }
 
   const dismissals = await getUserDismissals(userId);
@@ -298,15 +365,41 @@ export async function generateForYouPlaylists(
 
   for (const entry of topArtists.slice(0, MAX_TOP_ARTISTS)) {
     const candidateId = `for-you:${slugify(entry.artist)}`;
-    if (dismissals.has(candidateId)) continue;
+    if (dismissals.has(candidateId)) {
+      builder.recordSeedSkipped(entry.artist, "dismissed");
+      continue;
+    }
 
-    const playlist = buildForYouPlaylist(entry.artist, indexStore, allTracks);
-    if (playlist) {
-      playlists.push(playlist);
+    const result = buildForYouPlaylist(entry.artist, indexStore, allTracks);
+
+    if (result.playlist) {
+      playlists.push(result.playlist);
+      builder.recordSeedChosen(entry.artist);
+      builder.recordPlaylist({
+        seed: entry.artist,
+        playlistId: result.playlist.id,
+        profile: result.trace.profile,
+        candidatePoolSize: result.trace.candidatePoolSize,
+        seedTrackCount: result.trace.seedTrackCount,
+        peerTrackCount: result.trace.peerTrackCount,
+        finalTrackIds: result.trace.finalTrackIds
+      });
+    } else {
+      builder.recordSeedSkipped(entry.artist, result.trace.rejection ?? "unknown");
+      builder.recordPlaylist({
+        seed: entry.artist,
+        playlistId: null,
+        profile: result.trace.profile,
+        candidatePoolSize: result.trace.candidatePoolSize,
+        seedTrackCount: result.trace.seedTrackCount,
+        peerTrackCount: result.trace.peerTrackCount,
+        finalTrackIds: result.trace.finalTrackIds,
+        rejection: result.trace.rejection
+      });
     }
   }
 
-  return playlists;
+  return { playlists, trace: builder.build() };
 }
 
 // ── Storage ───────────────────────────────────────────────────────
@@ -317,7 +410,7 @@ export async function saveForYouPlaylists(userId: string, playlists: ForYouPlayl
 
   const existing = await fs.readdir(dir).catch(() => []);
   for (const file of existing) {
-    if (file.endsWith(".json") && file !== "_meta.json") {
+    if (file.endsWith(".json") && file !== "_meta.json" && file !== "_trace.json") {
       await fs.unlink(path.join(dir, file)).catch(() => {});
     }
   }
@@ -341,7 +434,7 @@ export async function loadForYouPlaylists(userId: string): Promise<ForYouPlaylis
   const playlists: ForYouPlaylist[] = [];
 
   for (const file of files) {
-    if (!file.endsWith(".json") || file === "_meta.json") continue;
+    if (!file.endsWith(".json") || file === "_meta.json" || file === "_trace.json") continue;
     const data = await readJsonFile<ForYouPlaylist>(
       path.join(dir, file),
       null as unknown as ForYouPlaylist
@@ -380,10 +473,28 @@ export async function regenerateForYouPlaylists(
   indexStore: IndexStore
 ): Promise<ForYouPlaylist[]> {
   log.info(`Regenerating for-you playlists for user ${userId}...`);
-  const playlists = await generateForYouPlaylists(userId, indexStore);
+  const { playlists, trace } = await generateForYouPlaylistsWithTrace(userId, indexStore);
   await saveForYouPlaylists(userId, playlists);
-  log.info(`Generated ${playlists.length} for-you playlist(s) for user ${userId}`);
+  await saveForYouTrace(userId, trace);
+
+  const totalCandidates = trace.playlists.reduce((sum, p) => sum + p.candidatePoolSize, 0);
+  const seeds = trace.seedSelection.chosen.join(",") || "(none)";
+  log.info(
+    `for-you: user=${userId} seeds=${seeds} playlists=${playlists.length} ` +
+      `totalCandidates=${totalCandidates} durationMs=${trace.durationMs}`
+  );
   return playlists;
+}
+
+export async function saveForYouTrace(userId: string, trace: ForYouTrace): Promise<void> {
+  await ensureDir(userForYouDir(userId));
+  await writeJsonAtomic(userForYouTracePath(userId), trace);
+}
+
+export async function loadForYouTrace(userId: string): Promise<ForYouTrace | null> {
+  const data = await readJsonFile<ForYouTrace>(userForYouTracePath(userId), null as unknown as ForYouTrace);
+  if (!data || typeof data !== "object" || !data.userId) return null;
+  return data;
 }
 
 export async function checkAndRegenerateForYouOnBoot(

--- a/backend/src/services/playlists/forYouPlaylistService.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.ts
@@ -7,6 +7,8 @@ import { ensureDir, readJsonFile, updateJsonFile, writeJsonAtomic } from "../../
 import { normalizeGenreLabel } from "../genre/genreSynonymService";
 import { getUserPlayCounts } from "../activity/playCountStore";
 import { getRecentSkipCounts } from "../activity/skipStore";
+import { loadEmbedding } from "../embeddings/audioEmbeddingService";
+import { cosineSimilarity, meanVector } from "../embeddings/audioFeatures";
 import type { IndexStore } from "../indexer/indexStore";
 import type { Track } from "../../types/library";
 import { ForYouTraceBuilder, type ForYouTrace, type ScoredTrackTrace } from "./playlistTrace";
@@ -17,6 +19,7 @@ import {
   noveltyScore,
   scoreFeatures,
   yearProximity,
+  NEUTRAL_EMBEDDING_SIMILARITY,
   SKIP_HARD_FILTER_THRESHOLD,
   type CandidateFeatures
 } from "./forYouRanker";
@@ -374,7 +377,8 @@ function computeFeatures(
   seedGenres: ReadonlySet<string>,
   midYear: number,
   seedAlbumKeys: ReadonlySet<string>,
-  signals: SignalMaps
+  signals: SignalMaps,
+  similarityByTrackId: ReadonlyMap<string, number>
 ): CandidateFeatures {
   const lifetimePlays = signals.artistLifetimePlays.get(candidate.artist) ?? 0;
   const recentPlays = signals.trackRecentPlays.get(candidate.track.id) ?? 0;
@@ -385,7 +389,9 @@ function computeFeatures(
     libraryPopularity: logPopularity(lifetimePlays, signals.maxArtistLifetimePlays),
     novelty: noveltyScore(recentPlays),
     albumOverlapWithSeed: candidate.album && seedAlbumKeys.has(candidate.album) ? 1 : 0,
-    recentSkipCount: signals.trackRecentSkips.get(candidate.track.id) ?? 0
+    recentSkipCount: signals.trackRecentSkips.get(candidate.track.id) ?? 0,
+    embeddingSimilarity:
+      similarityByTrackId.get(candidate.track.id) ?? NEUTRAL_EMBEDDING_SIMILARITY
   };
 }
 
@@ -396,16 +402,28 @@ function rankCandidates(
   seedGenres: ReadonlySet<string>,
   midYear: number,
   seedAlbumKeys: ReadonlySet<string>,
-  signals: SignalMaps
+  signals: SignalMaps,
+  similarityByTrackId: ReadonlyMap<string, number>
 ): RankedCandidate[] {
   return candidates
     .map((c) => {
-      const features = computeFeatures(c, seedGenres, midYear, seedAlbumKeys, signals);
+      const features = computeFeatures(c, seedGenres, midYear, seedAlbumKeys, signals, similarityByTrackId);
       const rawScore = scoreFeatures(features);
       const jitter = fnvJitter(`${userId}|${seedKey}|${c.track.id}`);
       return { ...c, features, rawScore, score: rawScore + jitter };
     })
     .sort((a, b) => b.score - a.score);
+}
+
+async function loadEmbeddingVectors(trackIds: string[]): Promise<Map<string, number[]>> {
+  const out = new Map<string, number[]>();
+  await Promise.all(
+    trackIds.map(async (id) => {
+      const e = await loadEmbedding(id);
+      if (e) out.set(id, e.vec);
+    })
+  );
+  return out;
 }
 
 /**
@@ -603,13 +621,13 @@ type BuildResult =
   | { playlist: ForYouPlaylist; trace: BuildTrace }
   | { playlist: null; trace: BuildTrace };
 
-function buildForYouPlaylist(
+async function buildForYouPlaylist(
   seedArtist: string,
   indexStore: IndexStore,
   allTracks: Track[],
   signals: SignalMaps,
   userId: string
-): BuildResult {
+): Promise<BuildResult> {
   const profile = getArtistProfile(seedArtist, indexStore);
   const baseTrace: BuildTrace = {
     profile,
@@ -640,6 +658,21 @@ function buildForYouPlaylist(
   }
 
   const seedKey = seedArtist.toLowerCase();
+
+  // Embedding similarity: load seed-track embeddings once, then candidate
+  // embeddings in parallel; precompute a trackId → cosine map so the rest
+  // of the ranker stays sync.
+  const seedEmbeddings = await loadEmbeddingVectors(seedTracks.map((t) => t.id));
+  const seedMean =
+    seedEmbeddings.size > 0 ? meanVector([...seedEmbeddings.values()]) : null;
+  const candidateEmbeddings = await loadEmbeddingVectors(candidates.map((c) => c.track.id));
+  const similarityByTrackId = new Map<string, number>();
+  if (seedMean) {
+    for (const [trackId, vec] of candidateEmbeddings) {
+      similarityByTrackId.set(trackId, cosineSimilarity(seedMean, vec));
+    }
+  }
+
   const ranked = rankCandidates(
     candidates,
     userId,
@@ -647,7 +680,8 @@ function buildForYouPlaylist(
     seedGenres,
     midYear,
     seedAlbumKeys,
-    signals
+    signals,
+    similarityByTrackId
   );
 
   const lifetimePlays = signals.artistLifetimePlays.get(seedKey) ?? 0;
@@ -670,7 +704,8 @@ function buildForYouPlaylist(
         libraryPopularity: logPopularity(lifetimePlays, signals.maxArtistLifetimePlays),
         novelty: noveltyScore(trackPlays),
         albumOverlapWithSeed: 1,
-        recentSkipCount: signals.trackRecentSkips.get(t.id) ?? 0
+        recentSkipCount: signals.trackRecentSkips.get(t.id) ?? 0,
+        embeddingSimilarity: 1
       };
       const rawScore = scoreFeatures(features);
       return {
@@ -795,7 +830,7 @@ export async function generateForYouPlaylistsWithTrace(
     }
     attemptedSeeds++;
 
-    const result = buildForYouPlaylist(candidate.artist, indexStore, allTracks, signals, userId);
+    const result = await buildForYouPlaylist(candidate.artist, indexStore, allTracks, signals, userId);
 
     if (result.playlist) {
       playlists.push(result.playlist);

--- a/backend/src/services/playlists/forYouRanker.test.ts
+++ b/backend/src/services/playlists/forYouRanker.test.ts
@@ -99,7 +99,8 @@ describe("forYouRanker", () => {
         libraryPopularity: 0.5,
         novelty: 0.5,
         albumOverlapWithSeed: 0,
-        recentSkipCount: 0
+        recentSkipCount: 0,
+        embeddingSimilarity: 0.5
       };
     }
 
@@ -143,10 +144,17 @@ describe("forYouRanker", () => {
       expect(scoreFeatures(ten)).toBe(scoreFeatures(three));
     });
 
+    it("increases with embeddingSimilarity", () => {
+      const lo = { ...baseFeatures(), embeddingSimilarity: 0.1 };
+      const hi = { ...baseFeatures(), embeddingSimilarity: 0.9 };
+      expect(scoreFeatures(hi)).toBeGreaterThan(scoreFeatures(lo));
+    });
+
     it("uses the documented default weights", () => {
       expect(DEFAULT_WEIGHTS.genreOverlap).toBe(0.4);
       expect(DEFAULT_WEIGHTS.albumOverlapWithSeed).toBeLessThan(0);
       expect(DEFAULT_WEIGHTS.skipPenalty).toBeLessThan(0);
+      expect(DEFAULT_WEIGHTS.embeddingSimilarity).toBeGreaterThan(0);
     });
   });
 });

--- a/backend/src/services/playlists/forYouRanker.test.ts
+++ b/backend/src/services/playlists/forYouRanker.test.ts
@@ -98,7 +98,8 @@ describe("forYouRanker", () => {
         yearProximity: 0.5,
         libraryPopularity: 0.5,
         novelty: 0.5,
-        albumOverlapWithSeed: 0
+        albumOverlapWithSeed: 0,
+        recentSkipCount: 0
       };
     }
 
@@ -132,9 +133,20 @@ describe("forYouRanker", () => {
       expect(scoreFeatures(on)).toBeLessThan(scoreFeatures(off));
     });
 
+    it("decreases monotonically with recentSkipCount up to the soft cap", () => {
+      const zero = { ...baseFeatures(), recentSkipCount: 0 };
+      const one = { ...baseFeatures(), recentSkipCount: 1 };
+      const three = { ...baseFeatures(), recentSkipCount: 3 };
+      const ten = { ...baseFeatures(), recentSkipCount: 10 };
+      expect(scoreFeatures(one)).toBeLessThan(scoreFeatures(zero));
+      expect(scoreFeatures(three)).toBeLessThan(scoreFeatures(one));
+      expect(scoreFeatures(ten)).toBe(scoreFeatures(three));
+    });
+
     it("uses the documented default weights", () => {
       expect(DEFAULT_WEIGHTS.genreOverlap).toBe(0.4);
       expect(DEFAULT_WEIGHTS.albumOverlapWithSeed).toBeLessThan(0);
+      expect(DEFAULT_WEIGHTS.skipPenalty).toBeLessThan(0);
     });
   });
 });

--- a/backend/src/services/playlists/forYouRanker.test.ts
+++ b/backend/src/services/playlists/forYouRanker.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../genre/genreSynonymService", () => ({
+  normalizeGenreLabel: (g: string) => g
+}));
+
+import {
+  DEFAULT_WEIGHTS,
+  fnvJitter,
+  genreJaccard,
+  logPopularity,
+  noveltyScore,
+  scoreFeatures,
+  yearProximity,
+  type CandidateFeatures
+} from "./forYouRanker";
+
+describe("forYouRanker", () => {
+  describe("genreJaccard", () => {
+    it("returns 0 when either side is empty", () => {
+      expect(genreJaccard([], new Set(["rock"]))).toBe(0);
+      expect(genreJaccard(["rock"], new Set())).toBe(0);
+    });
+
+    it("returns 1 for identical sets", () => {
+      expect(genreJaccard(["Rock", "Pop"], new Set(["rock", "pop"]))).toBe(1);
+    });
+
+    it("returns the correct jaccard for partial overlap", () => {
+      // candidate: {rock, jazz}; seed: {rock, pop} → intersection 1, union 3
+      expect(genreJaccard(["Rock", "Jazz"], new Set(["rock", "pop"]))).toBeCloseTo(1 / 3);
+    });
+  });
+
+  describe("yearProximity", () => {
+    it("is 1 at the centre", () => {
+      expect(yearProximity(1975, 1975)).toBeCloseTo(1);
+    });
+
+    it("decays with distance", () => {
+      const close = yearProximity(1976, 1975);
+      const far = yearProximity(1990, 1975);
+      expect(close).toBeGreaterThan(far);
+    });
+
+    it("returns the neutral fallback when year is unknown", () => {
+      expect(yearProximity(undefined, 1975)).toBe(0.3);
+    });
+  });
+
+  describe("logPopularity", () => {
+    it("returns 0 when plays are 0", () => {
+      expect(logPopularity(0, 100)).toBe(0);
+    });
+
+    it("returns 1 when plays match the max", () => {
+      expect(logPopularity(100, 100)).toBeCloseTo(1);
+    });
+
+    it("is monotonic in plays", () => {
+      expect(logPopularity(5, 100)).toBeLessThan(logPopularity(50, 100));
+    });
+  });
+
+  describe("noveltyScore", () => {
+    it("is 1 when never recently played", () => {
+      expect(noveltyScore(0)).toBe(1);
+    });
+
+    it("is monotonically decreasing in recent plays", () => {
+      expect(noveltyScore(1)).toBeGreaterThan(noveltyScore(5));
+    });
+  });
+
+  describe("fnvJitter", () => {
+    it("is deterministic for the same seed", () => {
+      expect(fnvJitter("user|seed|track")).toBe(fnvJitter("user|seed|track"));
+    });
+
+    it("differs across seeds", () => {
+      expect(fnvJitter("a")).not.toBe(fnvJitter("b"));
+    });
+
+    it("stays inside the requested range", () => {
+      const range = 0.1;
+      for (const s of ["a", "long-input-here", "another", "track-42"]) {
+        const j = fnvJitter(s, range);
+        expect(j).toBeGreaterThanOrEqual(-range / 2);
+        expect(j).toBeLessThanOrEqual(range / 2);
+      }
+    });
+  });
+
+  describe("scoreFeatures monotonicity", () => {
+    function baseFeatures(): CandidateFeatures {
+      return {
+        genreOverlap: 0.5,
+        yearProximity: 0.5,
+        libraryPopularity: 0.5,
+        novelty: 0.5,
+        albumOverlapWithSeed: 0
+      };
+    }
+
+    it("increases with genreOverlap", () => {
+      const lo = { ...baseFeatures(), genreOverlap: 0.1 };
+      const hi = { ...baseFeatures(), genreOverlap: 0.9 };
+      expect(scoreFeatures(hi)).toBeGreaterThan(scoreFeatures(lo));
+    });
+
+    it("increases with yearProximity", () => {
+      const lo = { ...baseFeatures(), yearProximity: 0.1 };
+      const hi = { ...baseFeatures(), yearProximity: 0.9 };
+      expect(scoreFeatures(hi)).toBeGreaterThan(scoreFeatures(lo));
+    });
+
+    it("increases with libraryPopularity", () => {
+      const lo = { ...baseFeatures(), libraryPopularity: 0.1 };
+      const hi = { ...baseFeatures(), libraryPopularity: 0.9 };
+      expect(scoreFeatures(hi)).toBeGreaterThan(scoreFeatures(lo));
+    });
+
+    it("increases with novelty", () => {
+      const lo = { ...baseFeatures(), novelty: 0.1 };
+      const hi = { ...baseFeatures(), novelty: 0.9 };
+      expect(scoreFeatures(hi)).toBeGreaterThan(scoreFeatures(lo));
+    });
+
+    it("decreases when albumOverlapWithSeed is set", () => {
+      const off = { ...baseFeatures(), albumOverlapWithSeed: 0 };
+      const on = { ...baseFeatures(), albumOverlapWithSeed: 1 };
+      expect(scoreFeatures(on)).toBeLessThan(scoreFeatures(off));
+    });
+
+    it("uses the documented default weights", () => {
+      expect(DEFAULT_WEIGHTS.genreOverlap).toBe(0.4);
+      expect(DEFAULT_WEIGHTS.albumOverlapWithSeed).toBeLessThan(0);
+    });
+  });
+});

--- a/backend/src/services/playlists/forYouRanker.ts
+++ b/backend/src/services/playlists/forYouRanker.ts
@@ -45,8 +45,14 @@ export const DEFAULT_WEIGHTS: RankerWeights = {
 /** Neutral similarity score when an embedding is unavailable. */
 export const NEUTRAL_EMBEDDING_SIMILARITY = 0.5;
 
+/**
+ * Hard filter excludes tracks at >= SKIP_HARD_FILTER_THRESHOLD skips. The
+ * soft cap shapes the penalty curve for tracks that survive the filter:
+ * each additional skip below the cap deepens the penalty, then plateaus.
+ * Keep hard > soft so the cap actually does work.
+ */
 export const SKIP_SOFT_CAP = 3;
-export const SKIP_HARD_FILTER_THRESHOLD = 3;
+export const SKIP_HARD_FILTER_THRESHOLD = 5;
 
 export const YEAR_SIGMA = 8;
 export const JITTER_RANGE = 0.1;

--- a/backend/src/services/playlists/forYouRanker.ts
+++ b/backend/src/services/playlists/forYouRanker.ts
@@ -14,6 +14,12 @@ export type CandidateFeatures = {
   novelty: number;
   albumOverlapWithSeed: number;
   recentSkipCount: number;
+  /**
+   * Cosine similarity between the candidate's audio embedding and the mean
+   * embedding of the seed tracks. Range -1..1; 0.5 is the neutral value used
+   * when either side is missing an embedding.
+   */
+  embeddingSimilarity: number;
 };
 
 export type RankerWeights = {
@@ -23,6 +29,7 @@ export type RankerWeights = {
   novelty: number;
   albumOverlapWithSeed: number;
   skipPenalty: number;
+  embeddingSimilarity: number;
 };
 
 export const DEFAULT_WEIGHTS: RankerWeights = {
@@ -31,8 +38,12 @@ export const DEFAULT_WEIGHTS: RankerWeights = {
   libraryPopularity: 0.15,
   novelty: 0.15,
   albumOverlapWithSeed: -0.30,
-  skipPenalty: -0.20
+  skipPenalty: -0.20,
+  embeddingSimilarity: 0.10
 };
+
+/** Neutral similarity score when an embedding is unavailable. */
+export const NEUTRAL_EMBEDDING_SIMILARITY = 0.5;
 
 export const SKIP_SOFT_CAP = 3;
 export const SKIP_HARD_FILTER_THRESHOLD = 3;
@@ -102,6 +113,7 @@ export function scoreFeatures(features: CandidateFeatures, weights: RankerWeight
     weights.libraryPopularity * features.libraryPopularity +
     weights.novelty * features.novelty +
     weights.albumOverlapWithSeed * features.albumOverlapWithSeed +
-    weights.skipPenalty * cappedSkips
+    weights.skipPenalty * cappedSkips +
+    weights.embeddingSimilarity * features.embeddingSimilarity
   );
 }

--- a/backend/src/services/playlists/forYouRanker.ts
+++ b/backend/src/services/playlists/forYouRanker.ts
@@ -13,6 +13,7 @@ export type CandidateFeatures = {
   libraryPopularity: number;
   novelty: number;
   albumOverlapWithSeed: number;
+  recentSkipCount: number;
 };
 
 export type RankerWeights = {
@@ -21,6 +22,7 @@ export type RankerWeights = {
   libraryPopularity: number;
   novelty: number;
   albumOverlapWithSeed: number;
+  skipPenalty: number;
 };
 
 export const DEFAULT_WEIGHTS: RankerWeights = {
@@ -28,8 +30,12 @@ export const DEFAULT_WEIGHTS: RankerWeights = {
   yearProximity: 0.20,
   libraryPopularity: 0.15,
   novelty: 0.15,
-  albumOverlapWithSeed: -0.30
+  albumOverlapWithSeed: -0.30,
+  skipPenalty: -0.20
 };
+
+export const SKIP_SOFT_CAP = 3;
+export const SKIP_HARD_FILTER_THRESHOLD = 3;
 
 export const YEAR_SIGMA = 8;
 export const JITTER_RANGE = 0.1;
@@ -89,11 +95,13 @@ export function fnvJitter(seed: string, range: number = JITTER_RANGE): number {
 }
 
 export function scoreFeatures(features: CandidateFeatures, weights: RankerWeights = DEFAULT_WEIGHTS): number {
+  const cappedSkips = Math.min(features.recentSkipCount, SKIP_SOFT_CAP);
   return (
     weights.genreOverlap * features.genreOverlap +
     weights.yearProximity * features.yearProximity +
     weights.libraryPopularity * features.libraryPopularity +
     weights.novelty * features.novelty +
-    weights.albumOverlapWithSeed * features.albumOverlapWithSeed
+    weights.albumOverlapWithSeed * features.albumOverlapWithSeed +
+    weights.skipPenalty * cappedSkips
   );
 }

--- a/backend/src/services/playlists/forYouRanker.ts
+++ b/backend/src/services/playlists/forYouRanker.ts
@@ -1,0 +1,99 @@
+/**
+ * Pure scoring helpers for For You peer ranking. No I/O, no side effects —
+ * everything here is unit-testable in isolation. The ranker turns a candidate
+ * track into a score by combining genre overlap, year proximity, library
+ * popularity, novelty, and an album-overlap penalty.
+ */
+
+import { normalizeGenreLabel } from "../genre/genreSynonymService";
+
+export type CandidateFeatures = {
+  genreOverlap: number;
+  yearProximity: number;
+  libraryPopularity: number;
+  novelty: number;
+  albumOverlapWithSeed: number;
+};
+
+export type RankerWeights = {
+  genreOverlap: number;
+  yearProximity: number;
+  libraryPopularity: number;
+  novelty: number;
+  albumOverlapWithSeed: number;
+};
+
+export const DEFAULT_WEIGHTS: RankerWeights = {
+  genreOverlap: 0.40,
+  yearProximity: 0.20,
+  libraryPopularity: 0.15,
+  novelty: 0.15,
+  albumOverlapWithSeed: -0.30
+};
+
+export const YEAR_SIGMA = 8;
+export const JITTER_RANGE = 0.1;
+
+/** Jaccard similarity between candidate genres and the seed's normalized genre set. */
+export function genreJaccard(candidateGenres: string[], seedGenres: ReadonlySet<string>): number {
+  if (candidateGenres.length === 0 || seedGenres.size === 0) return 0;
+  const candidateSet = new Set<string>();
+  for (const g of candidateGenres) {
+    candidateSet.add(normalizeGenreLabel(g).toLowerCase());
+  }
+
+  let intersection = 0;
+  for (const g of candidateSet) {
+    if (seedGenres.has(g)) intersection++;
+  }
+  const union = candidateSet.size + seedGenres.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/** Gaussian centered on the seed era's mid-year. Returns 0..1. Year-less tracks get a small neutral score. */
+export function yearProximity(
+  year: number | undefined,
+  midYear: number,
+  sigma: number = YEAR_SIGMA
+): number {
+  if (!year) return 0.3;
+  const diff = year - midYear;
+  return Math.exp(-(diff * diff) / (2 * sigma * sigma));
+}
+
+/** Log-scaled popularity: 0 if never played, 1 at the most-played artist/track in the user's library. */
+export function logPopularity(plays: number, maxPlays: number): number {
+  if (maxPlays <= 0 || plays <= 0) return 0;
+  return Math.log(1 + plays) / Math.log(1 + maxPlays);
+}
+
+/** Penalize tracks the user has played heavily in the recency window. */
+export function noveltyScore(recentPlays: number): number {
+  if (recentPlays <= 0) return 1;
+  return 1 / (1 + recentPlays);
+}
+
+/**
+ * 32-bit FNV-1a hash mapped into a small symmetric range so two regenerations
+ * with identical inputs produce identical playlists, but day-to-day variation
+ * still shifts ordering slightly. Deterministic per (userId, seed, trackId).
+ */
+export function fnvJitter(seed: string, range: number = JITTER_RANGE): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i++) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  const norm = hash / 0x100000000;
+  return (norm - 0.5) * range;
+}
+
+export function scoreFeatures(features: CandidateFeatures, weights: RankerWeights = DEFAULT_WEIGHTS): number {
+  return (
+    weights.genreOverlap * features.genreOverlap +
+    weights.yearProximity * features.yearProximity +
+    weights.libraryPopularity * features.libraryPopularity +
+    weights.novelty * features.novelty +
+    weights.albumOverlapWithSeed * features.albumOverlapWithSeed
+  );
+}

--- a/backend/src/services/playlists/personalPlaylistService.test.ts
+++ b/backend/src/services/playlists/personalPlaylistService.test.ts
@@ -221,7 +221,7 @@ describe("personalPlaylistService", () => {
     }
   });
 
-  it("hard-filters tracks with 3+ recent skips out of personal mixes", async () => {
+  it("hard-filters heavily-skipped tracks out of personal mixes", async () => {
     const { generatePersonalPlaylistsWithTrace } = await import("./personalPlaylistService");
     const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
     const thisYear = new Date().getFullYear();
@@ -243,8 +243,8 @@ describe("personalPlaylistService", () => {
     await ensureDir(dir);
     await writeJsonAtomic(path.join(dir, "skips.json"), {
       tracks: {
-        "new-0": { count: 4, lastSkippedAt: recent },
-        "new-1": { count: 3, lastSkippedAt: recent }
+        "new-0": { count: 6, lastSkippedAt: recent },
+        "new-1": { count: 5, lastSkippedAt: recent }
       }
     });
 

--- a/backend/src/services/playlists/personalPlaylistService.test.ts
+++ b/backend/src/services/playlists/personalPlaylistService.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+let tmpDir: string;
+
+vi.mock("../../utils/paths", async () => {
+  return {
+    get dataRoot() { return path.join(tmpDir, "data"); },
+    get usersStorageRoot() { return path.join(tmpDir, "data", "storage", "users"); },
+    get configRoot() { return path.join(tmpDir, "data", "config"); }
+  };
+});
+
+vi.mock("../../utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+vi.mock("../genre/genreSynonymService", () => ({
+  normalizeGenreLabel: (g: string) => g
+}));
+
+import type { Track } from "../../types/library";
+import type { IndexStore } from "../indexer/indexStore";
+
+function makeTrack(overrides: Partial<Track> & { id: string }): Track {
+  return {
+    owner: "user-1",
+    path: `/music/${overrides.id}.flac`,
+    duration: 240,
+    mimeType: "audio/flac",
+    codec: "flac",
+    tags: {},
+    ...overrides
+  };
+}
+
+function makeMockIndexStore(tracks: Track[]): IndexStore {
+  const byId = new Map(tracks.map((t) => [t.id, t]));
+  const byArtist = new Map<string, Track[]>();
+  const byAlbum = new Map<string, Track[]>();
+  for (const t of tracks) {
+    const artist = (t.tags.artist ?? "Unknown").toLowerCase();
+    const aList = byArtist.get(artist) ?? [];
+    aList.push(t);
+    byArtist.set(artist, aList);
+    const album = (t.tags.album ?? "").toLowerCase();
+    if (album) {
+      const list = byAlbum.get(album) ?? [];
+      list.push(t);
+      byAlbum.set(album, list);
+    }
+  }
+  return {
+    getSnapshot: () => ({ tracks, totalTracks: tracks.length, generatedAt: "", playlists: [] }),
+    getTrackById: (id: string) => byId.get(id),
+    getTracksByArtist: (artist: string) => byArtist.get(artist.toLowerCase()) ?? [],
+    getTracksByAlbum: (album: string) => byAlbum.get(album.toLowerCase()) ?? [],
+    hasTrack: (id: string) => byId.has(id)
+  } as unknown as IndexStore;
+}
+
+async function writePlayCounts(
+  userId: string,
+  counts: Record<string, { count: number; lastPlayedAt: string }>
+): Promise<void> {
+  const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+  const dir = path.join(tmpDir, "data", "storage", "users", userId);
+  await ensureDir(dir);
+  await writeJsonAtomic(path.join(dir, "play-counts.json"), { tracks: counts });
+}
+
+describe("personalPlaylistService", () => {
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "personal-test-"));
+    await fs.mkdir(path.join(tmpDir, "data", "config"), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, "data", "storage", "users"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("skips generation when user is below thresholds", async () => {
+    const { generatePersonalPlaylistsWithTrace } = await import("./personalPlaylistService");
+    const tracks = Array.from({ length: 5 }, (_, i) =>
+      makeTrack({ id: `t-${i}`, tags: { artist: `A${i}` } })
+    );
+    const indexStore = makeMockIndexStore(tracks);
+    await writePlayCounts("user-1", {
+      "t-0": { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" }
+    });
+    const { playlists } = await generatePersonalPlaylistsWithTrace("user-1", indexStore);
+    expect(playlists).toEqual([]);
+  });
+
+  it("discovered-this-year filters by addedAt within the current year and requires plays", async () => {
+    const { generatePersonalPlaylistsWithTrace } = await import("./personalPlaylistService");
+    const thisYear = new Date().getFullYear();
+    const tracks: Track[] = [];
+    // 10 tracks added this year, played
+    for (let i = 0; i < 10; i++) {
+      tracks.push(makeTrack({
+        id: `new-${i}`,
+        addedAt: `${thisYear}-03-15T00:00:00Z`,
+        tags: { artist: `Artist ${i % 4}`, album: `Album ${i % 4}`, year: thisYear }
+      }));
+    }
+    // Old tracks added years ago, also played
+    for (let i = 0; i < 5; i++) {
+      tracks.push(makeTrack({
+        id: `old-${i}`,
+        addedAt: `${thisYear - 3}-05-01T00:00:00Z`,
+        tags: { artist: `OldArtist ${i}`, album: `OldAlbum ${i}`, year: thisYear - 3 }
+      }));
+    }
+
+    const indexStore = makeMockIndexStore(tracks);
+    const counts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 10; i++) counts[`new-${i}`] = { count: 2, lastPlayedAt: `${thisYear}-04-01T00:00:00Z` };
+    for (let i = 0; i < 5; i++) counts[`old-${i}`] = { count: 2, lastPlayedAt: `${thisYear}-04-01T00:00:00Z` };
+    await writePlayCounts("user-1", counts);
+
+    const { playlists } = await generatePersonalPlaylistsWithTrace("user-1", indexStore);
+    const discovered = playlists.find((p) => p.variant === "discovered-this-year");
+    expect(discovered).toBeDefined();
+    expect(discovered!.trackIds.length).toBeGreaterThanOrEqual(8);
+    for (const id of discovered!.trackIds) {
+      expect(id.startsWith("new-")).toBe(true);
+    }
+  });
+
+  it("forgotten-favorites surfaces tracks not played in the recent window", async () => {
+    const { generatePersonalPlaylistsWithTrace } = await import("./personalPlaylistService");
+    const thisYear = new Date().getFullYear();
+    const tracks: Track[] = [];
+    for (let i = 0; i < 10; i++) {
+      tracks.push(makeTrack({
+        id: `forgot-${i}`,
+        tags: { artist: `Artist ${i % 4}`, album: `Album ${i % 4}`, year: thisYear - 5 }
+      }));
+    }
+    // Recently-played decoys that should NOT appear
+    for (let i = 0; i < 5; i++) {
+      tracks.push(makeTrack({
+        id: `recent-${i}`,
+        tags: { artist: `Recent ${i}`, album: `RecentAlbum ${i}`, year: thisYear }
+      }));
+    }
+    const indexStore = makeMockIndexStore(tracks);
+
+    const oldDate = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString();
+    const newDate = new Date().toISOString();
+    const counts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 10; i++) counts[`forgot-${i}`] = { count: 5, lastPlayedAt: oldDate };
+    for (let i = 0; i < 5; i++) counts[`recent-${i}`] = { count: 5, lastPlayedAt: newDate };
+    await writePlayCounts("user-1", counts);
+
+    const { playlists } = await generatePersonalPlaylistsWithTrace("user-1", indexStore);
+    const forgotten = playlists.find((p) => p.variant === "forgotten-favorites");
+    expect(forgotten).toBeDefined();
+    for (const id of forgotten!.trackIds) {
+      expect(id.startsWith("forgot-")).toBe(true);
+    }
+  });
+
+  it("album-deep-cuts surfaces unplayed tracks from engaged albums", async () => {
+    const { generatePersonalPlaylistsWithTrace } = await import("./personalPlaylistService");
+    const tracks: Track[] = [];
+    // Album X has 10 tracks; user played 4, leaving 6 unplayed deep cuts.
+    for (let i = 0; i < 10; i++) {
+      tracks.push(makeTrack({
+        id: `xa-${i}`,
+        tags: { artist: "Big Star", album: "Album X", albumArtist: "Big Star", year: 1972 }
+      }));
+    }
+    // Album Y has 10 tracks; user played 3, leaving 7 deep cuts.
+    for (let i = 0; i < 10; i++) {
+      tracks.push(makeTrack({
+        id: `yb-${i}`,
+        tags: { artist: "Big Star", album: "Album Y", albumArtist: "Big Star", year: 1973 }
+      }));
+    }
+    // Filler so distinct artists threshold is met.
+    for (let i = 0; i < 4; i++) {
+      tracks.push(makeTrack({
+        id: `fill-${i}`,
+        tags: { artist: `Filler ${i}`, album: `Filler-album-${i}`, year: 1980 }
+      }));
+    }
+    const indexStore = makeMockIndexStore(tracks);
+
+    const at = "2026-04-01T00:00:00Z";
+    const counts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    counts["xa-0"] = { count: 3, lastPlayedAt: at };
+    counts["xa-1"] = { count: 3, lastPlayedAt: at };
+    counts["xa-2"] = { count: 2, lastPlayedAt: at };
+    counts["xa-3"] = { count: 2, lastPlayedAt: at };
+    counts["yb-0"] = { count: 4, lastPlayedAt: at };
+    counts["yb-1"] = { count: 2, lastPlayedAt: at };
+    counts["yb-2"] = { count: 2, lastPlayedAt: at };
+    counts["fill-0"] = { count: 1, lastPlayedAt: at };
+    counts["fill-1"] = { count: 1, lastPlayedAt: at };
+    counts["fill-2"] = { count: 1, lastPlayedAt: at };
+    await writePlayCounts("user-1", counts);
+
+    const { playlists } = await generatePersonalPlaylistsWithTrace("user-1", indexStore);
+    const deep = playlists.find((p) => p.variant === "album-deep-cuts");
+    expect(deep).toBeDefined();
+    // Should be exactly the unplayed tracks from Album X and Album Y.
+    const playedIds = new Set(Object.keys(counts));
+    for (const id of deep!.trackIds) {
+      expect(playedIds.has(id)).toBe(false);
+      expect(id.startsWith("xa-") || id.startsWith("yb-")).toBe(true);
+    }
+  });
+
+  it("regeneratePersonalPlaylists persists playlists, meta, and trace", async () => {
+    const { regeneratePersonalPlaylists, loadPersonalPlaylists, loadPersonalTrace } =
+      await import("./personalPlaylistService");
+    const thisYear = new Date().getFullYear();
+    const tracks: Track[] = [];
+    for (let i = 0; i < 12; i++) {
+      tracks.push(makeTrack({
+        id: `t-${i}`,
+        addedAt: `${thisYear}-02-01T00:00:00Z`,
+        tags: { artist: `Artist ${i % 4}`, album: `Album ${i % 4}`, year: thisYear }
+      }));
+    }
+    const indexStore = makeMockIndexStore(tracks);
+    const counts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 12; i++) counts[`t-${i}`] = { count: 2, lastPlayedAt: `${thisYear}-04-01T00:00:00Z` };
+    await writePlayCounts("user-1", counts);
+
+    await regeneratePersonalPlaylists("user-1", indexStore);
+    const loaded = await loadPersonalPlaylists("user-1");
+    expect(loaded.length).toBeGreaterThan(0);
+    const trace = await loadPersonalTrace("user-1");
+    expect(trace).not.toBeNull();
+    expect(trace!.userId).toBe("user-1");
+    expect(trace!.variants.length).toBe(3);
+  });
+});

--- a/backend/src/services/playlists/personalPlaylistService.test.ts
+++ b/backend/src/services/playlists/personalPlaylistService.test.ts
@@ -221,6 +221,40 @@ describe("personalPlaylistService", () => {
     }
   });
 
+  it("hard-filters tracks with 3+ recent skips out of personal mixes", async () => {
+    const { generatePersonalPlaylistsWithTrace } = await import("./personalPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+    const thisYear = new Date().getFullYear();
+    const tracks: Track[] = [];
+    for (let i = 0; i < 12; i++) {
+      tracks.push(makeTrack({
+        id: `new-${i}`,
+        addedAt: `${thisYear}-02-01T00:00:00Z`,
+        tags: { artist: `Artist ${i % 4}`, album: `Album ${i % 4}`, year: thisYear }
+      }));
+    }
+    const indexStore = makeMockIndexStore(tracks);
+    const counts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 12; i++) counts[`new-${i}`] = { count: 2, lastPlayedAt: `${thisYear}-04-01T00:00:00Z` };
+    await writePlayCounts("user-1", counts);
+
+    const recent = new Date().toISOString();
+    const dir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(dir);
+    await writeJsonAtomic(path.join(dir, "skips.json"), {
+      tracks: {
+        "new-0": { count: 4, lastSkippedAt: recent },
+        "new-1": { count: 3, lastSkippedAt: recent }
+      }
+    });
+
+    const { playlists } = await generatePersonalPlaylistsWithTrace("user-1", indexStore);
+    const discovered = playlists.find((p) => p.variant === "discovered-this-year");
+    expect(discovered).toBeDefined();
+    expect(discovered!.trackIds).not.toContain("new-0");
+    expect(discovered!.trackIds).not.toContain("new-1");
+  });
+
   it("regeneratePersonalPlaylists persists playlists, meta, and trace", async () => {
     const { regeneratePersonalPlaylists, loadPersonalPlaylists, loadPersonalTrace } =
       await import("./personalPlaylistService");

--- a/backend/src/services/playlists/personalPlaylistService.ts
+++ b/backend/src/services/playlists/personalPlaylistService.ts
@@ -24,7 +24,9 @@ import { createLogger } from "../../utils/logger";
 import { dataRoot } from "../../utils/paths";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
 import { getUserPlayCounts } from "../activity/playCountStore";
+import { getRecentSkipCounts } from "../activity/skipStore";
 import { pickMosaicCovers } from "./autoPlaylistService";
+import { SKIP_HARD_FILTER_THRESHOLD } from "./forYouRanker";
 import type { IndexStore } from "../indexer/indexStore";
 import type { Track } from "../../types/library";
 import {
@@ -48,6 +50,7 @@ const FORGOTTEN_RECENT_DAYS = 90;
 const FORGOTTEN_MIN_PLAYS = 3;
 const DEEP_CUTS_MIN_ALBUM_ENGAGEMENT = 2;
 const DEEP_CUTS_MIN_ALBUM_TRACKS = 4;
+const RECENT_SKIPS_WINDOW_DAYS = 60;
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -293,6 +296,12 @@ export async function generatePersonalPlaylistsWithTrace(
 ): Promise<PersonalGenerationResult> {
   const builder = new PersonalTraceBuilder(userId);
   const playCounts = await getUserPlayCounts(userId);
+  const recentSkips = await getRecentSkipCounts(userId, RECENT_SKIPS_WINDOW_DAYS);
+  const heavySkippedTrackIds = new Set(
+    Object.entries(recentSkips)
+      .filter(([, e]) => e.count >= SKIP_HARD_FILTER_THRESHOLD)
+      .map(([id]) => id)
+  );
   const entries = Object.entries(playCounts);
   const totalPlays = entries.reduce((sum, [, e]) => sum + e.count, 0);
 
@@ -326,7 +335,10 @@ export async function generatePersonalPlaylistsWithTrace(
   ];
 
   for (const { variant, fn } of variantBuilders) {
-    const { scored, notes } = fn();
+    const { scored: rawScored, notes } = fn();
+    const scored = heavySkippedTrackIds.size > 0
+      ? rawScored.filter((s) => !heavySkippedTrackIds.has(s.track.id))
+      : rawScored;
     const playlist = buildPlaylist(variant, scored, generatedAt);
 
     const traceEntry: PersonalVariantTrace = {

--- a/backend/src/services/playlists/personalPlaylistService.ts
+++ b/backend/src/services/playlists/personalPlaylistService.ts
@@ -1,0 +1,461 @@
+/**
+ * Personal mixes — user-aware Auto playlists. Three variants:
+ *
+ *   • discovered-this-year   tracks added in the current calendar year that
+ *                            the user has played at least once.
+ *   • forgotten-favorites    tracks with high lifetime plays but no plays in
+ *                            the recent window (default 90 days).
+ *   • album-deep-cuts        tracks from albums the user has otherwise
+ *                            engaged with, but hasn't played themselves.
+ *
+ * Storage follows the for-you pattern: file-based, per-user.
+ *   data/auto-playlists/personal/<userId>/<variant>.json
+ *   data/auto-playlists/personal/<userId>/_meta.json
+ *   data/auto-playlists/personal/<userId>/_trace.json
+ *
+ * No DB; the auth layer is the only thing in the DB. Everything else here
+ * is JSON files read/written atomically.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { dataRoot } from "../../utils/paths";
+import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
+import { getUserPlayCounts } from "../activity/playCountStore";
+import { pickMosaicCovers } from "./autoPlaylistService";
+import type { IndexStore } from "../indexer/indexStore";
+import type { Track } from "../../types/library";
+import {
+  PersonalTraceBuilder,
+  type PersonalTrace,
+  type PersonalVariantId,
+  type PersonalVariantTrace
+} from "./playlistTrace";
+
+const log = createLogger("personal-playlists");
+
+const PERSONAL_DIR = path.join(dataRoot, "auto-playlists", "personal");
+const REGENERATION_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+const MIN_TOTAL_PLAYS = 20;
+const MIN_DISTINCT_ARTISTS = 3;
+const MIN_TRACKS_PER_PLAYLIST = 8;
+const TRACKS_PER_PLAYLIST = 30;
+
+const FORGOTTEN_RECENT_DAYS = 90;
+const FORGOTTEN_MIN_PLAYS = 3;
+const DEEP_CUTS_MIN_ALBUM_ENGAGEMENT = 2;
+const DEEP_CUTS_MIN_ALBUM_TRACKS = 4;
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export type PersonalPlaylist = {
+  id: string;
+  variant: PersonalVariantId;
+  name: string;
+  description: string;
+  trackIds: string[];
+  trackCount: number;
+  generatedAt: string;
+  colors: [string, string, string];
+  gradientAngle: number;
+  mosaicCovers?: string[];
+};
+
+type PersonalMeta = {
+  lastGeneratedAt: string;
+};
+
+// ── Paths ──────────────────────────────────────────────────────────
+
+function userPersonalDir(userId: string): string {
+  return path.join(PERSONAL_DIR, userId);
+}
+
+function userPersonalMetaPath(userId: string): string {
+  return path.join(userPersonalDir(userId), "_meta.json");
+}
+
+function userPersonalTracePath(userId: string): string {
+  return path.join(userPersonalDir(userId), "_trace.json");
+}
+
+// ── Style ──────────────────────────────────────────────────────────
+
+const VARIANT_GRADIENTS: Record<PersonalVariantId, { colors: [string, string, string]; angle: number }> = {
+  "discovered-this-year": {
+    colors: ["hsl(195, 70%, 55%)", "hsl(220, 65%, 55%)", "hsl(260, 70%, 55%)"],
+    angle: 135
+  },
+  "forgotten-favorites": {
+    colors: ["hsl(30, 80%, 60%)", "hsl(15, 75%, 55%)", "hsl(345, 70%, 55%)"],
+    angle: 145
+  },
+  "album-deep-cuts": {
+    colors: ["hsl(160, 55%, 45%)", "hsl(190, 50%, 45%)", "hsl(220, 50%, 45%)"],
+    angle: 125
+  }
+};
+
+const VARIANT_LABELS: Record<PersonalVariantId, { name: string; description: string }> = {
+  "discovered-this-year": {
+    name: "Discovered this year",
+    description: "Music you added and started playing in the last twelve months."
+  },
+  "forgotten-favorites": {
+    name: "Forgotten favorites",
+    description: "Tracks you used to love but haven't played in a while."
+  },
+  "album-deep-cuts": {
+    name: "Album deep cuts",
+    description: "Songs from albums you know, that you haven't actually played."
+  }
+};
+
+// ── Diversity helper ───────────────────────────────────────────────
+
+type ScoredTrack = {
+  track: Track;
+  artist: string;
+  album: string;
+  weight: number;
+};
+
+/**
+ * Order tracks for sequencing: weight-sorted, then a deterministic adjacency
+ * pass that avoids putting two same-album tracks back to back.
+ */
+function sequenceWeighted(scored: ScoredTrack[], maxTracks: number): Track[] {
+  const sorted = [...scored].sort((a, b) => b.weight - a.weight).slice(0, maxTracks);
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i]!.album && sorted[i]!.album === sorted[i - 1]!.album) {
+      for (let j = i + 1; j < sorted.length; j++) {
+        if (sorted[j]!.album !== sorted[i - 1]!.album) {
+          [sorted[i], sorted[j]] = [sorted[j]!, sorted[i]!];
+          break;
+        }
+      }
+    }
+  }
+  return sorted.map((s) => s.track);
+}
+
+function makeScored(track: Track, weight: number): ScoredTrack {
+  return {
+    track,
+    artist: (track.tags.artist ?? "").toLowerCase(),
+    album: (track.tags.album ?? "").toLowerCase(),
+    weight
+  };
+}
+
+// ── Variant generators ─────────────────────────────────────────────
+
+type PlayCountEntry = { count: number; lastPlayedAt: string };
+
+function isWithinDays(iso: string, days: number, now: number): boolean {
+  const t = new Date(iso).getTime();
+  if (isNaN(t)) return false;
+  return now - t < days * 24 * 60 * 60 * 1000;
+}
+
+/** Tracks added this calendar year that the user has played at least once. */
+function buildDiscoveredThisYear(
+  playCounts: Record<string, PlayCountEntry>,
+  indexStore: IndexStore,
+  now: number
+): { scored: ScoredTrack[]; notes: string[] } {
+  const yearStart = new Date(new Date(now).getFullYear(), 0, 1).getTime();
+  const scored: ScoredTrack[] = [];
+  const missingAddedAt: string[] = [];
+
+  for (const [trackId, entry] of Object.entries(playCounts)) {
+    if (entry.count <= 0) continue;
+    const track = indexStore.getTrackById(trackId);
+    if (!track) continue;
+    if (!track.addedAt) {
+      missingAddedAt.push(trackId);
+      continue;
+    }
+    const addedAt = new Date(track.addedAt).getTime();
+    if (isNaN(addedAt) || addedAt < yearStart) continue;
+    scored.push(makeScored(track, entry.count));
+  }
+
+  const notes: string[] = [];
+  if (missingAddedAt.length > 0) {
+    notes.push(`${missingAddedAt.length} candidate track(s) skipped: no addedAt timestamp`);
+  }
+  return { scored, notes };
+}
+
+/** High-lifetime plays but no plays in the recent window. */
+function buildForgottenFavorites(
+  playCounts: Record<string, PlayCountEntry>,
+  indexStore: IndexStore,
+  now: number
+): { scored: ScoredTrack[]; notes: string[] } {
+  const scored: ScoredTrack[] = [];
+  for (const [trackId, entry] of Object.entries(playCounts)) {
+    if (entry.count < FORGOTTEN_MIN_PLAYS) continue;
+    if (isWithinDays(entry.lastPlayedAt, FORGOTTEN_RECENT_DAYS, now)) continue;
+    const track = indexStore.getTrackById(trackId);
+    if (!track) continue;
+    scored.push(makeScored(track, entry.count));
+  }
+  return { scored, notes: [] };
+}
+
+/** Tracks the user hasn't played, from albums where they've played other tracks. */
+function buildAlbumDeepCuts(
+  playCounts: Record<string, PlayCountEntry>,
+  indexStore: IndexStore
+): { scored: ScoredTrack[]; notes: string[] } {
+  // Aggregate plays by (artist, album).
+  const albumKey = (artist: string, album: string): string =>
+    `${(artist ?? "").toLowerCase()}::${(album ?? "").toLowerCase()}`;
+
+  const playedTrackIds = new Set<string>();
+  const albumEngagement = new Map<string, { artist: string; album: string; played: number }>();
+
+  for (const [trackId, entry] of Object.entries(playCounts)) {
+    if (entry.count <= 0) continue;
+    playedTrackIds.add(trackId);
+    const track = indexStore.getTrackById(trackId);
+    if (!track) continue;
+    const album = track.tags.album;
+    const artist = track.tags.albumArtist ?? track.tags.artist;
+    if (!album || !artist) continue;
+    const key = albumKey(artist, album);
+    const existing = albumEngagement.get(key);
+    if (existing) {
+      existing.played += entry.count;
+    } else {
+      albumEngagement.set(key, { artist, album, played: entry.count });
+    }
+  }
+
+  const scored: ScoredTrack[] = [];
+  for (const [, info] of albumEngagement) {
+    if (info.played < DEEP_CUTS_MIN_ALBUM_ENGAGEMENT) continue;
+    const albumTracks = indexStore.getTracksByAlbum(info.album);
+    if (albumTracks.length < DEEP_CUTS_MIN_ALBUM_TRACKS) continue;
+    for (const track of albumTracks) {
+      if (playedTrackIds.has(track.id)) continue;
+      // Match the album-artist when possible to avoid pulling tracks from
+      // different artists that happen to share an album title.
+      const trackArtist = (track.tags.albumArtist ?? track.tags.artist ?? "").toLowerCase();
+      if (trackArtist !== info.artist.toLowerCase()) continue;
+      // Weight: more-engaged albums rank higher.
+      scored.push(makeScored(track, info.played));
+    }
+  }
+  return { scored, notes: [] };
+}
+
+// ── Generation ─────────────────────────────────────────────────────
+
+export type PersonalGenerationResult = {
+  playlists: PersonalPlaylist[];
+  trace: PersonalTrace;
+};
+
+function buildPlaylist(
+  variant: PersonalVariantId,
+  scored: ScoredTrack[],
+  generatedAt: string
+): PersonalPlaylist | null {
+  if (scored.length < MIN_TRACKS_PER_PLAYLIST) return null;
+  const tracks = sequenceWeighted(scored, TRACKS_PER_PLAYLIST);
+  if (tracks.length < MIN_TRACKS_PER_PLAYLIST) return null;
+  const labels = VARIANT_LABELS[variant];
+  const gradient = VARIANT_GRADIENTS[variant];
+  const mosaic = pickMosaicCovers(tracks);
+  return {
+    id: `personal:${variant}`,
+    variant,
+    name: labels.name,
+    description: labels.description,
+    trackIds: tracks.map((t) => t.id),
+    trackCount: tracks.length,
+    generatedAt,
+    colors: gradient.colors,
+    gradientAngle: gradient.angle,
+    ...(mosaic.length > 0 ? { mosaicCovers: mosaic } : {})
+  };
+}
+
+export async function generatePersonalPlaylistsWithTrace(
+  userId: string,
+  indexStore: IndexStore
+): Promise<PersonalGenerationResult> {
+  const builder = new PersonalTraceBuilder(userId);
+  const playCounts = await getUserPlayCounts(userId);
+  const entries = Object.entries(playCounts);
+  const totalPlays = entries.reduce((sum, [, e]) => sum + e.count, 0);
+
+  const distinctArtists = new Set<string>();
+  for (const [trackId] of entries) {
+    const track = indexStore.getTrackById(trackId);
+    if (track) {
+      const a = (track.tags.artist ?? "").toLowerCase();
+      if (a) distinctArtists.add(a);
+    }
+  }
+
+  builder.setStats(totalPlays, distinctArtists.size);
+
+  if (totalPlays < MIN_TOTAL_PLAYS || distinctArtists.size < MIN_DISTINCT_ARTISTS) {
+    log.debug(`Personal: user ${userId} below thresholds, skipping`);
+    return { playlists: [], trace: builder.build() };
+  }
+
+  const generatedAt = new Date().toISOString();
+  const now = Date.now();
+  const playlists: PersonalPlaylist[] = [];
+
+  const variantBuilders: Array<{
+    variant: PersonalVariantId;
+    fn: () => { scored: ScoredTrack[]; notes: string[] };
+  }> = [
+    { variant: "discovered-this-year", fn: () => buildDiscoveredThisYear(playCounts, indexStore, now) },
+    { variant: "forgotten-favorites", fn: () => buildForgottenFavorites(playCounts, indexStore, now) },
+    { variant: "album-deep-cuts", fn: () => buildAlbumDeepCuts(playCounts, indexStore) }
+  ];
+
+  for (const { variant, fn } of variantBuilders) {
+    const { scored, notes } = fn();
+    const playlist = buildPlaylist(variant, scored, generatedAt);
+
+    const traceEntry: PersonalVariantTrace = {
+      variant,
+      playlistId: playlist?.id ?? null,
+      candidatePoolSize: scored.length,
+      finalTrackCount: playlist?.trackCount ?? 0,
+      ...(playlist ? {} : { rejection: "below-min-tracks" }),
+      ...(notes.length > 0 ? { notes } : {})
+    };
+    builder.recordVariant(traceEntry);
+
+    if (playlist) playlists.push(playlist);
+  }
+
+  return { playlists, trace: builder.build() };
+}
+
+// ── Storage ────────────────────────────────────────────────────────
+
+export async function savePersonalPlaylists(userId: string, playlists: PersonalPlaylist[]): Promise<void> {
+  const dir = userPersonalDir(userId);
+  await ensureDir(dir);
+
+  const existing = await fs.readdir(dir).catch(() => []);
+  for (const file of existing) {
+    if (file.endsWith(".json") && file !== "_meta.json" && file !== "_trace.json") {
+      await fs.unlink(path.join(dir, file)).catch(() => {});
+    }
+  }
+
+  for (const playlist of playlists) {
+    const fileName = `${playlist.variant}.json`;
+    await writeJsonAtomic(path.join(dir, fileName), playlist);
+  }
+
+  const meta: PersonalMeta = { lastGeneratedAt: new Date().toISOString() };
+  await writeJsonAtomic(userPersonalMetaPath(userId), meta);
+
+  log.info(`Saved ${playlists.length} personal playlist(s) for user ${userId}`);
+}
+
+export async function loadPersonalPlaylists(userId: string): Promise<PersonalPlaylist[]> {
+  const dir = userPersonalDir(userId);
+  await ensureDir(dir);
+
+  const files = await fs.readdir(dir).catch(() => []);
+  const playlists: PersonalPlaylist[] = [];
+
+  for (const file of files) {
+    if (!file.endsWith(".json") || file === "_meta.json" || file === "_trace.json") continue;
+    const data = await readJsonFile<PersonalPlaylist>(
+      path.join(dir, file),
+      null as unknown as PersonalPlaylist
+    );
+    if (data && data.id && data.trackIds) {
+      playlists.push(data);
+    }
+  }
+
+  // Stable order matching the in-code variant order, so the UI is consistent.
+  const ORDER: Record<PersonalVariantId, number> = {
+    "discovered-this-year": 0,
+    "forgotten-favorites": 1,
+    "album-deep-cuts": 2
+  };
+  return playlists.sort((a, b) => (ORDER[a.variant] ?? 99) - (ORDER[b.variant] ?? 99));
+}
+
+export async function getPersonalPlaylistById(
+  userId: string,
+  playlistId: string
+): Promise<PersonalPlaylist | null> {
+  const all = await loadPersonalPlaylists(userId);
+  return all.find((p) => p.id === playlistId) ?? null;
+}
+
+export async function savePersonalTrace(userId: string, trace: PersonalTrace): Promise<void> {
+  await ensureDir(userPersonalDir(userId));
+  await writeJsonAtomic(userPersonalTracePath(userId), trace);
+}
+
+export async function loadPersonalTrace(userId: string): Promise<PersonalTrace | null> {
+  const data = await readJsonFile<PersonalTrace>(
+    userPersonalTracePath(userId),
+    null as unknown as PersonalTrace
+  );
+  if (!data || typeof data !== "object" || !data.userId) return null;
+  return data;
+}
+
+// ── Regeneration ───────────────────────────────────────────────────
+
+export async function needsPersonalRegeneration(userId: string): Promise<boolean> {
+  const meta = await readJsonFile<PersonalMeta>(userPersonalMetaPath(userId), { lastGeneratedAt: "" });
+  if (!meta.lastGeneratedAt) return true;
+  const lastGenerated = new Date(meta.lastGeneratedAt).getTime();
+  if (isNaN(lastGenerated)) return true;
+  return Date.now() - lastGenerated > REGENERATION_INTERVAL_MS;
+}
+
+export async function regeneratePersonalPlaylists(
+  userId: string,
+  indexStore: IndexStore
+): Promise<PersonalPlaylist[]> {
+  log.info(`Regenerating personal playlists for user ${userId}...`);
+  const { playlists, trace } = await generatePersonalPlaylistsWithTrace(userId, indexStore);
+  await savePersonalPlaylists(userId, playlists);
+  await savePersonalTrace(userId, trace);
+
+  const variantSummary = trace.variants
+    .map((v) => `${v.variant}=${v.finalTrackCount}`)
+    .join(",");
+  log.info(
+    `personal: user=${userId} variants=${variantSummary} ` +
+      `playlists=${playlists.length} durationMs=${trace.durationMs}`
+  );
+  return playlists;
+}
+
+export async function checkAndRegeneratePersonalOnBoot(
+  userId: string,
+  indexStore: IndexStore
+): Promise<void> {
+  const shouldRegenerate = await needsPersonalRegeneration(userId);
+  if (!shouldRegenerate) {
+    const existing = await loadPersonalPlaylists(userId);
+    log.debug(`Personal playlists up to date for user ${userId} (${existing.length} playlist(s))`);
+    return;
+  }
+  await regeneratePersonalPlaylists(userId, indexStore);
+}

--- a/backend/src/services/playlists/playlistTrace.ts
+++ b/backend/src/services/playlists/playlistTrace.ts
@@ -18,9 +18,25 @@ export type SeedSkippedTrace = {
   reason: string;
 };
 
+export type ScoredTrackTrace = {
+  trackId: string;
+  artist: string;
+  score: number;
+  features: {
+    genreOverlap: number;
+    yearProximity: number;
+    libraryPopularity: number;
+    novelty: number;
+    albumOverlapWithSeed: number;
+  };
+  source?: string;
+  rejection?: string;
+};
+
 export type ForYouPlaylistTrace = {
   seed: string;
   playlistId: string | null;
+  playlistName?: string;
   profile: {
     genres: string[];
     minYear: number;
@@ -30,6 +46,8 @@ export type ForYouPlaylistTrace = {
   seedTrackCount: number;
   peerTrackCount: number;
   finalTrackIds: string[];
+  finalOrder?: ScoredTrackTrace[];
+  topRejections?: ScoredTrackTrace[];
   rejection?: string;
 };
 

--- a/backend/src/services/playlists/playlistTrace.ts
+++ b/backend/src/services/playlists/playlistTrace.ts
@@ -28,6 +28,7 @@ export type ScoredTrackTrace = {
     libraryPopularity: number;
     novelty: number;
     albumOverlapWithSeed: number;
+    recentSkipCount: number;
   };
   source?: string;
   rejection?: string;

--- a/backend/src/services/playlists/playlistTrace.ts
+++ b/backend/src/services/playlists/playlistTrace.ts
@@ -152,6 +152,60 @@ export class ForYouTraceBuilder {
   }
 }
 
+// ── Personal mix traces ────────────────────────────────────────────
+
+export type PersonalVariantId = "discovered-this-year" | "forgotten-favorites" | "album-deep-cuts";
+
+export type PersonalVariantTrace = {
+  variant: PersonalVariantId;
+  playlistId: string | null;
+  candidatePoolSize: number;
+  finalTrackCount: number;
+  rejection?: string;
+  notes?: string[];
+};
+
+export type PersonalTrace = {
+  generatedAt: string;
+  userId: string;
+  durationMs: number;
+  totalPlays: number;
+  distinctArtists: number;
+  variants: PersonalVariantTrace[];
+};
+
+export class PersonalTraceBuilder {
+  private readonly startedAt = Date.now();
+  private readonly userId: string;
+  private totalPlays = 0;
+  private distinctArtists = 0;
+  private readonly variants: PersonalVariantTrace[] = [];
+
+  constructor(userId: string) {
+    this.userId = userId;
+  }
+
+  setStats(totalPlays: number, distinctArtists: number): void {
+    this.totalPlays = totalPlays;
+    this.distinctArtists = distinctArtists;
+  }
+
+  recordVariant(entry: PersonalVariantTrace): void {
+    this.variants.push(entry);
+  }
+
+  build(): PersonalTrace {
+    return {
+      generatedAt: new Date().toISOString(),
+      userId: this.userId,
+      durationMs: Date.now() - this.startedAt,
+      totalPlays: this.totalPlays,
+      distinctArtists: this.distinctArtists,
+      variants: this.variants
+    };
+  }
+}
+
 export class AutoTraceBuilder {
   private readonly startedAt = Date.now();
   private totalCandidateTracks = 0;

--- a/backend/src/services/playlists/playlistTrace.ts
+++ b/backend/src/services/playlists/playlistTrace.ts
@@ -29,6 +29,7 @@ export type ScoredTrackTrace = {
     novelty: number;
     albumOverlapWithSeed: number;
     recentSkipCount: number;
+    embeddingSimilarity: number;
   };
   source?: string;
   rejection?: string;

--- a/backend/src/services/playlists/playlistTrace.ts
+++ b/backend/src/services/playlists/playlistTrace.ts
@@ -1,0 +1,172 @@
+/**
+ * Diagnostic traces for auto-generated playlists. Phase 0 of the playlist
+ * algorithm work: persist a structured record of every regeneration so we
+ * can tune subsequent phases against real data instead of guessing.
+ *
+ * Traces are written next to the playlist JSON files (`_trace.json`). They
+ * replace the previous trace on each regeneration; we only keep the latest.
+ */
+
+export type SeedCandidateTrace = {
+  artist: string;
+  score: number;
+  sources: string[];
+};
+
+export type SeedSkippedTrace = {
+  artist: string;
+  reason: string;
+};
+
+export type ForYouPlaylistTrace = {
+  seed: string;
+  playlistId: string | null;
+  profile: {
+    genres: string[];
+    minYear: number;
+    maxYear: number;
+  };
+  candidatePoolSize: number;
+  seedTrackCount: number;
+  peerTrackCount: number;
+  finalTrackIds: string[];
+  rejection?: string;
+};
+
+export type ForYouTrace = {
+  generatedAt: string;
+  userId: string;
+  durationMs: number;
+  totalPlays: number;
+  distinctArtists: number;
+  skipReason?: "below-min-plays" | "below-min-artists";
+  seedSelection: {
+    candidates: SeedCandidateTrace[];
+    chosen: string[];
+    skipped: SeedSkippedTrace[];
+  };
+  playlists: ForYouPlaylistTrace[];
+};
+
+export type AutoPlaylistGroupTrace = {
+  key: string;
+  genre: string;
+  decade: number;
+  trackCount: number;
+  selected: boolean;
+  rejection?: string;
+};
+
+export type AutoTrace = {
+  generatedAt: string;
+  durationMs: number;
+  totalCandidateTracks: number;
+  totalGroups: number;
+  qualifyingGroups: number;
+  generatedPlaylists: number;
+  groups: AutoPlaylistGroupTrace[];
+};
+
+/**
+ * Mutable accumulator passed through the For You pipeline. Centralizes
+ * the trace shape so callers don't need to know the JSON layout; they just
+ * call the recording methods at the right point in the pipeline.
+ */
+export class ForYouTraceBuilder {
+  private readonly startedAt = Date.now();
+  private readonly userId: string;
+  private totalPlays = 0;
+  private distinctArtists = 0;
+  private skipReason: ForYouTrace["skipReason"];
+  private readonly candidates: SeedCandidateTrace[] = [];
+  private readonly chosen: string[] = [];
+  private readonly skipped: SeedSkippedTrace[] = [];
+  private readonly playlists: ForYouPlaylistTrace[] = [];
+
+  constructor(userId: string) {
+    this.userId = userId;
+  }
+
+  setStats(totalPlays: number, distinctArtists: number): void {
+    this.totalPlays = totalPlays;
+    this.distinctArtists = distinctArtists;
+  }
+
+  setSkipReason(reason: NonNullable<ForYouTrace["skipReason"]>): void {
+    this.skipReason = reason;
+  }
+
+  recordSeedCandidate(entry: SeedCandidateTrace): void {
+    this.candidates.push(entry);
+  }
+
+  recordSeedChosen(artist: string): void {
+    this.chosen.push(artist);
+  }
+
+  recordSeedSkipped(artist: string, reason: string): void {
+    this.skipped.push({ artist, reason });
+  }
+
+  recordPlaylist(entry: ForYouPlaylistTrace): void {
+    this.playlists.push(entry);
+  }
+
+  build(): ForYouTrace {
+    return {
+      generatedAt: new Date().toISOString(),
+      userId: this.userId,
+      durationMs: Date.now() - this.startedAt,
+      totalPlays: this.totalPlays,
+      distinctArtists: this.distinctArtists,
+      ...(this.skipReason ? { skipReason: this.skipReason } : {}),
+      seedSelection: {
+        candidates: this.candidates,
+        chosen: this.chosen,
+        skipped: this.skipped
+      },
+      playlists: this.playlists
+    };
+  }
+}
+
+export class AutoTraceBuilder {
+  private readonly startedAt = Date.now();
+  private totalCandidateTracks = 0;
+  private totalGroups = 0;
+  private qualifyingGroups = 0;
+  private generatedPlaylists = 0;
+  private readonly groups: AutoPlaylistGroupTrace[] = [];
+
+  setTotalCandidateTracks(count: number): void {
+    this.totalCandidateTracks = count;
+  }
+
+  setTotalGroups(count: number): void {
+    this.totalGroups = count;
+  }
+
+  setQualifyingGroups(count: number): void {
+    this.qualifyingGroups = count;
+  }
+
+  setGeneratedPlaylists(count: number): void {
+    this.generatedPlaylists = count;
+  }
+
+  recordGroup(entry: AutoPlaylistGroupTrace): void {
+    this.groups.push(entry);
+  }
+
+  build(): AutoTrace {
+    return {
+      generatedAt: new Date().toISOString(),
+      durationMs: Date.now() - this.startedAt,
+      totalCandidateTracks: this.totalCandidateTracks,
+      totalGroups: this.totalGroups,
+      qualifyingGroups: this.qualifyingGroups,
+      generatedPlaylists: this.generatedPlaylists,
+      groups: this.groups
+    };
+  }
+}

--- a/backend/src/services/playlists/playlistTrace.ts
+++ b/backend/src/services/playlists/playlistTrace.ts
@@ -68,10 +68,14 @@ export type ForYouTrace = {
 
 export type AutoPlaylistGroupTrace = {
   key: string;
+  axis: "decade-genre" | "genre-tempo";
   genre: string;
+  /** 0 for genre-tempo axis groups. */
   decade: number;
+  tempo?: "slow" | "mid" | "driving" | "fast";
   trackCount: number;
   selected: boolean;
+  mosaicCoverCount?: number;
   rejection?: string;
 };
 

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -109,7 +109,7 @@ export function AuthenticatedApp({
     repeatMode, setRepeatMode,
     shuffleEnabled, setShuffleEnabled,
     recentTracks, requestTrackPlayback, replayRecentTrack,
-    recordTrackPlayed, removeTrackFromPlayback,
+    recordTrackPlayed, recordTrackSkipped, removeTrackFromPlayback,
     setSelectedTrack, resetAfterLogout
   } = usePlaybackState({ user, allTracksById, allTracks: allTracksLibrary.tracks, loadingAllTracks });
 
@@ -548,6 +548,7 @@ export function AuthenticatedApp({
           ? undefined
           : (options) => handleNavigateTrack("previous", options?.wrap ?? true),
         onTrackPlayed: recordTrackPlayed,
+        onTrackSkipped: recordTrackSkipped,
         transcodeMode,
         onTranscodeModeChange: setTranscodeMode,
         repeatMode,

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -18,6 +18,7 @@ import { usePlaybackState } from "./hooks/usePlaybackState";
 import { useRecentlyUploaded } from "./hooks/useRecentlyUploaded";
 import { useAutoPlaylists } from "./hooks/useAutoPlaylists";
 import { useForYouPlaylists } from "./hooks/useForYouPlaylists";
+import { usePersonalPlaylists } from "./hooks/usePersonalPlaylists";
 import { useRadioStation } from "./hooks/useRadioStation";
 
 type AuthenticatedAppProps = {
@@ -93,6 +94,7 @@ export function AuthenticatedApp({
 
   const { autoPlaylists, loading: loadingAutoPlaylists, refresh: refreshAutoPlaylists } = useAutoPlaylists();
   const { forYouPlaylists, loading: loadingForYouPlaylists, dismiss: dismissForYouPlaylist, regenerate: regenerateForYouPlaylists } = useForYouPlaylists();
+  const { personalPlaylists, loading: loadingPersonalPlaylists, regenerate: regeneratePersonalPlaylists } = usePersonalPlaylists();
 
   const allTracksById = useMemo(
     () => new Map(allTracksLibrary.tracks.map((track) => [track.id, track])),
@@ -389,7 +391,10 @@ export function AuthenticatedApp({
           forYouPlaylists,
           loadingForYouPlaylists,
           onDismissForYouPlaylist: dismissForYouPlaylist,
-          onRefreshForYouPlaylists: regenerateForYouPlaylists
+          onRefreshForYouPlaylists: regenerateForYouPlaylists,
+          personalPlaylists,
+          loadingPersonalPlaylists,
+          onRefreshPersonalPlaylists: regeneratePersonalPlaylists
         },
         artistsProps: {
           libraryMetadataError,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1041,6 +1041,13 @@ export async function reportTrackPlay(trackId: string): Promise<void> {
   });
 }
 
+export async function reportTrackSkip(trackId: string): Promise<void> {
+  await fetch(withApiBase(`/api/tracks/${encodeURIComponent(trackId)}/skip`), {
+    method: "POST",
+    credentials: "include"
+  });
+}
+
 export type PlayStatsResponse = {
   topTracks: Array<{ trackId: string; count: number; lastPlayedAt: string }>;
   topArtists: Array<{ artist: string; playCount: number }>;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -349,8 +349,14 @@ export async function getAlbumTracks(albumId: string): Promise<Track[]> {
   return payload.tracks;
 }
 
-export function coverPathUrl(relativePath: string): string {
-  const searchParams = new URLSearchParams({ path: relativePath });
+export function coverPathUrl(coverRef: string): string {
+  // Track.cover comes in two flavors: a relative file path (e.g. data/covers/foo.jpg)
+  // resolved through libraryMediaResolver, or a fully-formed /api/covers/<id> URL
+  // produced by coverService. Don't double-wrap the URL form.
+  if (coverRef.startsWith("/api/") || /^https?:\/\//.test(coverRef)) {
+    return withApiBase(coverRef);
+  }
+  const searchParams = new URLSearchParams({ path: coverRef });
   return withApiBase(`/api/covers/from-path?${searchParams.toString()}`);
 }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -5,6 +5,8 @@ import type {
   AutoPlaylistSummary,
   ForYouPlaylistDetail,
   ForYouPlaylistSummary,
+  PersonalPlaylistDetail,
+  PersonalPlaylistSummary,
   LibraryResponse,
   Playlist,
   RadioCreateResponse,
@@ -814,6 +816,25 @@ export async function dismissForYouPlaylist(playlistId: string): Promise<void> {
 
 export async function regenerateForYouPlaylists(): Promise<{ regenerated: number }> {
   return requestJson<{ regenerated: number }>("/api/playlists/for-you/regenerate", {
+    method: "POST"
+  });
+}
+
+export async function getPersonalPlaylists(): Promise<PersonalPlaylistSummary[]> {
+  const payload = await requestJson<{ playlists: PersonalPlaylistSummary[] }>("/api/playlists/personal");
+  return payload.playlists;
+}
+
+export async function getPersonalPlaylistDetail(
+  id: string
+): Promise<{ playlist: PersonalPlaylistDetail; tracks: Track[] }> {
+  return requestJson<{ playlist: PersonalPlaylistDetail; tracks: Track[] }>(
+    `/api/playlists/personal/${encodeURIComponent(id)}`
+  );
+}
+
+export async function regeneratePersonalPlaylists(): Promise<{ regenerated: number }> {
+  return requestJson<{ regenerated: number }>("/api/playlists/personal/regenerate", {
     method: "POST"
   });
 }

--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -28,6 +28,7 @@ type AudioPlayerProps = {
   onPrevious?: (options?: NavigateOptions) => Promise<void> | void;
   onNext?: (options?: NavigateOptions) => Promise<void> | void;
   onTrackPlayed?: (track: Track) => void;
+  onTrackSkipped?: (track: Track) => void;
   transcodeMode?: TranscodeMode;
   onTranscodeModeChange?: (mode: TranscodeMode) => void;
   repeatMode?: RepeatMode;
@@ -57,6 +58,7 @@ export function AudioPlayer({
   onPrevious,
   onNext,
   onTrackPlayed,
+  onTrackSkipped,
   transcodeMode = "original",
   onTranscodeModeChange,
   repeatMode = "off",
@@ -91,7 +93,7 @@ export function AudioPlayer({
     track, transcodeMode, onTranscodeModeChange,
     repeatMode, onRepeatModeChange,
     shuffleEnabled, onShuffleEnabledChange,
-    playRequestNonce, playRequestOffsetSec, onNext, onPrevious, onTrackPlayed
+    playRequestNonce, playRequestOffsetSec, onNext, onPrevious, onTrackPlayed, onTrackSkipped
   });
 
   const [showPlaylistPicker, setShowPlaylistPicker] = useState(false);

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -3,7 +3,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { AutoPlaylistSummary, ForYouPlaylistSummary, Playlist } from "../types";
+import type { AutoPlaylistSummary, ForYouPlaylistSummary, PersonalPlaylistSummary, Playlist } from "../types";
 import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
 
 function createPlaylist(input: {
@@ -46,7 +46,9 @@ const defaultProps = {
   forYouPlaylists: [] as ForYouPlaylistSummary[],
   loadingForYouPlaylists: false,
   onDismissForYouPlaylist: vi.fn().mockResolvedValue(undefined),
-  onHeartPlaylist: vi.fn().mockResolvedValue(undefined)
+  onHeartPlaylist: vi.fn().mockResolvedValue(undefined),
+  personalPlaylists: [] as PersonalPlaylistSummary[],
+  loadingPersonalPlaylists: false
 };
 
 describe("LibraryPlaylistSection", () => {

--- a/frontend/src/components/LibraryPlaylistSection.test.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.test.tsx
@@ -479,7 +479,6 @@ describe("LibraryPlaylistSection", () => {
 
     expect(screen.getByText("Made for you")).toBeTruthy();
     expect(screen.getByText("Because you listen to Pink Floyd")).toBeTruthy();
-    expect(screen.getByText("Pink Floyd")).toBeTruthy();
   });
 
   it("shows Made for you section with info message when empty", () => {

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -2,7 +2,14 @@ import { FormEvent, useState } from "react";
 
 import defaultCoverImage from "../assets/default-cover.png";
 import { coverPathUrl, coverUrl, getForYouPlaylistDetail, playlistCoverUrl } from "../api";
-import type { AutoPlaylistSummary, ForYouPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
+import type { AutoPlaylistSummary, ForYouPlaylistSummary, Playlist, PlaylistVisibility, TempoBucket, Track, User } from "../types";
+
+const TEMPO_HERO_LABEL: Record<TempoBucket, string> = {
+  slow: "Slow",
+  mid: "Mid",
+  driving: "Drive",
+  fast: "Fast"
+};
 
 export type LibraryPlaylistSectionProps = {
   availablePlaylists: Playlist[];
@@ -482,6 +489,12 @@ export function LibraryPlaylistSection({
               const [c1, c2, c3] = ap.colors ?? ["hsl(220, 60%, 50%)", "hsl(260, 60%, 50%)", "hsl(340, 60%, 50%)"];
               const angle = ap.gradientAngle ?? 135;
               const gradientStyle = { background: `linear-gradient(${angle}deg, ${c1}, ${c2}, ${c3})` };
+              const mosaic = ap.mosaicCovers ?? [];
+              const heroLabel = ap.axis === "genre-tempo" && ap.tempo
+                ? TEMPO_HERO_LABEL[ap.tempo]
+                : ap.decade % 100 === 0
+                  ? String(ap.decade)
+                  : `${ap.decade % 100}s`;
               return (
                 <div
                   key={ap.id}
@@ -492,8 +505,23 @@ export function LibraryPlaylistSection({
                   onKeyDown={(e) => { if (e.key === "Enter") onNavigateToPlaylist(ap.id); }}
                 >
                   <div className="group/cover relative aspect-square w-full overflow-hidden" style={gradientStyle}>
-                    <div className="flex h-full w-full flex-col items-center justify-center">
-                      <p className="font-display text-5xl font-extrabold text-white drop-shadow-md">{ap.decade % 100 === 0 ? ap.decade : `${ap.decade % 100}s`}</p>
+                    {mosaic.length > 0 ? (
+                      <div
+                        className={`absolute inset-0 grid ${mosaic.length === 1 ? "grid-cols-1" : "grid-cols-2"} ${mosaic.length <= 2 ? "grid-rows-1" : "grid-rows-2"}`}
+                      >
+                        {mosaic.slice(0, 4).map((cover, i) => (
+                          <img
+                            key={`${ap.id}-cover-${i}`}
+                            src={coverPathUrl(cover)}
+                            alt=""
+                            className="h-full w-full object-cover"
+                            loading="lazy"
+                          />
+                        ))}
+                      </div>
+                    ) : null}
+                    <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/20">
+                      <p className="font-display text-5xl font-extrabold text-white drop-shadow-md">{heroLabel}</p>
                       <p className="mt-1 text-xs font-medium text-white/80">{ap.genre}</p>
                     </div>
 

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -2,7 +2,7 @@ import { FormEvent, useState } from "react";
 
 import defaultCoverImage from "../assets/default-cover.png";
 import { coverPathUrl, coverUrl, getForYouPlaylistDetail, playlistCoverUrl } from "../api";
-import type { AutoPlaylistSummary, ForYouPlaylistSummary, Playlist, PlaylistVisibility, TempoBucket, Track, User } from "../types";
+import type { AutoPlaylistSummary, ForYouPlaylistSummary, PersonalPlaylistSummary, Playlist, PlaylistVisibility, TempoBucket, Track, User } from "../types";
 
 const TEMPO_HERO_LABEL: Record<TempoBucket, string> = {
   slow: "Slow",
@@ -30,6 +30,9 @@ export type LibraryPlaylistSectionProps = {
   loadingForYouPlaylists: boolean;
   onDismissForYouPlaylist: (playlistId: string) => Promise<void>;
   onRefreshForYouPlaylists?: () => Promise<{ regenerated: number }>;
+  personalPlaylists: PersonalPlaylistSummary[];
+  loadingPersonalPlaylists: boolean;
+  onRefreshPersonalPlaylists?: () => Promise<{ regenerated: number }>;
 };
 
 // ── Mosaic cover (compact) ─────────────────────────────────────────
@@ -238,7 +241,10 @@ export function LibraryPlaylistSection({
   forYouPlaylists,
   loadingForYouPlaylists,
   onDismissForYouPlaylist,
-  onRefreshForYouPlaylists
+  onRefreshForYouPlaylists,
+  personalPlaylists,
+  loadingPersonalPlaylists,
+  onRefreshPersonalPlaylists
 }: LibraryPlaylistSectionProps): JSX.Element {
   const [playlistName, setPlaylistName] = useState("");
   const [playlistDescription, setPlaylistDescription] = useState("");
@@ -471,6 +477,72 @@ export function LibraryPlaylistSection({
               />
             ))}
           </div>
+        </section>
+      ) : null}
+
+      {/* ── Personal Mixes ─────────────────────────────────────────── */}
+      {(loadingPersonalPlaylists || personalPlaylists.length > 0) ? (
+        <section className="rounded-xl border border-flaque-clay/60 bg-gradient-to-br from-white/85 to-flaque-cream/40 p-5 shadow-panel backdrop-blur-sm">
+          <div className="flex items-center justify-between">
+            <SectionHeader title="Personal Mixes" />
+            {!loadingPersonalPlaylists && personalPlaylists.length > 0 && onRefreshPersonalPlaylists ? (
+              <button
+                type="button"
+                className="rounded-md border border-flaque-clay/60 bg-white px-2.5 py-1 text-xs font-medium text-flaque-ink transition hover:bg-flaque-cream"
+                onClick={() => { void onRefreshPersonalPlaylists(); }}
+              >
+                Refresh
+              </button>
+            ) : null}
+          </div>
+          {loadingPersonalPlaylists ? (
+            <p className="mt-2 text-sm text-flaque-steel">Loading...</p>
+          ) : (
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {personalPlaylists.map((pp) => {
+                const [c1, c2, c3] = pp.colors ?? ["hsl(220, 60%, 50%)", "hsl(260, 60%, 50%)", "hsl(340, 60%, 50%)"];
+                const angle = pp.gradientAngle ?? 135;
+                const gradientStyle = { background: `linear-gradient(${angle}deg, ${c1}, ${c2}, ${c3})` };
+                const mosaic = pp.mosaicCovers ?? [];
+                return (
+                  <div
+                    key={pp.id}
+                    className="group relative flex cursor-pointer overflow-hidden rounded-2xl bg-white/85 shadow-sm transition hover:shadow-lg"
+                    onClick={() => onNavigateToPlaylist(pp.id)}
+                    role="link"
+                    tabIndex={0}
+                    onKeyDown={(e) => { if (e.key === "Enter") onNavigateToPlaylist(pp.id); }}
+                  >
+                    <div className="relative h-24 w-24 shrink-0 overflow-hidden" style={gradientStyle}>
+                      {mosaic.length > 0 ? (
+                        <div
+                          className={`absolute inset-0 grid ${mosaic.length === 1 ? "grid-cols-1" : "grid-cols-2"} ${mosaic.length <= 2 ? "grid-rows-1" : "grid-rows-2"}`}
+                        >
+                          {mosaic.slice(0, 4).map((cover, i) => (
+                            <img
+                              key={`${pp.id}-cover-${i}`}
+                              src={coverPathUrl(cover)}
+                              alt=""
+                              className="h-full w-full object-cover"
+                              loading="lazy"
+                            />
+                          ))}
+                        </div>
+                      ) : null}
+                      <div className="absolute inset-0 bg-black/30" />
+                    </div>
+                    <div className="flex min-w-0 flex-1 flex-col justify-center p-3">
+                      <p className="truncate text-sm font-semibold text-flaque-ink">{pp.name}</p>
+                      <p className="mt-0.5 line-clamp-2 text-xs text-flaque-steel">{pp.description}</p>
+                      <p className="mt-1 text-xs text-flaque-steel/80">
+                        {pp.trackCount} track{pp.trackCount !== 1 ? "s" : ""}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </section>
       ) : null}
 

--- a/frontend/src/components/LibraryPlaylistSection.tsx
+++ b/frontend/src/components/LibraryPlaylistSection.tsx
@@ -374,18 +374,19 @@ export function LibraryPlaylistSection({
       <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
         <div className="flex items-center justify-between">
           <SectionHeader title="Made for you" />
-          {!loadingForYouPlaylists && forYouPlaylists.length > 0 && (
+          {!loadingForYouPlaylists && onRefreshForYouPlaylists ? (
             <button
               type="button"
               className="text-xs text-flaque-steel hover:text-flaque-ink"
               onClick={() => { void onRefreshForYouPlaylists?.(); }}
               title="Refresh recommendations"
+              aria-label="Refresh recommendations"
             >
               <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
               </svg>
             </button>
-          )}
+          ) : null}
         </div>
         {loadingForYouPlaylists ? (
           <p className="mt-2 text-sm text-flaque-steel">Loading recommendations...</p>
@@ -410,14 +411,11 @@ export function LibraryPlaylistSection({
                         className="absolute inset-0 h-full w-full object-cover"
                         loading="lazy"
                       />
-                    ) : null}
-                    <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/30 px-3 text-center">
-                      <svg className="h-8 w-8 text-white drop-shadow" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-                          d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-                      </svg>
-                      <p className="mt-1 font-display text-sm font-bold leading-tight text-white drop-shadow">{fy.seedArtist}</p>
-                    </div>
+                    ) : (
+                      <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-flaque-cream to-flaque-clay/60 text-flaque-steel">
+                        <span className="font-display text-3xl">{fy.seedArtist.charAt(0).toUpperCase()}</span>
+                      </div>
+                    )}
 
                     {/* Play button overlay */}
                     <button
@@ -485,20 +483,24 @@ export function LibraryPlaylistSection({
         <section className="rounded-xl border border-flaque-clay/60 bg-gradient-to-br from-white/85 to-flaque-cream/40 p-5 shadow-panel backdrop-blur-sm">
           <div className="flex items-center justify-between">
             <SectionHeader title="Personal Mixes" />
-            {!loadingPersonalPlaylists && personalPlaylists.length > 0 && onRefreshPersonalPlaylists ? (
+            {!loadingPersonalPlaylists && onRefreshPersonalPlaylists ? (
               <button
                 type="button"
-                className="rounded-md border border-flaque-clay/60 bg-white px-2.5 py-1 text-xs font-medium text-flaque-ink transition hover:bg-flaque-cream"
+                className="text-xs text-flaque-steel hover:text-flaque-ink"
                 onClick={() => { void onRefreshPersonalPlaylists(); }}
+                title="Refresh personal mixes"
+                aria-label="Refresh personal mixes"
               >
-                Refresh
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
               </button>
             ) : null}
           </div>
           {loadingPersonalPlaylists ? (
             <p className="mt-2 text-sm text-flaque-steel">Loading...</p>
           ) : (
-            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="mt-4 grid grid-cols-3 gap-2.5 sm:grid-cols-4 lg:grid-cols-6">
               {personalPlaylists.map((pp) => {
                 const [c1, c2, c3] = pp.colors ?? ["hsl(220, 60%, 50%)", "hsl(260, 60%, 50%)", "hsl(340, 60%, 50%)"];
                 const angle = pp.gradientAngle ?? 135;
@@ -507,13 +509,13 @@ export function LibraryPlaylistSection({
                 return (
                   <div
                     key={pp.id}
-                    className="group relative flex cursor-pointer overflow-hidden rounded-2xl bg-white/85 shadow-sm transition hover:shadow-lg"
+                    className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl bg-white/85 shadow-sm transition hover:shadow-lg"
                     onClick={() => onNavigateToPlaylist(pp.id)}
                     role="link"
                     tabIndex={0}
                     onKeyDown={(e) => { if (e.key === "Enter") onNavigateToPlaylist(pp.id); }}
                   >
-                    <div className="relative h-24 w-24 shrink-0 overflow-hidden" style={gradientStyle}>
+                    <div className="group/cover relative aspect-square w-full overflow-hidden" style={gradientStyle}>
                       {mosaic.length > 0 ? (
                         <div
                           className={`absolute inset-0 grid ${mosaic.length === 1 ? "grid-cols-1" : "grid-cols-2"} ${mosaic.length <= 2 ? "grid-rows-1" : "grid-rows-2"}`}
@@ -529,12 +531,30 @@ export function LibraryPlaylistSection({
                           ))}
                         </div>
                       ) : null}
-                      <div className="absolute inset-0 bg-black/30" />
+                      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/75 via-black/40 to-transparent px-3 pb-2 pt-6 text-center">
+                        <p
+                          className="line-clamp-2 font-display text-sm font-bold leading-tight drop-shadow"
+                          style={{ color: "#ffffff" }}
+                        >
+                          {pp.name}
+                        </p>
+                      </div>
+
+                      {/* Play button overlay */}
+                      <button
+                        type="button"
+                        className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition group-hover/cover:bg-black/35 group-hover/cover:opacity-100"
+                        onClick={(e) => { e.stopPropagation(); onNavigateToPlaylist(pp.id); }}
+                        aria-label={`Open ${pp.name}`}
+                      >
+                        <svg className="h-10 w-10 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
+                          <path d="M8 6v12l10-6-10-6z" />
+                        </svg>
+                      </button>
                     </div>
-                    <div className="flex min-w-0 flex-1 flex-col justify-center p-3">
-                      <p className="truncate text-sm font-semibold text-flaque-ink">{pp.name}</p>
-                      <p className="mt-0.5 line-clamp-2 text-xs text-flaque-steel">{pp.description}</p>
-                      <p className="mt-1 text-xs text-flaque-steel/80">
+                    <div className="p-2">
+                      <p className="line-clamp-2 text-xs text-flaque-steel">{pp.description}</p>
+                      <p className="mt-0.5 text-xs text-flaque-steel/80">
                         {pp.trackCount} track{pp.trackCount !== 1 ? "s" : ""}
                       </p>
                     </div>
@@ -593,8 +613,18 @@ export function LibraryPlaylistSection({
                       </div>
                     ) : null}
                     <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/20">
-                      <p className="font-display text-5xl font-extrabold text-white drop-shadow-md">{heroLabel}</p>
-                      <p className="mt-1 text-xs font-medium text-white/80">{ap.genre}</p>
+                      <p
+                        className="font-display text-5xl font-extrabold drop-shadow-md"
+                        style={{ color: "#ffffff" }}
+                      >
+                        {heroLabel}
+                      </p>
+                      <p
+                        className="mt-1 text-xs font-medium"
+                        style={{ color: "rgba(255, 255, 255, 0.8)" }}
+                      >
+                        {ap.genre}
+                      </p>
                     </div>
 
                     {/* Play button overlay */}

--- a/frontend/src/components/PersonalPlaylistDetailView.tsx
+++ b/frontend/src/components/PersonalPlaylistDetailView.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { coverPathUrl, getPersonalPlaylistDetail } from "../api";
+import { usePlaylistDetailPlayback } from "../hooks/usePlaylistDetailPlayback";
+import type { PersonalPlaylistDetail, Playlist, Track } from "../types";
+import { formatDurationCompact } from "../utils/format";
+import { PlaylistTrackList } from "./PlaylistTrackList";
+
+export type PersonalPlaylistDetailViewProps = {
+  playlistId: string;
+  allTracksById: Map<string, Track>;
+  onBack: () => void;
+  onPlayTrack: (playlist: Playlist, options?: { shuffle?: boolean }) => void;
+};
+
+export function PersonalPlaylistDetailView({
+  playlistId,
+  allTracksById,
+  onBack,
+  onPlayTrack
+}: PersonalPlaylistDetailViewProps): JSX.Element {
+  const [detail, setDetail] = useState<PersonalPlaylistDetail | null>(null);
+  const [detailTracks, setDetailTracks] = useState<Track[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    getPersonalPlaylistDetail(playlistId)
+      .then((result) => {
+        setDetail(result.playlist);
+        setDetailTracks(result.tracks);
+      })
+      .catch(() => {
+        setDetail(null);
+        setDetailTracks([]);
+      })
+      .finally(() => setLoading(false));
+  }, [playlistId]);
+
+  const tracks = useMemo(() => {
+    if (!detail) return detailTracks;
+    return detail.trackIds
+      .map((id) => detailTracks.find((t) => t.id === id) ?? allTracksById.get(id))
+      .filter((t): t is Track => t !== undefined);
+  }, [detail, detailTracks, allTracksById]);
+
+  const totalDuration = useMemo(() => tracks.reduce((sum, t) => sum + t.duration, 0), [tracks]);
+
+  const syntheticPlaylist = useMemo<Playlist | null>(() => {
+    if (!detail) return null;
+    return {
+      id: detail.id,
+      name: detail.name,
+      authorId: "system",
+      visibility: "public",
+      trackIds: tracks.map((t) => t.id),
+      description: detail.description,
+      cover: null,
+      hearts: [],
+      heartCount: 0,
+      listenCount: 0,
+      collaborators: []
+    };
+  }, [detail, tracks]);
+
+  const { handlePlayAll, handleShufflePlay, handlePlayFromTrack } = usePlaylistDetailPlayback({
+    playlist: syntheticPlaylist,
+    tracks,
+    onPlay: onPlayTrack
+  });
+
+  if (loading) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <BackButton onClick={onBack} />
+        <p className="text-sm text-flaque-steel">Loading...</p>
+      </section>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <section className="m-4 rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <BackButton onClick={onBack} />
+        <p className="text-sm text-flaque-steel">Personal playlist not found.</p>
+      </section>
+    );
+  }
+
+  const [c1, c2, c3] = detail.colors ?? ["hsl(220, 60%, 50%)", "hsl(260, 60%, 50%)", "hsl(340, 60%, 50%)"];
+  const angle = detail.gradientAngle ?? 135;
+  const gradientStyle = { background: `linear-gradient(${angle}deg, ${c1}, ${c2}, ${c3})` };
+  const mosaic = detail.mosaicCovers ?? [];
+
+  return (
+    <section className="m-4 space-y-4">
+      <BackButton onClick={onBack} />
+
+      <div className="rounded-2xl p-5">
+        <div className="flex flex-col gap-5 sm:flex-row">
+          <div className="group relative h-48 w-48 shrink-0 self-center overflow-hidden rounded-2xl sm:self-start" style={gradientStyle}>
+            {mosaic.length > 0 ? (
+              <div
+                className={`absolute inset-0 grid ${mosaic.length === 1 ? "grid-cols-1" : "grid-cols-2"} ${mosaic.length <= 2 ? "grid-rows-1" : "grid-rows-2"}`}
+              >
+                {mosaic.slice(0, 4).map((cover, i) => (
+                  <img
+                    key={`${detail.id}-cover-${i}`}
+                    src={coverPathUrl(cover)}
+                    alt=""
+                    className="h-full w-full object-cover"
+                    loading="lazy"
+                  />
+                ))}
+              </div>
+            ) : null}
+            <div className="absolute inset-0 bg-black/30" />
+            <button
+              type="button"
+              className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/0 opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100"
+              onClick={handlePlayAll}
+              aria-label={`Play ${detail.name}`}
+            >
+              <svg className="h-12 w-12 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
+                <path d="M8 6v12l10-6-10-6z" />
+              </svg>
+            </button>
+          </div>
+
+          <div className="flex min-w-0 flex-1 flex-col">
+            <h2 className="font-display text-2xl text-flaque-ink">{detail.name}</h2>
+            {detail.description ? (
+              <p className="mt-1 text-sm text-flaque-steel">{detail.description}</p>
+            ) : null}
+
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-flaque-steel">
+              <span className="rounded-full bg-flaque-sand/50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-flaque-ink/70">
+                Personal mix
+              </span>
+              <span>{detail.trackCount} track{detail.trackCount !== 1 ? "s" : ""}</span>
+              {totalDuration > 0 ? <span>{formatDurationCompact(totalDuration)}</span> : null}
+              <span>Generated {new Date(detail.generatedAt).toLocaleDateString()}</span>
+            </div>
+
+            <div className="mt-auto flex flex-wrap items-center gap-2 pt-4">
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl bg-flaque-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black"
+                onClick={handlePlayAll}
+              >
+                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+                Play all
+              </button>
+
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-xl border border-flaque-clay px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream"
+                onClick={handleShufflePlay}
+              >
+                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+                  <path d="M16 3h5v5" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M4 20l8-8" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M21 3l-7 7" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M4 4l6 6" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M15 16l2 2" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                Shuffle
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <PlaylistTrackList tracks={tracks} onTrackPlay={handlePlayFromTrack} />
+    </section>
+  );
+}
+
+function BackButton({ onClick }: { onClick: () => void }): JSX.Element {
+  return (
+    <button
+      type="button"
+      className="mb-4 flex items-center gap-1 text-sm text-flaque-steel transition hover:text-flaque-ink"
+      onClick={onClick}
+    >
+      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+      </svg>
+      Back to playlists
+    </button>
+  );
+}

--- a/frontend/src/components/PlaylistsSection.test.tsx
+++ b/frontend/src/components/PlaylistsSection.test.tsx
@@ -55,6 +55,8 @@ function baseProps(overrides: Partial<PlaylistsSectionProps> = {}): PlaylistsSec
     forYouPlaylists: [],
     loadingForYouPlaylists: false,
     onDismissForYouPlaylist: vi.fn(),
+    personalPlaylists: [],
+    loadingPersonalPlaylists: false,
     ...overrides
   };
 }

--- a/frontend/src/components/PlaylistsSection.tsx
+++ b/frontend/src/components/PlaylistsSection.tsx
@@ -1,7 +1,8 @@
-import type { AutoPlaylistSummary, ForYouPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
+import type { AutoPlaylistSummary, ForYouPlaylistSummary, PersonalPlaylistSummary, Playlist, PlaylistVisibility, Track, User } from "../types";
 import { AutoPlaylistDetailView } from "./AutoPlaylistDetailView";
 import { ForYouPlaylistDetailView } from "./ForYouPlaylistDetailView";
 import { LibraryPlaylistSection } from "./LibraryPlaylistSection";
+import { PersonalPlaylistDetailView } from "./PersonalPlaylistDetailView";
 import { PlaylistDetailView } from "./PlaylistDetailView";
 
 export type PlaylistsSectionProps = {
@@ -24,6 +25,9 @@ export type PlaylistsSectionProps = {
   loadingForYouPlaylists: boolean;
   onDismissForYouPlaylist: (playlistId: string) => Promise<void>;
   onRefreshForYouPlaylists?: () => Promise<{ regenerated: number }>;
+  personalPlaylists: PersonalPlaylistSummary[];
+  loadingPersonalPlaylists: boolean;
+  onRefreshPersonalPlaylists?: () => Promise<{ regenerated: number }>;
 };
 
 export function PlaylistsSection({
@@ -45,7 +49,10 @@ export function PlaylistsSection({
   forYouPlaylists,
   loadingForYouPlaylists,
   onDismissForYouPlaylist,
-  onRefreshForYouPlaylists
+  onRefreshForYouPlaylists,
+  personalPlaylists,
+  loadingPersonalPlaylists,
+  onRefreshPersonalPlaylists
 }: PlaylistsSectionProps): JSX.Element {
   if (playlistDetailId && playlistDetailId.startsWith("for-you:")) {
     return (
@@ -62,6 +69,17 @@ export function PlaylistsSection({
   if (playlistDetailId && playlistDetailId.startsWith("auto:")) {
     return (
       <AutoPlaylistDetailView
+        playlistId={playlistDetailId}
+        allTracksById={allTracksById}
+        onBack={() => onPlaylistDetailNavigate(null)}
+        onPlayTrack={onPlayPlaylist}
+      />
+    );
+  }
+
+  if (playlistDetailId && playlistDetailId.startsWith("personal:")) {
+    return (
+      <PersonalPlaylistDetailView
         playlistId={playlistDetailId}
         allTracksById={allTracksById}
         onBack={() => onPlaylistDetailNavigate(null)}
@@ -110,6 +128,9 @@ export function PlaylistsSection({
       loadingForYouPlaylists={loadingForYouPlaylists}
       onDismissForYouPlaylist={onDismissForYouPlaylist}
       onRefreshForYouPlaylists={onRefreshForYouPlaylists}
+      personalPlaylists={personalPlaylists}
+      loadingPersonalPlaylists={loadingPersonalPlaylists}
+      onRefreshPersonalPlaylists={onRefreshPersonalPlaylists}
     />
   );
 }

--- a/frontend/src/hooks/useAudioPlayback.test.tsx
+++ b/frontend/src/hooks/useAudioPlayback.test.tsx
@@ -1,0 +1,89 @@
+/* @vitest-environment happy-dom */
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useAudioPlayback } from "./useAudioPlayback";
+import type { Track } from "../types";
+
+function makeTrack(overrides: Partial<Track> & { id: string }): Track {
+  return {
+    id: overrides.id,
+    owner: "u",
+    path: `${overrides.id}.mp3`,
+    duration: 180,
+    mimeType: "audio/mpeg",
+    codec: "mp3",
+    tags: {},
+    cover: null,
+    ...overrides
+  } as Track;
+}
+
+function mountHook(initialTrack: Track | null, onTrackSkipped: (t: Track) => void) {
+  const result = renderHook(
+    ({ track }: { track: Track | null }) =>
+      useAudioPlayback({
+        track,
+        transcodeMode: "original",
+        repeatMode: "off",
+        shuffleEnabled: false,
+        playRequestNonce: 0,
+        onTrackSkipped
+      }),
+    { initialProps: { track: initialTrack } }
+  );
+
+  // Stand in for a real HTMLAudioElement. The hook calls .load()/.play()/etc.;
+  // returning a resolved promise from play() avoids unhandled rejections.
+  const fakeAudio = {
+    load: vi.fn(),
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    paused: true,
+    currentTime: 0,
+    duration: 0,
+    volume: 1,
+    muted: false
+  };
+  result.result.current.audioRef.current = fakeAudio as unknown as HTMLAudioElement;
+  return result;
+}
+
+describe("useAudioPlayback skip detection", () => {
+  it("does not fire onTrackSkipped when transitioning track → null → new track", async () => {
+    const onTrackSkipped = vi.fn();
+    const trackA = makeTrack({ id: "a", duration: 200 });
+    const trackB = makeTrack({ id: "b", duration: 200 });
+
+    const { rerender, result } = mountHook(null, onTrackSkipped);
+
+    // First, set track to A so previousTrackRef is populated by the effect.
+    await act(async () => {
+      rerender({ track: trackA });
+    });
+
+    // Simulate a few seconds of playback so currentTimeRef is non-zero —
+    // otherwise the `elapsed > 0` guard would mask the bug.
+    await act(async () => {
+      result.current.handleAudioTimeUpdate({
+        currentTarget: { currentTime: 5 }
+      } as unknown as React.SyntheticEvent<HTMLAudioElement>);
+    });
+
+    // Now clear the queue (track → null). The previous-track ref should be
+    // dropped here so the next change doesn't fire a skip with stale data.
+    await act(async () => {
+      rerender({ track: null });
+    });
+
+    // Some time later, the user starts a different track. Without the fix
+    // this call sees previousTrack=A, currentTimeRef=0, and emits a bogus
+    // skip event for A.
+    await act(async () => {
+      rerender({ track: trackB });
+    });
+
+    expect(onTrackSkipped).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useAudioPlayback.test.tsx
+++ b/frontend/src/hooks/useAudioPlayback.test.tsx
@@ -8,7 +8,6 @@ import type { Track } from "../types";
 
 function makeTrack(overrides: Partial<Track> & { id: string }): Track {
   return {
-    id: overrides.id,
     owner: "u",
     path: `${overrides.id}.mp3`,
     duration: 180,

--- a/frontend/src/hooks/useAudioPlayback.ts
+++ b/frontend/src/hooks/useAudioPlayback.ts
@@ -134,7 +134,15 @@ export function useAudioPlayback({
   // ── Track change: reset and autoplay ──────────────────────────────────
   useEffect(() => {
     const audioElement = audioRef.current;
-    if (!audioElement || !track) {
+    if (!audioElement) {
+      return;
+    }
+    if (!track) {
+      // Queue cleared. Drop the previous-track reference so we don't fire a
+      // bogus skip when the user later starts a new track.
+      previousTrackRef.current = null;
+      endedNaturallyRef.current = false;
+      currentTimeRef.current = 0;
       return;
     }
 

--- a/frontend/src/hooks/useAudioPlayback.ts
+++ b/frontend/src/hooks/useAudioPlayback.ts
@@ -16,6 +16,8 @@ type NavigateOptions = {
 };
 
 const PLAYER_VOLUME_STORAGE_KEY = "flaque_player_volume_v1";
+const SKIP_TIME_THRESHOLD_SECONDS = 30;
+const SKIP_RATIO_THRESHOLD = 0.5;
 
 function isFlacTrack(track: Track): boolean {
   return (
@@ -55,6 +57,7 @@ type UseAudioPlaybackInput = {
   onNext?: (options?: NavigateOptions) => Promise<void> | void;
   onPrevious?: (options?: NavigateOptions) => Promise<void> | void;
   onTrackPlayed?: (track: Track) => void;
+  onTrackSkipped?: (track: Track) => void;
 };
 
 export type AudioPlaybackState = {
@@ -95,7 +98,8 @@ export function useAudioPlayback({
   playRequestOffsetSec = 0,
   onNext,
   onPrevious,
-  onTrackPlayed
+  onTrackPlayed,
+  onTrackSkipped
 }: UseAudioPlaybackInput): AudioPlaybackState {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const autoplayOnTrackChangeRef = useRef(true);
@@ -107,6 +111,8 @@ export function useAudioPlayback({
   const qualitySwapSnapshotTimeRef = useRef<number | null>(null);
   const qualitySwapShouldPlayRef = useRef<boolean | null>(null);
   const currentTimeRef = useRef(0);
+  const previousTrackRef = useRef<Track | null>(null);
+  const endedNaturallyRef = useRef(false);
 
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
@@ -131,6 +137,18 @@ export function useAudioPlayback({
     if (!audioElement || !track) {
       return;
     }
+
+    const previousTrack = previousTrackRef.current;
+    if (previousTrack && previousTrack.id !== track.id && !endedNaturallyRef.current) {
+      const elapsed = currentTimeRef.current;
+      const total = previousTrack.duration || 0;
+      const ratio = total > 0 ? elapsed / total : 0;
+      if (elapsed > 0 && elapsed < SKIP_TIME_THRESHOLD_SECONDS && ratio < SKIP_RATIO_THRESHOLD) {
+        onTrackSkipped?.(previousTrack);
+      }
+    }
+    endedNaturallyRef.current = false;
+    previousTrackRef.current = track;
 
     pendingRestoreTimeRef.current = null;
     pendingRestoreShouldPlayRef.current = false;
@@ -362,6 +380,8 @@ export function useAudioPlayback({
     if (!audioElement) {
       return;
     }
+
+    endedNaturallyRef.current = true;
 
     if (repeatMode === "one") {
       audioElement.currentTime = 0;

--- a/frontend/src/hooks/usePersonalPlaylists.ts
+++ b/frontend/src/hooks/usePersonalPlaylists.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+
+import { getPersonalPlaylists, regeneratePersonalPlaylists } from "../api";
+import type { PersonalPlaylistSummary } from "../types";
+import { useQuery } from "./useQuery";
+
+type UsePersonalPlaylistsResult = {
+  personalPlaylists: PersonalPlaylistSummary[];
+  loading: boolean;
+  refresh: () => void;
+  regenerate: () => Promise<{ regenerated: number }>;
+};
+
+const EMPTY: PersonalPlaylistSummary[] = [];
+
+export function usePersonalPlaylists(): UsePersonalPlaylistsResult {
+  const fetcher = useCallback(() => getPersonalPlaylists(), []);
+  const { data, loading, refresh, setData } = useQuery<PersonalPlaylistSummary[]>(fetcher, EMPTY);
+
+  const regenerate = useCallback(async () => {
+    const result = await regeneratePersonalPlaylists();
+    const updated = await getPersonalPlaylists();
+    setData(updated);
+    return result;
+  }, [setData]);
+
+  return { personalPlaylists: data, loading, refresh, regenerate };
+}

--- a/frontend/src/hooks/usePlaybackState.ts
+++ b/frontend/src/hooks/usePlaybackState.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
 
-import { reportTrackPlay } from "../api";
+import { reportTrackPlay, reportTrackSkip } from "../api";
 import type { RepeatMode, TranscodeMode } from "../components/AudioPlayer";
 import type { Track, User } from "../types";
 import { isTrackLike, parseStoredQueueSnapshot, readShuffleMode, readTranscodeMode, type StoredQueueSnapshot } from "../utils/appUtils";
@@ -33,6 +33,7 @@ type UsePlaybackStateResult = {
   requestTrackPlayback: (track: Track, queueSource?: Track[], options?: { startOffsetSec?: number }) => void;
   replayRecentTrack: (track: Track) => void;
   recordTrackPlayed: (track: Track) => void;
+  recordTrackSkipped: (track: Track) => void;
   removeTrackFromPlayback: (trackId: string) => void;
   setSelectedTrack: Dispatch<SetStateAction<Track | null>>;
   resetAfterLogout: () => void;
@@ -259,6 +260,11 @@ export function usePlaybackState({
     void reportTrackPlay(track.id).catch(() => {});
   }, []);
 
+  const recordTrackSkipped = useCallback((track: Track): void => {
+    if (track.owner === "radio") return;
+    void reportTrackSkip(track.id).catch(() => {});
+  }, []);
+
   const removeTrackFromPlayback = useCallback((trackId: string): void => {
     if (selectedTrackRefreshed?.id === trackId) {
       setSelectedTrack(null);
@@ -290,6 +296,7 @@ export function usePlaybackState({
     requestTrackPlayback,
     replayRecentTrack,
     recordTrackPlayed,
+    recordTrackSkipped,
     removeTrackFromPlayback,
     setSelectedTrack,
     resetAfterLogout

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -108,15 +108,23 @@ export type RadioQueueResponse = {
   } | null;
 };
 
+export type AutoAxis = "decade-genre" | "genre-tempo";
+
+export type TempoBucket = "slow" | "mid" | "driving" | "fast";
+
 export type AutoPlaylistSummary = {
   id: string;
   name: string;
   genre: string;
   decade: number;
+  axis?: AutoAxis;
+  tempo?: TempoBucket;
   trackCount: number;
   generatedAt: string;
   colors?: [string, string, string];
   gradientAngle?: number;
+  /** Up to 4 cover paths (relative under the data dir). Empty/missing → render gradient. */
+  mosaicCovers?: string[];
 };
 
 export type AutoPlaylistDetail = AutoPlaylistSummary & {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -131,6 +131,24 @@ export type AutoPlaylistDetail = AutoPlaylistSummary & {
   trackIds: string[];
 };
 
+export type PersonalVariantId = "discovered-this-year" | "forgotten-favorites" | "album-deep-cuts";
+
+export type PersonalPlaylistSummary = {
+  id: string;
+  variant: PersonalVariantId;
+  name: string;
+  description: string;
+  trackCount: number;
+  generatedAt: string;
+  colors?: [string, string, string];
+  gradientAngle?: number;
+  mosaicCovers?: string[];
+};
+
+export type PersonalPlaylistDetail = PersonalPlaylistSummary & {
+  trackIds: string[];
+};
+
 export type ForYouPlaylistSummary = {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary

Multi-phase rework of the auto-generated playlist pipeline. Each phase landed as its own commit on this branch:

- **Trace observability** — every regeneration writes a `_trace.json` next to the playlist data so we can tune later phases against real signals.
- **For-you rank-based generation** — multi-source seeds (top artists, album-deep, label, year fallback) ranked on genre overlap, year proximity, library popularity, novelty, and album-overlap penalty.
- **Auto playlists** — added a tempo axis (slow / mid / driving / fast), multi-genre presence, and mosaic covers.
- **Personal Mixes** — three file-based per-user variants: discovered-this-year, forgotten-favorites, album-deep-cuts.
- **Skip tracking** — `<30s elapsed AND <50% played AND not natural end` flagged as skip, used as a negative ranker signal and as a hard filter.
- **Audio embeddings** — 32-dim MFCC + spectral/temporal feature vector per track (ffmpeg → 16 kHz mono PCM → DSP pipeline), stored as a sidecar JSON. Cosine similarity to the seed mean is fed into the ranker.

The final commit is a pre-merge polish round covering correctness bugs, determinism, perf, and visual coherence — see the commit message for the full list.

## Operational notes

- Bumped `EMBEDDING_VERSION` from 1 → 2 to fix a feature-scaling bug (centroid/rolloff in Hz drowned MFCCs under the final L2 norm). On first boot the backfill will recompute every existing sidecar — one-time CPU/IO spike, capped to 2 concurrent ffmpeg processes.
- Auto playlist regeneration is now deterministic: same input → same playlists, colors, gradient angle. Existing on-disk playlists keep their old random colors until next regen.
- `SKIP_HARD_FILTER_THRESHOLD` raised 3 → 5; tracks at 3-4 skips are now scored (heavily penalized via the soft cap) instead of hard-filtered.

## Test plan

- [x] Backend: 406/406 tests pass (`vitest run` in `backend/`)
- [x] Frontend: 152/152 tests pass (`vitest run` in `frontend/`)
- [x] Both sides typecheck clean (`tsc --noEmit`)
- [x] New regression tests added for: auto-playlist determinism, album-key collision, skip-detection ref leak. Each verified to fail when the corresponding fix is reverted.
- [x] Manual smoke-test: regenerate Personal Mixes, hover a tile (album art shows, white title overlay readable, refresh button visible)
- [x] Manual smoke-test: For-You tile renders artist photo cleanly with no title overlay; monogram fallback when photo missing
- [x] Manual smoke-test: Auto playlists regenerate with stable colors across runs
- [x] Manual smoke-test: clear queue mid-track, then start a new track — no spurious skip recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)