### PR TITLE
feat(library): library view polish, multi-artist handling, OS media integration

### DIFF
--- a/backend/src/api/libraryRoutes.ts
+++ b/backend/src/api/libraryRoutes.ts
@@ -550,9 +550,13 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       const filter = readFilter(req.query as Record<string, unknown>);
       const indexedTracks = selectIndexedTracks(indexStore, { owner: filter.owner }, ownerNamesById);
       const tracksWithOwnerNames = mapTrackOwners(indexedTracks, ownerNamesById);
-      const tracksForArtist = tracksWithOwnerNames.filter(
-        (track) => getTrackArtistDirectorySegment(track) === normalizedArtist
-      );
+      const tracksForArtist = tracksWithOwnerNames.filter((track) => {
+        if (getTrackArtistDirectorySegment(track) === normalizedArtist) {
+          return true;
+        }
+        const primaryArtist = getTrackArtistName(track)?.trim().toLowerCase();
+        return Boolean(primaryArtist) && primaryArtist === normalizedArtist;
+      });
       const tracks = filterTracks(tracksForArtist, { owner: filter.owner, q: filter.q });
       const albums = await attachCollaborativeAlbumCovers(tracks, "year-desc");
       res.json({ total: tracks.length, artist: normalizedArtist, albums });

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -6,7 +6,7 @@ import type { ConfigSection } from "./components/ConfigView";
 import type { Track, User } from "./types";
 import type { LibrarySection } from "./types/library";
 import { navigateTo, normalizeText, sortAlbumTracksByNumber, type ViewName } from "./utils/appUtils";
-import { getTrackDisplayAlbum, getTrackDisplayArtist } from "./utils/tracks";
+import { getTrackDisplayAlbum, getTrackPrimaryArtist } from "./utils/tracks";
 import { useAdminUsers } from "./hooks/useAdminUsers";
 import { useAppNotice } from "./hooks/useAppNotice";
 import { useDocumentTitle } from "./hooks/useDocumentTitle";
