### PR TITLE
feat: admin activity logs + player stops at end of queue

### DIFF
--- a/backend/src/api/authRoutes.ts
+++ b/backend/src/api/authRoutes.ts
@@ -59,6 +59,10 @@ function emitAuthAuditLog(level: "info" | "warn", event: string, details: Record
   log[level](event, details);
 }
 
+function truncateLoginAttempt(value: string): string {
+  return value.length > 64 ? `${value.slice(0, 64)}…` : value;
+}
+
 function fingerprintValue(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 12);
 }
@@ -222,7 +226,8 @@ export function createAuthRouter(): Router {
     if (!login || !password) {
       emitAuthAuditLog("warn", "login-bad-request", {
         ip,
-        loginFingerprint
+        loginFingerprint,
+        loginAttempt: login ? truncateLoginAttempt(login) : "(missing)"
       });
       return next(new AppError("login and password are required", 400));
     }
@@ -231,7 +236,9 @@ export function createAuthRouter(): Router {
     if (!user || !verifyPassword(password, user.password_hash)) {
       emitAuthAuditLog("warn", "login-failed", {
         ip,
-        loginFingerprint
+        loginFingerprint,
+        loginAttempt: truncateLoginAttempt(login),
+        ...(user ? { username: user.username } : {})
       });
       return next(new AppError("Invalid credentials", 401));
     }
@@ -247,7 +254,8 @@ export function createAuthRouter(): Router {
 
     emitAuthAuditLog("info", "login-succeeded", {
       ip,
-      userId: user.id
+      userId: user.id,
+      username: user.username
     });
 
     res.json({

--- a/backend/src/api/library/trackAdmin.ts
+++ b/backend/src/api/library/trackAdmin.ts
@@ -122,6 +122,7 @@ export function createTrackMutationRouter(indexStore: IndexStore): Router {
       }
 
       const deleted: string[] = [];
+      const deletedTitles: string[] = [];
       const notFound: string[] = [];
       const overridePatch: Record<string, Record<string, never>> = {};
 
@@ -144,6 +145,7 @@ export function createTrackMutationRouter(indexStore: IndexStore): Router {
         await deleteTrackCover(trackId);
         overridePatch[trackId] = {};
         deleted.push(trackId);
+        deletedTitles.push(track.tags.title ?? track.path);
       }
 
       if (Object.keys(overridePatch).length > 0) {
@@ -153,7 +155,8 @@ export function createTrackMutationRouter(indexStore: IndexStore): Router {
       log.info("Tracks deleted in bulk", {
         userId: req.authUser?.id ?? "unknown",
         deletedCount: deleted.length,
-        notFoundCount: notFound.length
+        notFoundCount: notFound.length,
+        titles: deletedTitles.slice(0, 10)
       });
 
       const rebuiltIndex = await indexStore.rebuild();
@@ -200,6 +203,7 @@ export function createTrackMutationRouter(indexStore: IndexStore): Router {
       const currentOverrides = await readTrackMetadataOverrides();
       const overridePatch: Record<string, { title?: string; artist?: string; album?: string; year?: number; genre?: string[] }> = {};
       const updated: string[] = [];
+      const updatedTitles: string[] = [];
       const notFound: string[] = [];
 
       for (const trackId of validIds) {
@@ -218,6 +222,7 @@ export function createTrackMutationRouter(indexStore: IndexStore): Router {
           genre: hasGenre ? parsedGenre : current.genre
         };
         updated.push(trackId);
+        updatedTitles.push(track.tags.title ?? track.path);
       }
 
       if (Object.keys(overridePatch).length > 0) {
@@ -228,7 +233,8 @@ export function createTrackMutationRouter(indexStore: IndexStore): Router {
         userId: req.authUser?.id ?? "unknown",
         updatedCount: updated.length,
         notFoundCount: notFound.length,
-        fields: [hasTitle && "title", hasArtist && "artist", hasAlbum && "album", hasYear && "year", hasGenre && "genre"].filter(Boolean).join(", ")
+        fields: [hasTitle && "title", hasArtist && "artist", hasAlbum && "album", hasYear && "year", hasGenre && "genre"].filter(Boolean).join(", "),
+        titles: updatedTitles.slice(0, 10)
       });
 
       await indexStore.rebuild();

--- a/backend/src/api/playlist/automatic.ts
+++ b/backend/src/api/playlist/automatic.ts
@@ -37,6 +37,14 @@ export function createAutoPlaylistRouter(indexStore: IndexStore): Router {
       if (typeof body.tracksPerPlaylist === "number") patch.tracksPerPlaylist = body.tracksPerPlaylist;
 
       const updated = await updateAutoPlaylistConfig(patch);
+
+      if (Object.keys(patch).length > 0) {
+        log.info("Automatic playlist config updated", {
+          userId: req.authUser?.id ?? "unknown",
+          changes: patch
+        });
+      }
+
       res.json(updated);
     } catch (error) {
       next(error);

--- a/backend/src/api/userRoutes.ts
+++ b/backend/src/api/userRoutes.ts
@@ -38,8 +38,13 @@ import { getClientIp, hasOwnProperty, isSqliteUniqueError } from "./requestHelpe
 
 const log = createLogger("auth");
 
-function emitSecurityAuditLog(level: "info" | "warn", event: string, details: Record<string, string | number | boolean>): void {
-  log[level](event, details);
+function emitSecurityAuditLog(
+  level: "info" | "warn",
+  event: string,
+  message: string,
+  details: Record<string, string | number | boolean>
+): void {
+  log[level](message, { event, ...details });
 }
 
 const PROFILE_DIR_NAME = "profile";
@@ -176,8 +181,9 @@ export function createUserRouter(): Router {
       await removeExistingProfilePhotos(authUser.id);
       await fs.rename(tmpPath, targetPath);
 
-      emitSecurityAuditLog("info", "user-profile-photo-updated", {
+      emitSecurityAuditLog("info", "user-profile-photo-updated", "User updated profile photo", {
         userId: authUser.id,
+        username: authUser.username,
         originalName: file.originalname ?? "unknown",
         sizeBytes: file.size
       });
@@ -212,8 +218,9 @@ export function createUserRouter(): Router {
 
     const existingUser = findUserByUsername(authUser.username);
     if (!existingUser || !verifyPassword(currentPassword, existingUser.password_hash)) {
-      emitSecurityAuditLog("warn", "user-password-change-failed", {
+      emitSecurityAuditLog("warn", "user-password-change-failed", "User password change failed", {
         userId: authUser.id,
+        username: authUser.username,
         reason: "invalid-current-password",
         ip: getClientIp(req) ?? "unknown"
       });
@@ -225,8 +232,9 @@ export function createUserRouter(): Router {
       return next(new AppError("User not found", 404));
     }
 
-    emitSecurityAuditLog("info", "user-password-changed", {
+    emitSecurityAuditLog("info", "user-password-changed", "User changed password", {
       userId: authUser.id,
+      username: authUser.username,
       ip: getClientIp(req) ?? "unknown"
     });
 
@@ -259,8 +267,9 @@ export function createUserRouter(): Router {
         return next(new AppError("User not found", 404));
       }
 
-      emitSecurityAuditLog("info", "user-email-changed", {
+      emitSecurityAuditLog("info", "user-email-changed", "User changed email", {
         userId: authUser.id,
+        username: authUser.username,
         ip: getClientIp(req) ?? "unknown"
       });
 
@@ -311,8 +320,9 @@ export function createUserRouter(): Router {
 
       const user = createUser(username, password, role, email);
 
-      emitSecurityAuditLog("info", "admin-user-created", {
+      emitSecurityAuditLog("info", "admin-user-created", `Admin created user "${user.username}"`, {
         adminUserId: req.authUser!.id,
+        adminUsername: req.authUser!.username,
         createdUserId: user.id,
         createdUsername: user.username,
         createdRole: user.role,
@@ -434,9 +444,18 @@ export function createUserRouter(): Router {
         }
       }
 
-      emitSecurityAuditLog("info", "admin-user-updated", {
+      const changedFields = [
+        shouldChangeUsername && "username",
+        shouldChangeRole && "role",
+        shouldChangeEmail && "email"
+      ].filter(Boolean).join(", ");
+      const targetLabel = nextUsername ?? existingUser.username;
+
+      emitSecurityAuditLog("info", "admin-user-updated", `Admin updated user "${targetLabel}" (${changedFields})`, {
         adminUserId: req.authUser!.id,
+        adminUsername: req.authUser!.username,
         targetUserId: userId,
+        targetUsername: existingUser.username,
         usernameChanged: shouldChangeUsername,
         ...(shouldChangeUsername ? { oldUsername: existingUser.username, newUsername: nextUsername! } : {}),
         roleChanged: shouldChangeRole,
@@ -488,8 +507,9 @@ export function createUserRouter(): Router {
       return next(new AppError("User not found", 404));
     }
 
-    emitSecurityAuditLog("info", "admin-user-password-reset", {
+    emitSecurityAuditLog("info", "admin-user-password-reset", `Admin reset password for user "${existingUser.username}"`, {
       adminUserId: req.authUser!.id,
+      adminUsername: req.authUser!.username,
       targetUserId: userId,
       targetUsername: existingUser.username,
       ip: getClientIp(req) ?? "unknown"
@@ -530,8 +550,9 @@ export function createUserRouter(): Router {
       return next(new AppError("User not found", 404));
     }
 
-    emitSecurityAuditLog("info", "admin-user-deleted", {
+    emitSecurityAuditLog("info", "admin-user-deleted", `Admin deleted user "${existingUser.username}"`, {
       adminUserId: req.authUser!.id,
+      adminUsername: req.authUser!.username,
       deletedUserId: userId,
       deletedUsername: existingUser.username,
       ip: getClientIp(req) ?? "unknown"

--- a/frontend/src/hooks/usePlaybackCommands.ts
+++ b/frontend/src/hooks/usePlaybackCommands.ts
@@ -135,9 +135,23 @@ export function usePlaybackCommands({
       return;
     }
 
-    const nextTrackFromQueue = getAdjacentTrackInQueue(refreshedQueue, currentTrack.id, direction, wrap);
-    if (nextTrackFromQueue && nextTrackFromQueue.id !== currentTrack.id) {
-      setSelectedTrack(nextTrackFromQueue);
+    const currentIndexInQueue = refreshedQueue.findIndex((track) => track.id === currentTrack.id);
+    const isInQueue = currentIndexInQueue >= 0;
+
+    if (isInQueue) {
+      const nextTrackFromQueue = getAdjacentTrackInQueue(refreshedQueue, currentTrack.id, direction, wrap);
+      if (nextTrackFromQueue && nextTrackFromQueue.id !== currentTrack.id) {
+        setSelectedTrack(nextTrackFromQueue);
+        return;
+      }
+
+      if (!wrap) {
+        setPlayerStatusMessage(
+          direction === "next"
+            ? "You reached the end of the current queue."
+            : "You are already at the start of the current queue."
+        );
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

Two related improvements to existing features:

**Admin activity logs** — closes a few gaps so admins can audit instance activity from the log viewer without cross-referencing user IDs.
- `authRoutes`: `login-succeeded` adds verified `username`; `login-failed` adds the truncated entered `loginAttempt` and (when matched) the target `username`, so admins can spot brute-force targeting; `login-bad-request` records the truncated attempt or `(missing)`. Existing `loginFingerprint` preserved.
- `userRoutes`: `emitSecurityAuditLog` now takes a separate human-readable message and emits the event ID as a structured `event` field. All 8 call sites get admin-friendly messages (`Admin created user "alice"` instead of `admin-user-created`). Username added to payloads where only the user ID was present.
- `library/trackAdmin`: bulk delete and bulk metadata logs now include up to 10 sample `titles`, mirroring the upload log.
- `playlist/automatic`: `PATCH /automatic/config` now logs the changed fields when at least one field actually changes.

**Player end-of-queue** — `handleNavigateTrack` used to fall back to a library-filter API when the queue was exhausted, so the player would keep playing unrelated library tracks after the last song of an album/playlist. Now: when the current track is in the active queue and we hit a boundary with `wrap=false`, we stop. `repeat=one` and `repeat=all` (wrap) are unchanged. Same behaviour across albums, playlists, and library queues. Library-filter fallback preserved only for the recovery case where the current track is no longer in the queue.

## Test plan
- [ ] Tail `logs/flaque.log` while creating/updating/deleting a user — messages are human-readable and include the username
- [ ] Tail logs while logging in with a valid user, an unknown user, and an empty form — entries include the attempted login and (where applicable) the matched username
- [ ] Bulk delete / bulk metadata edit a few tracks — log entry lists titles
- [ ] Edit automatic playlist config — log entry shows the changed fields
- [ ] Play an album, let the last track end with repeat off — playback stops
- [ ] Same with repeat=all — wraps to first track of the album
- [ ] Same with repeat=one — replays last track
- [ ] Press next on the last track of a playlist with repeat off — stays on the last track and shows "end of queue" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)