### PR TITLE
fix(artists): include collab tracks under the primary artist's albums

### DIFF
--- a/backend/src/api/libraryRoutes.ts
+++ b/backend/src/api/libraryRoutes.ts
@@ -550,12 +550,22 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
       const filter = readFilter(req.query as Record<string, unknown>);
       const indexedTracks = selectIndexedTracks(indexStore, { owner: filter.owner }, ownerNamesById);
       const tracksWithOwnerNames = mapTrackOwners(indexedTracks, ownerNamesById);
+      const matchedArtist = listArtists(tracksWithOwnerNames).find(
+        (entry) => entry.normalizedName === normalizedArtist
+      );
+      const artistNameLower = matchedArtist?.name.trim().toLowerCase();
       const tracksForArtist = tracksWithOwnerNames.filter((track) => {
         if (getTrackArtistDirectorySegment(track) === normalizedArtist) {
           return true;
         }
         const primaryArtist = getTrackArtistName(track)?.trim().toLowerCase();
-        return Boolean(primaryArtist) && primaryArtist === normalizedArtist;
+        if (!primaryArtist) {
+          return false;
+        }
+        if (primaryArtist === normalizedArtist) {
+          return true;
+        }
+        return Boolean(artistNameLower) && primaryArtist === artistNameLower;
       });
       const tracks = filterTracks(tracksForArtist, { owner: filter.owner, q: filter.q });
       const albums = await attachCollaborativeAlbumCovers(tracks, "year-desc");


### PR DESCRIPTION
## Summary
The `/artists/:artist/albums` route accepted the artist's directory-based `normalizedName` as its URL param, but its secondary "primary tag" match compared that param to the lowercased artist name — so `bad_omens` never matched `bad omens`, and a multi-artist track filed outside the artist's main directory stayed hidden under that artist's page.

Resolve the matching artist via `listArtists` first to learn the canonical name (e.g. `Bad Omens`), then accept tracks whose primary artist equals either the URL param or that resolved name.

This was meant to land in #166 but got merged just before the fix was pushed.

## Test plan
- [ ] On a library with a multi-artist track filed outside the primary artist's main directory (e.g. THE DRAIN by Bad Omens & others), the album appears under Bad Omens' Artists view
- [ ] Existing single-artist albums still appear under their artist
- [ ] `npm test` (backend) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)