@@ -247,7 +247,7 @@ export function AuthenticatedApp({
       return;
     }
 
-    const artistName = getTrackDisplayArtist(selectedTrackRefreshed);
+    const artistName = getTrackPrimaryArtist(selectedTrackRefreshed);
     if (!artistName) {
       return;
     }
@@ -294,7 +294,7 @@ export function AuthenticatedApp({
       return;
     }
 
-    const artistName = getTrackDisplayArtist(selectedTrackRefreshed);
+    const artistName = getTrackPrimaryArtist(selectedTrackRefreshed);
     const targetName = normalizeText(albumName);
     const targetArtist = normalizeText(artistName);
     const matchAlbum = (name: string, artist?: string): boolean => {

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -505,7 +505,21 @@ export function AuthenticatedApp({
           hasMore: paginatedHasMore,
           sentinelRef: paginatedSentinelRef,
           currentTrackId: selectedTrackRefreshed?.id,
-          onTrackSelect: (track) => requestTrackPlaybackWithStatus(track, paginatedTracks),
+          // Queue is the full filtered library; pagination only affects rendering.
+          onTrackSelect: (track) => requestTrackPlaybackWithStatus(track, library.tracks),
+          onPlayLibrary: library.tracks.length > 0
+            ? () => {
+              setShuffleEnabled(false);
+              requestTrackPlaybackWithStatus(library.tracks[0]!, library.tracks);
+            }
+            : undefined,
+          onShuffleLibrary: library.tracks.length > 0
+            ? () => {
+              setShuffleEnabled(true);
+              const startIndex = Math.floor(Math.random() * library.tracks.length);
+              requestTrackPlaybackWithStatus(library.tracks[startIndex]!, library.tracks);
+            }
+            : undefined,
           playlists: manageablePlaylists,
           onAddTrackToPlaylist: handleAddTrackToPlaylist
         }

--- a/frontend/src/components/Coverflow.css
+++ b/frontend/src/components/Coverflow.css
@@ -43,7 +43,6 @@
   margin: 0 auto;
   padding: calc(var(--cover-size) / 2.4) 0;
   position: relative;
-  perspective: 40em;
   scroll-snap-type: x mandatory;
   scrollbar-width: thin;
 }
@@ -68,7 +67,7 @@
 .cover-transform {
   transform-style: preserve-3d;
   will-change: transform;
-  transform: translateX(-100%) rotateY(-45deg);
+  transform: perspective(40em) translateX(-100%) rotateY(-45deg);
 }
 
 .cover-transform img {

--- a/frontend/src/components/Coverflow.tsx
+++ b/frontend/src/components/Coverflow.tsx
@@ -54,7 +54,7 @@ function coverTransform(progress: number): string {
     s = 1;
   }
 
-  return `translateX(${tx.toFixed(1)}%) rotateY(${ry.toFixed(1)}deg) translateZ(${tz.toFixed(2)}em) scale(${s.toFixed(3)})`;
+  return `perspective(40em) translateX(${tx.toFixed(1)}%) rotateY(${ry.toFixed(1)}deg) translateZ(${tz.toFixed(2)}em) scale(${s.toFixed(3)})`;
 }
 
 type CoverflowProps = {

--- a/frontend/src/components/PaginatedLibrary.tsx
+++ b/frontend/src/components/PaginatedLibrary.tsx
@@ -12,7 +12,7 @@ export type PaginatedLibraryProps = {
   albums: AlbumEntry[];
   filters: LibraryFilters;
   onFilterChange: (next: LibraryFilters) => void;
-  // Paginated tracks
+  // Paginated tracks (rendering)
   tracks: Track[];
   total: number;
   loading: boolean;
@@ -22,8 +22,16 @@ export type PaginatedLibraryProps = {
   // Track interaction
   currentTrackId?: string;
   onTrackSelect: (track: Track) => void;
+  onPlayLibrary?: () => void;
+  onShuffleLibrary?: () => void;
   playlists?: Playlist[];
   onAddTrackToPlaylist?: (input: { trackId: string; playlistId: string }) => Promise<void> | void;
+};
+
+type ActiveChip = {
+  key: keyof LibraryFilters;
+  label: string;
+  value: string;
 };
 
 export function PaginatedLibrary({
@@ -41,13 +49,15 @@ export function PaginatedLibrary({
   sentinelRef,
   currentTrackId,
   onTrackSelect,
+  onPlayLibrary,
+  onShuffleLibrary,
   playlists,
   onAddTrackToPlaylist
 }: PaginatedLibraryProps): JSX.Element {
   const resolveOwnerLabel = (owner: string): string => ownerNameById?.[owner] ?? owner;
   const hasActiveFilters = Boolean(filters.owner || filters.artist || filters.album || filters.q);
   const [searchDraft, setSearchDraft] = useState(filters.q ?? "");
-  const [filtersExpanded, setFiltersExpanded] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
   const filteredAlbums = useMemo(() => {
     if (!filters.artist) {
@@ -55,6 +65,21 @@ export function PaginatedLibrary({
     }
     return albums.filter((a) => a.artist === filters.artist);
   }, [albums, filters.artist]);
+
+  const activeChips = useMemo<ActiveChip[]>(() => {
+    const chips: ActiveChip[] = [];
+    if (filters.owner) {
+      chips.push({ key: "owner", label: "Owner", value: resolveOwnerLabel(filters.owner) });
+    }
+    if (filters.artist) {
+      chips.push({ key: "artist", label: "Artist", value: filters.artist });
+    }
+    if (filters.album) {
+      chips.push({ key: "album", label: "Album", value: filters.album });
+    }
+    return chips;
+    // resolveOwnerLabel closes over ownerNameById, but we list its inputs directly.
+  }, [filters.album, filters.artist, filters.owner, ownerNameById]);
 
   useEffect(() => {
     setSearchDraft(filters.q ?? "");
@@ -79,129 +104,195 @@ export function PaginatedLibrary({
     };
   }, [filters, onFilterChange, searchDraft]);
 
+  function clearChip(key: keyof LibraryFilters): void {
+    onFilterChange({ ...filters, [key]: undefined });
+  }
+
+  const noTracks = !loading && tracks.length === 0;
+
   return (
     <section className="p-5">
+      {/* Hero header */}
+      <div className="rounded-3xl border border-flaque-clay/60 bg-gradient-to-br from-flaque-cream/80 to-white/70 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div className="min-w-0">
+            <h2 className="font-display text-3xl text-flaque-ink">Library</h2>
+            <p className="mt-1 text-sm text-flaque-steel">
+              {loading && total === 0
+                ? "Loading…"
+                : `${total.toLocaleString()} track${total === 1 ? "" : "s"}${hasActiveFilters ? " match current filters" : ""}`}
+            </p>
+          </div>
 
-      <div className="mt-4 rounded-t-xl border border-flaque-clay/55 bg-flaque-cream/45 p-3">
-        <div className="flex items-center justify-between gap-2">
-          <p className="text-xs font-medium uppercase tracking-[0.14em] text-flaque-steel">
-            Library
-            {!loading && total > 0 ? (
-              <span className="ml-2">({total} tracks)</span>
-            ) : null}
-            {!filtersExpanded && hasActiveFilters ? (
-              <span className="ml-1.5 inline-block h-1.5 w-1.5 rounded-full bg-flaque-ink/50" />
-            ) : null}
-          </p>
+          <div className="flex items-center gap-2">
+            <button
+              className="inline-flex items-center gap-1.5 rounded-full bg-flaque-ink px-4 py-2 text-sm font-semibold text-flaque-cream shadow-sm transition hover:bg-flaque-ink/90 disabled:cursor-not-allowed disabled:opacity-55"
+              type="button"
+              onClick={onPlayLibrary}
+              disabled={!onPlayLibrary || noTracks}
+              title="Play library"
+            >
+              <svg viewBox="0 0 24 24" className="h-4 w-4" fill="currentColor" aria-hidden="true">
+                <path d="M8 5.14v13.72a1 1 0 0 0 1.55.83l10.4-6.86a1 1 0 0 0 0-1.66l-10.4-6.86A1 1 0 0 0 8 5.14z" />
+              </svg>
+              Play
+            </button>
+            <button
+              className="inline-flex items-center gap-1.5 rounded-full border border-flaque-ink/15 bg-white px-4 py-2 text-sm font-semibold text-flaque-ink transition hover:bg-flaque-cream/70 disabled:cursor-not-allowed disabled:opacity-55"
+              type="button"
+              onClick={onShuffleLibrary}
+              disabled={!onShuffleLibrary || noTracks}
+              title="Shuffle library"
+            >
+              <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                <path d="M16 3h5v5" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M21 3l-7 7" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M3 21l8-8" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M16 21h5v-5" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M21 21l-7-7" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M3 3l5 5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              Shuffle
+            </button>
+          </div>
+        </div>
+
+        {/* Search + filters row */}
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <div className="relative min-w-[14rem] flex-1">
+            <svg
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-flaque-steel"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <circle cx="11" cy="11" r="7" />
+              <path d="m20 20-3.5-3.5" strokeLinecap="round" />
+            </svg>
+            <input
+              className="w-full rounded-full border border-flaque-clay bg-white py-2 pl-9 pr-3 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+              type="search"
+              placeholder="Search title, artist, album, year"
+              value={searchDraft}
+              onChange={(event) => setSearchDraft(event.target.value)}
+            />
+          </div>
           <button
-            className="flex items-center text-xs font-medium uppercase tracking-[0.14em] rounded-lg text-flaque-steel transition hover:bg-flaque-cream/70 hover:text-flaque-ink"
+            className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-2 text-xs font-medium uppercase tracking-[0.12em] transition ${
+              filtersOpen
+                ? "border-flaque-ink bg-flaque-ink text-flaque-cream"
+                : "border-flaque-clay bg-white text-flaque-steel hover:bg-flaque-cream/60"
+            }`}
             type="button"
-            aria-label={filtersExpanded ? "Collapse filters" : "Expand filters"}
-            onClick={() => setFiltersExpanded((c) => !c)}
+            aria-expanded={filtersOpen}
+            onClick={() => setFiltersOpen((c) => !c)}
           >
             Filters
-            <svg className={`h-4 w-4 transition-transform ${filtersExpanded ? "" : "-rotate-90"}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+            <svg className={`h-3.5 w-3.5 transition-transform ${filtersOpen ? "rotate-180" : ""}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
               <path d="M6 10l6 6 6-6" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
           </button>
+          {hasActiveFilters ? (
+            <button
+              className="rounded-full border border-flaque-clay bg-white px-3 py-2 text-xs text-flaque-steel transition hover:bg-flaque-cream/60 hover:text-flaque-ink"
+              type="button"
+              onClick={() => {
+                setSearchDraft("");
+                onFilterChange({});
+              }}
+            >
+              Clear all
+            </button>
+          ) : null}
         </div>
 
-        {filtersExpanded ? (
-          <>
-            <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-4">
-              <label className="text-xs text-flaque-steel">
-                Owner
-                <select
-                  className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-                  value={filters.owner ?? ""}
-                  onChange={(event) =>
-                    onFilterChange({
-                      ...filters,
-                      owner: event.target.value || undefined
-                    })
-                  }
-                >
-                  <option value="">All owners</option>
-                  {owners.map((owner) => (
-                    <option key={owner} value={owner}>
-                      {resolveOwnerLabel(owner)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <label className="text-xs text-flaque-steel">
-                Artist
-                <select
-                  className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-                  value={filters.artist ?? ""}
-                  onChange={(event) =>
-                    onFilterChange({
-                      ...filters,
-                      artist: event.target.value || undefined
-                    })
-                  }
-                >
-                  <option value="">All artists</option>
-                  {artists.map((artist) => (
-                    <option key={artist.name} value={artist.name}>
-                      {artist.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <label className="text-xs text-flaque-steel">
-                Album
-                <select
-                  className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-                  value={filters.album ?? ""}
-                  onChange={(event) =>
-                    onFilterChange({
-                      ...filters,
-                      album: event.target.value || undefined
-                    })
-                  }
-                >
-                  <option value="">All albums</option>
-                  {filteredAlbums.map((album) => (
-                    <option key={`${album.artist ?? "unknown"}-${album.name}`} value={album.name}>
-                      {album.artist ? `${album.artist} - ${album.name}` : album.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <label className="text-xs text-flaque-steel">
-                Search
-                <input
-                  className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-                  type="search"
-                  placeholder="Search title, artist, album, year"
-                  value={searchDraft}
-                  onChange={(event) => setSearchDraft(event.target.value)}
-                />
-              </label>
-            </div>
-
-            <div className="mt-3 flex justify-end">
-              <button
-                className="rounded-lg border border-flaque-clay bg-white px-2.5 py-1 text-xs text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-55"
-                type="button"
-                onClick={() => {
-                  setSearchDraft("");
-                  onFilterChange({});
-                }}
-                disabled={!hasActiveFilters}
+        {/* Active filter chips */}
+        {activeChips.length > 0 ? (
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            {activeChips.map((chip) => (
+              <span
+                key={chip.key}
+                className="inline-flex items-center gap-1 rounded-full bg-flaque-ink/8 px-3 py-1 text-xs text-flaque-ink"
               >
-                Reset filters
-              </button>
-            </div>
-          </>
+                <span className="text-flaque-steel">{chip.label}:</span>
+                <span className="max-w-[14rem] truncate" title={chip.value}>{chip.value}</span>
+                <button
+                  className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full text-flaque-steel transition hover:bg-flaque-ink/15 hover:text-flaque-ink"
+                  type="button"
+                  aria-label={`Remove ${chip.label.toLowerCase()} filter`}
+                  onClick={() => clearChip(chip.key)}
+                >
+                  <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
+                    <path d="M6 6l12 12M18 6L6 18" strokeLinecap="round" />
+                  </svg>
+                </button>
+              </span>
+            ))}
+          </div>
+        ) : null}
+
+        {/* Filter popover (dropdowns) */}
+        {filtersOpen ? (
+          <div className="mt-4 grid grid-cols-1 gap-3 rounded-2xl border border-flaque-clay/55 bg-flaque-cream/45 p-3 md:grid-cols-3">
+            <label className="text-xs text-flaque-steel">
+              Owner
+              <select
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                value={filters.owner ?? ""}
+                onChange={(event) =>
+                  onFilterChange({ ...filters, owner: event.target.value || undefined })
+                }
+              >
+                <option value="">All owners</option>
+                {owners.map((owner) => (
+                  <option key={owner} value={owner}>
+                    {resolveOwnerLabel(owner)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs text-flaque-steel">
+              Artist
+              <select
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                value={filters.artist ?? ""}
+                onChange={(event) =>
+                  onFilterChange({ ...filters, artist: event.target.value || undefined })
+                }
+              >
+                <option value="">All artists</option>
+                {artists.map((artist) => (
+                  <option key={artist.name} value={artist.name}>
+                    {artist.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs text-flaque-steel">
+              Album
+              <select
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                value={filters.album ?? ""}
+                onChange={(event) =>
+                  onFilterChange({ ...filters, album: event.target.value || undefined })
+                }
+              >
+                <option value="">All albums</option>
+                {filteredAlbums.map((album) => (
+                  <option key={`${album.artist ?? "unknown"}-${album.name}`} value={album.name}>
+                    {album.artist ? `${album.artist} - ${album.name}` : album.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
         ) : null}
       </div>
 
-      <div className="overflow-hidden rounded-b-2xl border border-flaque-clay/55 bg-white/75">
+      {/* Track list */}
+      <div className="mt-4 overflow-hidden rounded-2xl border border-flaque-clay/55 bg-white/75">
         {loading && tracks.length === 0 ? (
           <p className="px-4 py-6 text-sm text-flaque-steel">Loading library...</p>
         ) : (
@@ -213,6 +304,7 @@ export function PaginatedLibrary({
             playlists={playlists}
             onAddTrackToPlaylist={onAddTrackToPlaylist}
             constrainHeight={false}
+            showCover
           />
         )}
       </div>

--- a/frontend/src/components/TrackList.tsx
+++ b/frontend/src/components/TrackList.tsx
@@ -1,7 +1,9 @@
 import { Fragment, KeyboardEvent, memo, MouseEvent, useState } from "react";
 
+import { coverUrl } from "../api";
 import type { Playlist, Track } from "../types";
 import { formatDuration } from "../utils/format";
+import { defaultCoverImage } from "../utils/covers";
 import {
   getTrackDisplayAlbumWithYear,
   getTrackDisplayArtist,
@@ -20,6 +22,7 @@ type TrackListProps = {
   emptyMessage?: string;
   constrainHeight?: boolean;
   showTrackNumber?: boolean;
+  showCover?: boolean;
 };
 
 export const TrackList = memo(function TrackList({
@@ -31,7 +34,8 @@ export const TrackList = memo(function TrackList({
   onAddTrackToPlaylist,
   emptyMessage = "No tracks match this filter yet.",
   constrainHeight = true,
-  showTrackNumber = false
+  showTrackNumber = false,
+  showCover = false
 }: TrackListProps): JSX.Element {
   const resolveOwnerLabel = (owner: string): string => ownerNameById?.[owner] ?? owner;
   const [playlistPickerTrackId, setPlaylistPickerTrackId] = useState<string | null>(null);
@@ -110,6 +114,21 @@ export const TrackList = memo(function TrackList({
                   </button>
                 ) : null}
 
+                {showCover ? (
+                  <div className="mt-0.5 h-12 w-12 shrink-0 overflow-hidden rounded-lg bg-flaque-cream">
+                    <img
+                      src={coverUrl(track.id)}
+                      alt=""
+                      aria-hidden="true"
+                      loading="lazy"
+                      className="h-full w-full object-cover"
+                      onError={(event) => {
+                        event.currentTarget.src = defaultCoverImage;
+                      }}
+                    />
+                  </div>
+                ) : null}
+
                 <button className="min-w-0 flex-1 text-left" type="button" onClick={() => handleTrackSelect(track)}>
                   <p className="text-sm font-medium">
                     <span className="flex min-w-0 items-center gap-1.5">
@@ -177,6 +196,7 @@ export const TrackList = memo(function TrackList({
               <th className="w-10 px-1 py-3 font-medium text-center" aria-label="Playlist actions">
               </th>
               {showTrackNumber ? <th className="w-8 px-0 py-3 text-center font-medium">#</th> : null}
+              {showCover ? <th className="w-12 px-2 py-3" aria-label="Cover" /> : null}
               <th className="pl-1 pr-4 py-3 font-medium">Title</th>
               <th className="px-4 py-3 font-medium">Artist</th>
               <th className="px-4 py-3 font-medium">Album</th>
@@ -228,6 +248,22 @@ export const TrackList = memo(function TrackList({
                     {showTrackNumber ? (
                       <td className="px-0 py-3 text-center text-xs text-flaque-steel">{track.tags.trackNumber ?? ""}</td>
                     ) : null}
+                    {showCover ? (
+                      <td className="w-12 px-2 py-2">
+                        <div className="h-10 w-10 overflow-hidden rounded-md bg-flaque-cream">
+                          <img
+                            src={coverUrl(track.id)}
+                            alt=""
+                            aria-hidden="true"
+                            loading="lazy"
+                            className="h-full w-full object-cover"
+                            onError={(event) => {
+                              event.currentTarget.src = defaultCoverImage;
+                            }}
+                          />
+                        </div>
+                      </td>
+                    ) : null}
                     <td className="pl-1 pr-4 py-3 text-flaque-ink">
                       <span className="flex max-w-[24rem] min-w-0 items-center gap-1.5">
                         {hasLyrics ? <span className={getLyricsBadgeClassName(false)}>L</span> : null}
@@ -254,7 +290,7 @@ export const TrackList = memo(function TrackList({
 
                   {showPlaylistPicker && onAddTrackToPlaylist ? (
                     <tr className="border-t border-flaque-clay/30 bg-flaque-cream/30">
-                      <td className="px-4 pb-3 pt-1" colSpan={showTrackNumber ? 8 : 7}>
+                      <td className="px-4 pb-3 pt-1" colSpan={7 + (showTrackNumber ? 1 : 0) + (showCover ? 1 : 0)}>
                         {hasPlayablePlaylists ? (
                           <PlaylistPicker
                             trackId={track.id}
@@ -273,7 +309,7 @@ export const TrackList = memo(function TrackList({
             })}
             {tracks.length === 0 ? (
               <tr>
-                <td className="px-4 py-4 text-flaque-steel" colSpan={showTrackNumber ? 8 : 7}>
+                <td className="px-4 py-4 text-flaque-steel" colSpan={7 + (showTrackNumber ? 1 : 0) + (showCover ? 1 : 0)}>
                   {emptyMessage}
                 </td>
               </tr>

--- a/frontend/src/hooks/useAudioPlayback.ts
+++ b/frontend/src/hooks/useAudioPlayback.ts
@@ -296,16 +296,22 @@ export function useAudioPlayback({
     const artist = getTrackDisplayArtist(track) ?? "Unknown artist";
     const album = getTrackDisplayAlbumWithYear(track) ?? "";
     if (typeof MediaMetadata !== "undefined") {
+      const rawCoverUrl = coverUrl(track.id, track.cover);
+      const absoluteCoverUrl =
+        typeof window !== "undefined" && rawCoverUrl.startsWith("/")
+          ? `${window.location.origin}${rawCoverUrl}`
+          : rawCoverUrl;
       mediaSession.metadata = new MediaMetadata({
         title: getTrackDisplayTitle(track),
         artist,
         album,
         artwork: [
-          {
-            src: coverUrl(track.id, track.cover),
-            sizes: "512x512",
-            type: "image/png"
-          }
+          { src: absoluteCoverUrl, sizes: "96x96", type: "image/jpeg" },
+          { src: absoluteCoverUrl, sizes: "128x128", type: "image/jpeg" },
+          { src: absoluteCoverUrl, sizes: "192x192", type: "image/jpeg" },
+          { src: absoluteCoverUrl, sizes: "256x256", type: "image/jpeg" },
+          { src: absoluteCoverUrl, sizes: "384x384", type: "image/jpeg" },
+          { src: absoluteCoverUrl, sizes: "512x512", type: "image/jpeg" }
         ]
       });
     }
@@ -313,6 +319,7 @@ export function useAudioPlayback({
 
     bindAction("play", () => startPlayback());
     bindAction("pause", () => pausePlayback());
+    bindAction("stop", () => pausePlayback());
     bindAction("previoustrack", () => {
       if (onPrevious) {
         void onPrevious({ wrap: false });
@@ -323,14 +330,82 @@ export function useAudioPlayback({
         void onNext({ wrap: false });
       }
     });
+    bindAction("seekbackward", (details) => {
+      const audioElement = audioRef.current;
+      if (!audioElement) return;
+      const offset = details.seekOffset ?? 10;
+      const next = Math.max(0, audioElement.currentTime - offset);
+      audioElement.currentTime = next;
+      currentTimeRef.current = next;
+      setCurrentTime(next);
+    });
+    bindAction("seekforward", (details) => {
+      const audioElement = audioRef.current;
+      if (!audioElement) return;
+      const offset = details.seekOffset ?? 10;
+      const max = Number.isFinite(audioElement.duration) && audioElement.duration > 0
+        ? audioElement.duration
+        : Number.POSITIVE_INFINITY;
+      const next = Math.min(max, audioElement.currentTime + offset);
+      audioElement.currentTime = next;
+      currentTimeRef.current = next;
+      setCurrentTime(next);
+    });
+    bindAction("seekto", (details) => {
+      const audioElement = audioRef.current;
+      if (!audioElement || typeof details.seekTime !== "number") return;
+      if (details.fastSeek && typeof audioElement.fastSeek === "function") {
+        audioElement.fastSeek(details.seekTime);
+      } else {
+        audioElement.currentTime = details.seekTime;
+      }
+      currentTimeRef.current = details.seekTime;
+      setCurrentTime(details.seekTime);
+    });
 
     return () => {
       bindAction("play", null);
       bindAction("pause", null);
+      bindAction("stop", null);
       bindAction("previoustrack", null);
       bindAction("nexttrack", null);
+      bindAction("seekbackward", null);
+      bindAction("seekforward", null);
+      bindAction("seekto", null);
     };
   }, [isPlaying, onNext, onPrevious, track]);
+
+  // ── Media Session position state ──────────────────────────────────────
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !("mediaSession" in navigator)) {
+      return;
+    }
+
+    const mediaSession = navigator.mediaSession;
+    if (typeof mediaSession.setPositionState !== "function") {
+      return;
+    }
+
+    if (!track || !duration || !Number.isFinite(duration)) {
+      try {
+        mediaSession.setPositionState();
+      } catch {
+        // ignored
+      }
+      return;
+    }
+
+    const safePosition = Math.min(Math.max(0, currentTime), duration);
+    try {
+      mediaSession.setPositionState({
+        duration,
+        position: safePosition,
+        playbackRate: audioRef.current?.playbackRate ?? 1
+      });
+    } catch {
+      // ignored — can throw if values are invalid (e.g., during a seek)
+    }
+  }, [currentTime, duration, track?.id]);
 
   // ── Playback controls ─────────────────────────────────────────────────
 

--- a/frontend/src/hooks/useLibraryData.ts
+++ b/frontend/src/hooks/useLibraryData.ts
@@ -4,7 +4,7 @@ import { getAlbumTracks, getAlbums, getArtistAlbums, getArtists, getLibrary } fr
 import type { AlbumEntry, ArtistEntry, LibraryResponse, Playlist, Track, User } from "../types";
 import type { LibraryFilters, LibrarySection } from "../types/library";
 import { getAlbumKey, normalizeText, sortAlbumTracksByNumber, type ViewName } from "../utils/appUtils";
-import { getTrackDisplayAlbum, getTrackDisplayArtist } from "../utils/tracks";
+import { getTrackDisplayAlbum, getTrackPrimaryArtist } from "../utils/tracks";
 
 const EMPTY_LIBRARY: LibraryResponse = {
   generatedAt: "",
@@ -129,7 +129,7 @@ export function useLibraryData({
         return true;
       }
 
-      return normalizeText(getTrackDisplayArtist(track)) === selectedAlbumArtist;
+      return normalizeText(getTrackPrimaryArtist(track)) === selectedAlbumArtist;
     });
   }
 

--- a/frontend/src/utils/tracks.test.ts
+++ b/frontend/src/utils/tracks.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import type { Track } from "../types";
+import {
+  formatArtistList,
+  getTrackArtistList,
+  getTrackDisplayArtist,
+  getTrackPrimaryArtist
+} from "./tracks";
+
+function makeTrack(tags: Partial<Track["tags"]>): Track {
+  return {
+    id: "track-1",
+    owner: "owner",
+    path: "track.flac",
+    duration: 0,
+    mimeType: "audio/flac",
+    codec: "flac",
+    tags: tags as Track["tags"]
+  };
+}
+
+describe("formatArtistList", () => {
+  it("returns undefined when empty", () => {
+    expect(formatArtistList([])).toBeUndefined();
+  });
+
+  it("returns the only artist when length is 1", () => {
+    expect(formatArtistList(["A"])).toBe("A");
+  });
+
+  it("joins two artists with ' and '", () => {
+    expect(formatArtistList(["A", "B"])).toBe("A and B");
+  });
+
+  it("joins three or more artists with comma + ' and '", () => {
+    expect(formatArtistList(["A", "B", "C"])).toBe("A, B and C");
+    expect(formatArtistList(["A", "B", "C", "D"])).toBe("A, B, C and D");
+  });
+});
+
+describe("getTrackArtistList", () => {
+  it("splits a semicolon-delimited artist string", () => {
+    expect(getTrackArtistList(makeTrack({ artist: "A; B; C" }))).toEqual(["A", "B", "C"]);
+  });
+
+  it("trims whitespace around separators", () => {
+    expect(getTrackArtistList(makeTrack({ artist: "A ;  B  ;C" }))).toEqual(["A", "B", "C"]);
+  });
+
+  it("uses the artists array when provided", () => {
+    expect(getTrackArtistList(makeTrack({ artists: ["A", "B"] }))).toEqual(["A", "B"]);
+  });
+
+  it("dedupes between artist string and artists array", () => {
+    expect(
+      getTrackArtistList(makeTrack({ artist: "A; B", artists: ["A", "C"] }))
+    ).toEqual(["A", "B", "C"]);
+  });
+
+  it("falls back to album artist only when no artist tags exist", () => {
+    expect(getTrackArtistList(makeTrack({ albumArtist: "X" }))).toEqual(["X"]);
+  });
+
+  it("returns an empty array when no artist data is present", () => {
+    expect(getTrackArtistList(makeTrack({}))).toEqual([]);
+  });
+});
+
+describe("getTrackPrimaryArtist", () => {
+  it("returns the first artist from a semicolon-delimited string", () => {
+    expect(getTrackPrimaryArtist(makeTrack({ artist: "A; B; C" }))).toBe("A");
+  });
+
+  it("returns undefined when no artist data is present", () => {
+    expect(getTrackPrimaryArtist(makeTrack({}))).toBeUndefined();
+  });
+});
+
+describe("getTrackDisplayArtist", () => {
+  it("formats two artists with ' and '", () => {
+    expect(getTrackDisplayArtist(makeTrack({ artist: "A; B" }))).toBe("A and B");
+  });
+
+  it("formats three artists with comma + ' and '", () => {
+    expect(getTrackDisplayArtist(makeTrack({ artist: "A; B; C" }))).toBe("A, B and C");
+  });
+
+  it("returns a single artist as-is", () => {
+    expect(getTrackDisplayArtist(makeTrack({ artist: "A" }))).toBe("A");
+  });
+
+  it("returns undefined when no artist data is present", () => {
+    expect(getTrackDisplayArtist(makeTrack({}))).toBeUndefined();
+  });
+});

--- a/frontend/src/utils/tracks.ts
+++ b/frontend/src/utils/tracks.ts
@@ -149,28 +149,80 @@ function extractLyricsFromExtra(extra: Record<string, TrackTagExtraValue> | unde
   return undefined;
 }
 
-export function getTrackDisplayArtist(track: Pick<Track, "tags">): string | undefined {
+const ARTIST_SPLIT_PATTERN = /\s*;\s*/;
+
+function splitArtistString(value: string): string[] {
+  return value
+    .split(ARTIST_SPLIT_PATTERN)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+export function formatArtistList(artists: readonly string[]): string | undefined {
+  if (artists.length === 0) {
+    return undefined;
+  }
+
+  if (artists.length === 1) {
+    return artists[0];
+  }
+
+  if (artists.length === 2) {
+    return `${artists[0]} and ${artists[1]}`;
+  }
+
+  const head = artists.slice(0, -1).join(", ");
+  const tail = artists[artists.length - 1];
+  return `${head} and ${tail}`;
+}
+
+export function getTrackArtistList(track: Pick<Track, "tags">): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  const push = (value: string | undefined): void => {
+    if (!value) return;
+    const key = value.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.push(value);
+  };
+
   const directArtist = normalizeTagText(track.tags.artist);
   if (directArtist) {
-    return directArtist;
-  }
-
-  const albumArtist = normalizeTagText(track.tags.albumArtist);
-  if (albumArtist) {
-    return albumArtist;
-  }
-
-  if (Array.isArray(track.tags.artists)) {
-    const firstArtist = track.tags.artists
-      .map((artist) => normalizeTagText(artist))
-      .find((artist): artist is string => Boolean(artist));
-
-    if (firstArtist) {
-      return firstArtist;
+    for (const entry of splitArtistString(directArtist)) {
+      push(entry);
     }
   }
 
-  return undefined;
+  if (Array.isArray(track.tags.artists)) {
+    for (const raw of track.tags.artists) {
+      const normalized = normalizeTagText(raw);
+      if (!normalized) continue;
+      for (const entry of splitArtistString(normalized)) {
+        push(entry);
+      }
+    }
+  }
+
+  if (result.length === 0) {
+    const albumArtist = normalizeTagText(track.tags.albumArtist);
+    if (albumArtist) {
+      for (const entry of splitArtistString(albumArtist)) {
+        push(entry);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function getTrackPrimaryArtist(track: Pick<Track, "tags">): string | undefined {
+  return getTrackArtistList(track)[0];
+}
+
+export function getTrackDisplayArtist(track: Pick<Track, "tags">): string | undefined {
+  return formatArtistList(getTrackArtistList(track));
 }
 
 export function getTrackDisplayAlbum(track: Pick<Track, "tags">): string | undefined {


### PR DESCRIPTION
## Summary
- **Library view**: hero header in `PaginatedLibrary` with Play/Shuffle, persistent search + filter chips, optional cover thumbnails in `TrackList`, and queueing the full filtered library so shuffle/next iterates everything (not just the rendered page).
- **Multi-artist handling**: split `;`-delimited artist tags for display (`"A, B and C"`), use the primary artist for player navigation and album-artist matching, and include tracks under their primary artist's album page even when filed in another directory.
- **OS MediaSession**: absolute artwork URL with multiple sizes; `setPositionState` so the lock screen shows a real progress bar; `seekto`/`seekbackward`/`seekforward`/`stop` action handlers.

## Test plan
- [ ] Library view: search + filter chips, Play and Shuffle buttons, queue covers full filtered library
- [ ] Multi-artist track displays as `"A, B and C"` in player, queue, track lists
- [ ] Clicking artist name in the player navigates to the first artist's page
- [ ] Multi-artist albums appear under the primary artist's album page
- [ ] OS lock screen shows cover, scrub bar, ±10s seek, and stop button
- [ ] `npm test` (frontend + backend) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)