### PR TITLE
feat(musicbrainz): phase 2 - persist MBIDs, backfill year, fetch covers

### DIFF
--- a/backend/src/services/genre/coverArtArchiveService.test.ts
+++ b/backend/src/services/genre/coverArtArchiveService.test.ts
@@ -1,0 +1,156 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { tmpRoot } = vi.hoisted(() => {
+  const fsS = require("node:fs") as typeof import("node:fs");
+  const osM = require("node:os") as typeof import("node:os");
+  const pathM = require("node:path") as typeof import("node:path");
+  return {
+    tmpRoot: fsS.mkdtempSync(pathM.join(osM.tmpdir(), "caa-test-"))
+  };
+});
+
+const cacheRootDir = path.join(tmpRoot, "cache");
+const coversRootDir = path.join(tmpRoot, "covers");
+
+vi.mock("../../utils/paths", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../utils/paths")>()),
+  cacheRoot: cacheRootDir,
+  coversRoot: coversRootDir
+}));
+
+vi.mock("../../utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+const NEGATIVE_CACHE_FILE = path.join(cacheRootDir, "cover-art-archive-misses.json");
+const RG_MBID = "11111111-1111-4111-8111-111111111111";
+const RG_MBID_2 = "22222222-2222-4222-8222-222222222222";
+
+type FetchHandler = (url: string) => { status?: number; body?: Buffer; throw?: Error };
+
+let fetchHandler: FetchHandler = () => ({ status: 404 });
+let fetchCalls: string[] = [];
+
+beforeEach(async () => {
+  vi.resetModules();
+  for (const dir of [cacheRootDir, coversRootDir]) {
+    if (fsSync.existsSync(dir)) {
+      for (const entry of await fs.readdir(dir).catch(() => [])) {
+        await fs.rm(path.join(dir, entry), { recursive: true, force: true });
+      }
+    }
+  }
+  fetchHandler = () => ({ status: 404 });
+  fetchCalls = [];
+  vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input.toString();
+    fetchCalls.push(url);
+    const result = fetchHandler(url);
+    if (result.throw) throw result.throw;
+    const body = result.body ?? Buffer.alloc(0);
+    return new Response(body, {
+      status: result.status ?? 200
+    });
+  }));
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+  fsSync.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+async function loadModule(): Promise<typeof import("./coverArtArchiveService")> {
+  return await import("./coverArtArchiveService");
+}
+
+describe("coverArtArchiveService", () => {
+  it("downloads and saves cover art to coversRoot/<trackId>.jpg", async () => {
+    const fakeJpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]);
+    fetchHandler = () => ({ status: 200, body: fakeJpeg });
+    const { fetchAndSaveCoverArt } = await loadModule();
+
+    const result = await fetchAndSaveCoverArt("track-1", RG_MBID);
+    expect(result.kind).toBe("saved");
+    if (result.kind === "saved") expect(result.bytes).toBe(fakeJpeg.length);
+
+    const target = path.join(coversRootDir, "track-1.jpg");
+    expect(fsSync.existsSync(target)).toBe(true);
+    expect(fsSync.readFileSync(target).equals(fakeJpeg)).toBe(true);
+    expect(fsSync.existsSync(`${target}.tmp`)).toBe(false);
+  });
+
+  it("hits the release-group/{mbid}/front-500 endpoint", async () => {
+    fetchHandler = () => ({ status: 200, body: Buffer.from([0xff, 0xd8]) });
+    const { fetchAndSaveCoverArt } = await loadModule();
+    await fetchAndSaveCoverArt("track-1", RG_MBID);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]).toBe(`https://coverartarchive.org/release-group/${RG_MBID}/front-500`);
+  });
+
+  it("caches 404s and skips re-fetching for 30 days", async () => {
+    fetchHandler = () => ({ status: 404 });
+    const { fetchAndSaveCoverArt, flushCoverArtNegativeCache } = await loadModule();
+
+    expect((await fetchAndSaveCoverArt("track-1", RG_MBID)).kind).toBe("no-art");
+    flushCoverArtNegativeCache();
+
+    fetchCalls = [];
+    const second = await fetchAndSaveCoverArt("track-2", RG_MBID);
+    expect(second.kind).toBe("skipped-cached-miss");
+    expect(fetchCalls).toEqual([]);
+  });
+
+  it("does NOT cache 5xx as a miss (transient retry)", async () => {
+    fetchHandler = () => ({ status: 503 });
+    const { fetchAndSaveCoverArt, flushCoverArtNegativeCache } = await loadModule();
+    expect((await fetchAndSaveCoverArt("track-1", RG_MBID)).kind).toBe("transient");
+    flushCoverArtNegativeCache();
+
+    expect(fsSync.existsSync(NEGATIVE_CACHE_FILE)).toBe(false);
+  });
+
+  it("does NOT cache network errors as a miss (transient retry)", async () => {
+    fetchHandler = () => ({ throw: new Error("ECONNRESET") });
+    const { fetchAndSaveCoverArt } = await loadModule();
+    expect((await fetchAndSaveCoverArt("track-1", RG_MBID)).kind).toBe("transient");
+  });
+
+  it("expires the negative cache after 30 days", async () => {
+    fetchHandler = () => ({ status: 404 });
+    const { fetchAndSaveCoverArt, flushCoverArtNegativeCache } = await loadModule();
+    expect((await fetchAndSaveCoverArt("track-1", RG_MBID)).kind).toBe("no-art");
+    flushCoverArtNegativeCache();
+
+    // Manually rewrite the file with an ancient cachedAt
+    const raw = JSON.parse(fsSync.readFileSync(NEGATIVE_CACHE_FILE, "utf8")) as Record<string, number>;
+    for (const key of Object.keys(raw)) raw[key] = 0;
+    fsSync.writeFileSync(NEGATIVE_CACHE_FILE, JSON.stringify(raw), "utf8");
+
+    vi.resetModules();
+    const reloaded = await loadModule();
+    fetchHandler = () => ({ status: 200, body: Buffer.from([0xff, 0xd8]) });
+    const result = await reloaded.fetchAndSaveCoverArt("track-1", RG_MBID);
+    expect(result.kind).toBe("saved");
+  });
+
+  it("treats a different release-group as a separate negative cache key", async () => {
+    fetchHandler = () => ({ status: 404 });
+    const { fetchAndSaveCoverArt } = await loadModule();
+    await fetchAndSaveCoverArt("track-1", RG_MBID);
+
+    fetchCalls = [];
+    fetchHandler = () => ({ status: 200, body: Buffer.from([0xff]) });
+    const second = await fetchAndSaveCoverArt("track-2", RG_MBID_2);
+    expect(second.kind).toBe("saved");
+    expect(fetchCalls).toHaveLength(1);
+  });
+});

--- a/backend/src/services/genre/coverArtArchiveService.ts
+++ b/backend/src/services/genre/coverArtArchiveService.ts
@@ -1,0 +1,176 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+import { cacheRoot, coversRoot } from "../../utils/paths";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("cover-art-archive");
+
+const CAA_BASE_URL = "https://coverartarchive.org";
+const REQUEST_TIMEOUT_MS = 15_000;
+const NEGATIVE_CACHE_FILE = path.join(cacheRoot, "cover-art-archive-misses.json");
+const NEGATIVE_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const NEGATIVE_CACHE_FLUSH_DEBOUNCE_MS = 500;
+const COVER_FILE_EXTENSION = ".jpg";
+
+type NegativeCache = Record<string, number>;
+
+let negativeCache: NegativeCache | null = null;
+let negativeDirty = false;
+let negativeSaveTimer: NodeJS.Timeout | null = null;
+
+function loadNegativeCache(): NegativeCache {
+  if (negativeCache) return negativeCache;
+  try {
+    if (fs.existsSync(NEGATIVE_CACHE_FILE)) {
+      const raw = fs.readFileSync(NEGATIVE_CACHE_FILE, "utf8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const cleaned: NegativeCache = {};
+      for (const [key, value] of Object.entries(parsed)) {
+        if (typeof value === "number" && Number.isFinite(value)) {
+          cleaned[key] = value;
+        }
+      }
+      negativeCache = cleaned;
+      return cleaned;
+    }
+  } catch {
+    log.warn("Failed to load Cover Art Archive negative cache, starting fresh");
+  }
+  negativeCache = {};
+  return negativeCache;
+}
+
+function flushNegativeCacheNow(): void {
+  if (negativeSaveTimer) {
+    clearTimeout(negativeSaveTimer);
+    negativeSaveTimer = null;
+  }
+  if (!negativeCache || !negativeDirty) return;
+
+  try {
+    fs.mkdirSync(path.dirname(NEGATIVE_CACHE_FILE), { recursive: true });
+    const tmpPath = `${NEGATIVE_CACHE_FILE}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(negativeCache, null, 2), "utf8");
+    fs.renameSync(tmpPath, NEGATIVE_CACHE_FILE);
+    negativeDirty = false;
+  } catch (error) {
+    log.warn("Failed to save Cover Art Archive negative cache", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+function scheduleNegativeCacheSave(): void {
+  negativeDirty = true;
+  if (negativeSaveTimer) return;
+  negativeSaveTimer = setTimeout(() => {
+    negativeSaveTimer = null;
+    flushNegativeCacheNow();
+  }, NEGATIVE_CACHE_FLUSH_DEBOUNCE_MS);
+  negativeSaveTimer.unref?.();
+}
+
+function isNegativeFresh(cachedAt: number): boolean {
+  return Date.now() - cachedAt < NEGATIVE_CACHE_TTL_MS;
+}
+
+export type CoverArtFetchResult =
+  | { kind: "saved"; bytes: number }
+  | { kind: "skipped-cached-miss" }
+  | { kind: "no-art" }
+  | { kind: "transient" };
+
+/**
+ * Download the front cover for a release-group from the Cover Art Archive
+ * and save it to coversRoot/<trackId>.jpg. Returns "no-art" for a confirmed
+ * 404 (and remembers it for 30 days to avoid re-hitting CAA on every
+ * enrichment pass). Returns "transient" for network errors / 5xx so the
+ * caller can retry on the next run.
+ */
+export async function fetchAndSaveCoverArt(
+  trackId: string,
+  releaseGroupMbid: string
+): Promise<CoverArtFetchResult> {
+  const negCache = loadNegativeCache();
+  const cachedMissAt = negCache[releaseGroupMbid];
+  if (typeof cachedMissAt === "number" && isNegativeFresh(cachedMissAt)) {
+    return { kind: "skipped-cached-miss" };
+  }
+
+  const url = `${CAA_BASE_URL}/release-group/${releaseGroupMbid}/front-500`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { "User-Agent": "flaque (https://github.com/Marma92/flaque)" },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      redirect: "follow"
+    });
+  } catch (error) {
+    log.warn("Cover Art Archive fetch failed", {
+      releaseGroupMbid,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return { kind: "transient" };
+  }
+
+  if (response.status === 404) {
+    negCache[releaseGroupMbid] = Date.now();
+    scheduleNegativeCacheSave();
+    return { kind: "no-art" };
+  }
+
+  if (response.status >= 500 || response.status === 429) {
+    log.warn(`Cover Art Archive returned ${response.status}`, { releaseGroupMbid });
+    return { kind: "transient" };
+  }
+
+  if (!response.ok) {
+    log.warn(`Cover Art Archive returned ${response.status}`, { releaseGroupMbid });
+    return { kind: "transient" };
+  }
+
+  let buffer: Buffer;
+  try {
+    const arrayBuffer = await response.arrayBuffer();
+    buffer = Buffer.from(arrayBuffer);
+  } catch (error) {
+    log.warn("Cover Art Archive: failed to read body", {
+      releaseGroupMbid,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return { kind: "transient" };
+  }
+
+  if (buffer.length === 0) {
+    return { kind: "transient" };
+  }
+
+  try {
+    await fsp.mkdir(coversRoot, { recursive: true });
+    const targetPath = path.join(coversRoot, `${trackId}${COVER_FILE_EXTENSION}`);
+    const tmpPath = `${targetPath}.tmp`;
+    await fsp.writeFile(tmpPath, buffer);
+    await fsp.rename(tmpPath, targetPath);
+    return { kind: "saved", bytes: buffer.length };
+  } catch (error) {
+    log.warn("Failed to write cover art file", {
+      trackId,
+      releaseGroupMbid,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return { kind: "transient" };
+  }
+}
+
+export function flushCoverArtNegativeCache(): void {
+  flushNegativeCacheNow();
+}
+
+export function clearCoverArtNegativeCache(): void {
+  negativeCache = {};
+  negativeDirty = true;
+  flushNegativeCacheNow();
+}

--- a/backend/src/services/genre/genreEnrichmentService.ts
+++ b/backend/src/services/genre/genreEnrichmentService.ts
@@ -1,6 +1,17 @@
 import type { IndexStore } from "../indexer/indexStore";
-import { mergeTrackMetadataOverrides } from "../indexer/metadataOverrideStore";
-import { flushGenreCache, lookupGenre } from "./musicBrainzService";
+import {
+  mergeTrackMetadataOverrides,
+  readTrackMetadataOverrides,
+  type TrackMetadataOverride
+} from "../indexer/metadataOverrideStore";
+import { findCoverFileByTrackId } from "../storage/coverService";
+import type { Track } from "../../types/library";
+import { fetchAndSaveCoverArt, flushCoverArtNegativeCache } from "./coverArtArchiveService";
+import {
+  flushGenreCache,
+  lookupRecordingMetadata,
+  type RecordingMetadata
+} from "./musicBrainzService";
 import { normalizeGenreLabels } from "./genreSynonymService";
 import { createLogger } from "../../utils/logger";
 
@@ -37,19 +48,165 @@ export function stopEnrichment(): void {
   }
 }
 
+export type TrackEnrichmentInput = {
+  id: string;
+  artist: string;
+  title: string;
+  hasGenre: boolean;
+  hasYear: boolean;
+  hasCover: boolean;
+};
+
+export type TrackEnrichmentResult = {
+  genres: string[] | null;
+  year: number | null;
+  mbidRecording: string | null;
+  mbidReleaseGroup: string | null;
+  mbidArtist: string | null;
+  coverFetched: boolean;
+};
+
+function metadataDiffersFromOverride(
+  metadata: RecordingMetadata,
+  override: TrackMetadataOverride | undefined,
+  fillGenre: boolean,
+  fillYear: boolean,
+  normalizedGenres: string[]
+): boolean {
+  const next: TrackMetadataOverride = { ...(override ?? {}) };
+  let changed = false;
+
+  if (fillGenre && normalizedGenres.length > 0) {
+    if (JSON.stringify(next.genre) !== JSON.stringify(normalizedGenres)) {
+      next.genre = normalizedGenres;
+      changed = true;
+    }
+  }
+
+  if (fillYear && metadata.year !== undefined && next.year !== metadata.year) {
+    next.year = metadata.year;
+    changed = true;
+  }
+
+  if (metadata.recordingMbid && next.mbidRecording !== metadata.recordingMbid) {
+    next.mbidRecording = metadata.recordingMbid;
+    changed = true;
+  }
+
+  if (metadata.releaseGroupMbid && next.mbidReleaseGroup !== metadata.releaseGroupMbid) {
+    next.mbidReleaseGroup = metadata.releaseGroupMbid;
+    changed = true;
+  }
+
+  if (metadata.artistMbid && next.mbidArtist !== metadata.artistMbid) {
+    next.mbidArtist = metadata.artistMbid;
+    changed = true;
+  }
+
+  return changed;
+}
+
+/**
+ * Enrich a single track. Looks up the recording on MusicBrainz, fills missing
+ * genre/year/MBID overrides without clobbering existing ones, and downloads
+ * the front cover from the Cover Art Archive when the track has no embedded
+ * art and we have a release-group MBID.
+ */
+export async function enrichTrackMetadata(input: TrackEnrichmentInput): Promise<TrackEnrichmentResult> {
+  const result: TrackEnrichmentResult = {
+    genres: null,
+    year: null,
+    mbidRecording: null,
+    mbidReleaseGroup: null,
+    mbidArtist: null,
+    coverFetched: false
+  };
+
+  const metadata = await lookupRecordingMetadata(input.artist, input.title);
+  if (!metadata) return result;
+
+  const normalizedGenres = normalizeGenreLabels(metadata.genres);
+  const fillGenre = !input.hasGenre;
+  const fillYear = !input.hasYear;
+
+  const allOverrides = await readTrackMetadataOverrides();
+  const existingOverride = allOverrides[input.id];
+  const shouldWrite = metadataDiffersFromOverride(
+    metadata,
+    existingOverride,
+    fillGenre,
+    fillYear,
+    normalizedGenres
+  );
+
+  if (shouldWrite) {
+    const next: TrackMetadataOverride = { ...(existingOverride ?? {}) };
+    if (fillGenre && normalizedGenres.length > 0) next.genre = normalizedGenres;
+    if (fillYear && metadata.year !== undefined) next.year = metadata.year;
+    if (metadata.recordingMbid) next.mbidRecording = metadata.recordingMbid;
+    if (metadata.releaseGroupMbid) next.mbidReleaseGroup = metadata.releaseGroupMbid;
+    if (metadata.artistMbid) next.mbidArtist = metadata.artistMbid;
+    await mergeTrackMetadataOverrides({ [input.id]: next });
+  }
+
+  if (fillGenre && normalizedGenres.length > 0) result.genres = normalizedGenres;
+  if (fillYear && metadata.year !== undefined) result.year = metadata.year;
+  result.mbidRecording = metadata.recordingMbid ?? null;
+  result.mbidReleaseGroup = metadata.releaseGroupMbid ?? null;
+  result.mbidArtist = metadata.artistMbid ?? null;
+
+  if (!input.hasCover && metadata.releaseGroupMbid) {
+    const fetchResult = await fetchAndSaveCoverArt(input.id, metadata.releaseGroupMbid);
+    if (fetchResult.kind === "saved") {
+      result.coverFetched = true;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Backwards-compatible thin wrapper used by the upload-time hook in
+ * `api/upload/ingest.ts`. Newly uploaded tracks always have their freshly
+ * extracted state in hand at the call site, so we treat them as
+ * "missing genre" only when the caller passes us tracks that already lack
+ * one. The richer enrichTrackMetadata is preferred for new code.
+ */
 export async function enrichTrackGenre(
   trackId: string,
   artist: string,
-  title: string
+  title: string,
+  options: { hasYear?: boolean; hasCover?: boolean } = {}
 ): Promise<string[] | null> {
-  const rawGenres = await lookupGenre(artist, title);
-  if (rawGenres.length === 0) return null;
+  const result = await enrichTrackMetadata({
+    id: trackId,
+    artist,
+    title,
+    hasGenre: false,
+    hasYear: options.hasYear ?? true,
+    hasCover: options.hasCover ?? true
+  });
+  return result.genres;
+}
 
-  const genres = normalizeGenreLabels(rawGenres);
-  if (genres.length === 0) return null;
+function describeTrackEnrichmentNeeds(track: Track, hasCover: boolean): TrackEnrichmentInput | null {
+  const artist = track.tags.artist;
+  const title = track.tags.title;
+  if (!artist || !title) return null;
 
-  await mergeTrackMetadataOverrides({ [trackId]: { genre: genres } });
-  return genres;
+  const hasGenre = Array.isArray(track.tags.genre) && track.tags.genre.length > 0;
+  const hasYear = typeof track.tags.year === "number";
+
+  if (hasGenre && hasYear && hasCover) return null;
+
+  return {
+    id: track.id,
+    artist,
+    title,
+    hasGenre,
+    hasYear,
+    hasCover
+  };
 }
 
 export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<void> {
@@ -58,18 +215,18 @@ export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<v
     return;
   }
 
-  // Refresh the index so tracks added since the last scan (including files
-  // dropped directly into storage rather than uploaded via the UI) are
-  // considered.
   await indexStore.rebuild();
 
   const tracks = indexStore.getTracks();
-  const tracksWithoutGenre = tracks.filter(
-    (t) => !t.tags.genre || t.tags.genre.length === 0
-  );
+  const candidates: TrackEnrichmentInput[] = [];
+  for (const track of tracks) {
+    const cover = await findCoverFileByTrackId(track.id);
+    const needs = describeTrackEnrichmentNeeds(track, cover !== null);
+    if (needs) candidates.push(needs);
+  }
 
-  if (tracksWithoutGenre.length === 0) {
-    log.info("All tracks have genre metadata, nothing to enrich");
+  if (candidates.length === 0) {
+    log.info("All tracks have full metadata, nothing to enrich");
     status = {
       running: false,
       total: 0,
@@ -86,43 +243,48 @@ export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<v
 
   status = {
     running: true,
-    total: tracksWithoutGenre.length,
+    total: candidates.length,
     processed: 0,
     enriched: 0,
     failed: 0,
     startedAt: new Date().toISOString()
   };
 
-  log.info(`Starting genre enrichment for ${tracksWithoutGenre.length} tracks`);
+  log.info(`Starting metadata enrichment for ${candidates.length} tracks`);
 
-  let anyEnriched = false;
+  let anyMetadataWritten = false;
 
-  for (const track of tracksWithoutGenre) {
+  for (const candidate of candidates) {
     if (signal.aborted) {
-      log.info("Genre enrichment aborted");
+      log.info("Metadata enrichment aborted");
       break;
     }
 
-    const artist = track.tags.artist;
-    const title = track.tags.title;
-
-    if (!artist || !title) {
-      status.processed++;
-      continue;
-    }
-
     try {
-      const genres = await enrichTrackGenre(track.id, artist, title);
+      const result = await enrichTrackMetadata(candidate);
       status.processed++;
-      if (genres) {
+      const wroteMetadata =
+        result.genres !== null ||
+        result.year !== null ||
+        result.mbidRecording !== null ||
+        result.mbidReleaseGroup !== null ||
+        result.mbidArtist !== null;
+      if (wroteMetadata || result.coverFetched) {
         status.enriched++;
-        anyEnriched = true;
-        log.debug(`Enriched genre for "${title}" by "${artist}": ${genres.join(", ")}`);
+        if (wroteMetadata) anyMetadataWritten = true;
+        log.debug(
+          `Enriched "${candidate.title}" by "${candidate.artist}"`,
+          {
+            genres: result.genres ?? undefined,
+            year: result.year ?? undefined,
+            coverFetched: result.coverFetched
+          }
+        );
       }
     } catch (error) {
       status.processed++;
       status.failed++;
-      log.warn(`Failed to enrich genre for "${title}" by "${artist}"`, {
+      log.warn(`Failed to enrich "${candidate.title}" by "${candidate.artist}"`, {
         error: error instanceof Error ? error.message : String(error)
       });
     }
@@ -131,10 +293,11 @@ export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<v
   status.running = false;
   abortController = null;
   flushGenreCache();
-  if (anyEnriched) {
+  flushCoverArtNegativeCache();
+  if (anyMetadataWritten) {
     await indexStore.rebuild();
   }
   log.info(
-    `Genre enrichment complete: ${status.enriched} enriched, ${status.failed} failed, ${status.processed} processed out of ${status.total}`
+    `Metadata enrichment complete: ${status.enriched} enriched, ${status.failed} failed, ${status.processed} processed out of ${status.total}`
   );
 }

--- a/backend/src/services/genre/musicBrainzService.test.ts
+++ b/backend/src/services/genre/musicBrainzService.test.ts
@@ -233,3 +233,212 @@ describe("musicBrainzService", () => {
     expect(fsSync.existsSync(`${CACHE_FILE}.tmp`)).toBe(false);
   });
 });
+
+describe("musicBrainzService.lookupRecordingMetadata", () => {
+  const RECORDING_MBID = "11111111-1111-4111-8111-111111111111";
+  const RELEASE_GROUP_MBID = "22222222-2222-4222-8222-222222222222";
+  const ARTIST_MBID = "33333333-3333-4333-8333-333333333333";
+
+  it("returns full metadata with MBIDs and year from the earliest Album release", async () => {
+    let phase = 0;
+    fetchHandler = (url) => {
+      phase++;
+      if (phase === 1) {
+        return {
+          status: 200,
+          body: recordingsResponse([{ score: 95, id: RECORDING_MBID, tags: ["rock"] }])
+        };
+      }
+      // Detail fetch — returns 2 album releases (2003 and 2001) + 1 single
+      expect(url).toMatch(/inc=[^&]*release-groups/);
+      return {
+        status: 200,
+        body: {
+          id: RECORDING_MBID,
+          "artist-credit": [{ artist: { id: ARTIST_MBID, name: "Artist" } }],
+          releases: [
+            {
+              id: "rel-1",
+              "release-group": {
+                id: "rg-2003",
+                "first-release-date": "2003-05-01",
+                "primary-type": "Album"
+              }
+            },
+            {
+              id: "rel-2",
+              "release-group": {
+                id: RELEASE_GROUP_MBID,
+                "first-release-date": "2001-09-15",
+                "primary-type": "Album"
+              }
+            },
+            {
+              id: "rel-3",
+              "release-group": {
+                id: "rg-single-1999",
+                "first-release-date": "1999-01-01",
+                "primary-type": "Single"
+              }
+            }
+          ],
+          tags: [{ name: "rock" }],
+          genres: []
+        }
+      };
+    };
+    const { lookupRecordingMetadata } = await loadModule();
+    const result = await lookupRecordingMetadata("Artist", "Song");
+    expect(result).not.toBeNull();
+    expect(result!.recordingMbid).toBe(RECORDING_MBID);
+    expect(result!.releaseGroupMbid).toBe(RELEASE_GROUP_MBID);
+    expect(result!.artistMbid).toBe(ARTIST_MBID);
+    expect(result!.year).toBe(2001);
+    expect(result!.genres).toEqual(["Rock"]);
+  });
+
+  it("falls back to non-Album releases when no Album exists", async () => {
+    let phase = 0;
+    fetchHandler = () => {
+      phase++;
+      if (phase === 1) {
+        return {
+          status: 200,
+          body: recordingsResponse([{ score: 95, id: RECORDING_MBID }])
+        };
+      }
+      return {
+        status: 200,
+        body: {
+          id: RECORDING_MBID,
+          "artist-credit": [{ artist: { id: ARTIST_MBID } }],
+          releases: [
+            {
+              "release-group": {
+                id: "rg-ep-2010",
+                "first-release-date": "2010-06-01",
+                "primary-type": "EP"
+              }
+            }
+          ]
+        }
+      };
+    };
+    const { lookupRecordingMetadata } = await loadModule();
+    const result = await lookupRecordingMetadata("X", "Y");
+    expect(result?.releaseGroupMbid).toBe("rg-ep-2010");
+    expect(result?.year).toBe(2010);
+  });
+
+  it("returns null on a confirmed miss (no high-score recording)", async () => {
+    fetchHandler = () => ({ status: 200, body: recordingsResponse([{ score: 60, tags: ["rock"] }]) });
+    const { lookupRecordingMetadata } = await loadModule();
+    const result = await lookupRecordingMetadata("X", "Y");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on transient error and does not cache it", async () => {
+    fetchHandler = () => ({ status: 503 });
+    const { lookupRecordingMetadata, flushGenreCache } = await loadModule();
+    expect(await lookupRecordingMetadata("X", "Y")).toBeNull();
+    flushGenreCache();
+    expect(fsSync.existsSync(CACHE_FILE)).toBe(false);
+  });
+
+  it("re-fetches a Phase 1 cache hit when a richer lookup is requested", async () => {
+    // Pre-populate cache with a Phase 1 entry (no richVersion, just genres).
+    fsSync.mkdirSync(tmpDir, { recursive: true });
+    const phase1 = {
+      "artist|||song": {
+        cachedAt: Date.now(),
+        status: "hit",
+        genres: ["Rock"]
+      }
+    };
+    fsSync.writeFileSync(CACHE_FILE, JSON.stringify(phase1), "utf8");
+
+    let phase = 0;
+    fetchHandler = () => {
+      phase++;
+      if (phase === 1) {
+        return {
+          status: 200,
+          body: recordingsResponse([{ score: 95, id: RECORDING_MBID, tags: ["rock"] }])
+        };
+      }
+      return {
+        status: 200,
+        body: {
+          id: RECORDING_MBID,
+          "artist-credit": [{ artist: { id: ARTIST_MBID } }],
+          releases: [
+            {
+              "release-group": {
+                id: RELEASE_GROUP_MBID,
+                "first-release-date": "1999-01-01",
+                "primary-type": "Album"
+              }
+            }
+          ]
+        }
+      };
+    };
+
+    const { lookupRecordingMetadata, lookupGenre } = await loadModule();
+
+    // Genre-only lookup is served from the legacy cache without fetching.
+    fetchCalls = [];
+    expect(await lookupGenre("Artist", "Song")).toEqual(["Rock"]);
+    expect(fetchCalls).toEqual([]);
+
+    // Rich lookup detects Phase 1 entry and re-fetches.
+    const rich = await lookupRecordingMetadata("Artist", "Song");
+    expect(rich?.recordingMbid).toBe(RECORDING_MBID);
+    expect(rich?.releaseGroupMbid).toBe(RELEASE_GROUP_MBID);
+    expect(rich?.year).toBe(1999);
+  });
+
+  it("caches a rich miss so the next call returns from cache without fetching", async () => {
+    fetchHandler = () => ({ status: 200, body: { recordings: [] } });
+    const { lookupRecordingMetadata } = await loadModule();
+    expect(await lookupRecordingMetadata("Unknown", "Unknown")).toBeNull();
+    fetchCalls = [];
+    expect(await lookupRecordingMetadata("Unknown", "Unknown")).toBeNull();
+    expect(fetchCalls).toEqual([]);
+  });
+
+  it("caches a rich hit so the next call returns from cache without fetching", async () => {
+    let phase = 0;
+    fetchHandler = () => {
+      phase++;
+      if (phase === 1) {
+        return { status: 200, body: recordingsResponse([{ score: 95, id: RECORDING_MBID }]) };
+      }
+      return {
+        status: 200,
+        body: {
+          id: RECORDING_MBID,
+          "artist-credit": [{ artist: { id: ARTIST_MBID } }],
+          releases: [
+            {
+              "release-group": {
+                id: RELEASE_GROUP_MBID,
+                "first-release-date": "1979-03-23",
+                "primary-type": "Album"
+              }
+            }
+          ],
+          tags: [{ name: "rock" }]
+        }
+      };
+    };
+    const { lookupRecordingMetadata } = await loadModule();
+    const first = await lookupRecordingMetadata("X", "Y");
+    expect(first?.year).toBe(1979);
+    fetchCalls = [];
+    const second = await lookupRecordingMetadata("X", "Y");
+    expect(second?.year).toBe(1979);
+    expect(second?.releaseGroupMbid).toBe(RELEASE_GROUP_MBID);
+    expect(fetchCalls).toEqual([]);
+  });
+});

--- a/backend/src/services/genre/musicBrainzService.ts
+++ b/backend/src/services/genre/musicBrainzService.ts
@@ -14,6 +14,7 @@ const CACHE_FLUSH_DEBOUNCE_MS = 500;
 const NEGATIVE_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const MIN_SCORE_THRESHOLD = 80;
 const RECORDING_SEARCH_LIMIT = 10;
+const RICH_SCHEMA_VERSION = 1;
 
 function readVersion(): string {
   try {
@@ -28,10 +29,26 @@ function readVersion(): string {
 
 const USER_AGENT = `flaque/${readVersion()} (https://github.com/Marma92/flaque)`;
 
-type CacheEntry = {
+export type RecordingMetadata = {
   genres: string[];
+  recordingMbid?: string;
+  releaseGroupMbid?: string;
+  artistMbid?: string;
+  year?: number;
+};
+
+type CacheEntry = {
   cachedAt: number;
   status: "hit" | "miss";
+  // Set to RICH_SCHEMA_VERSION once we've populated MBIDs and year. Absent
+  // for Phase 1 entries (genres-only), which trigger a refetch when a
+  // caller asks for richer metadata.
+  richVersion?: number;
+  genres: string[];
+  recordingMbid?: string;
+  releaseGroupMbid?: string;
+  artistMbid?: string;
+  year?: number;
 };
 
 type GenreCache = Record<string, CacheEntry>;
@@ -41,19 +58,21 @@ let cache: GenreCache | null = null;
 let cacheDirty = false;
 let saveTimer: NodeJS.Timeout | null = null;
 let lastRequestTime = 0;
-const inflight = new Map<string, Promise<string[]>>();
+const inflightGenre = new Map<string, Promise<string[]>>();
+const inflightRich = new Map<string, Promise<RecordingMetadata | null>>();
 
 function cacheKey(artist: string, title: string): string {
   return `${artist.toLowerCase().trim()}|||${title.toLowerCase().trim()}`;
 }
 
-function isLegacyEntry(value: unknown): value is string[] {
+function isLegacyArrayEntry(value: unknown): value is string[] {
   return Array.isArray(value);
 }
 
-function migrateLegacyEntry(value: string[]): CacheEntry {
-  // Old format had no timestamp; treat empty arrays as expired misses so
-  // they get re-fetched, and non-empty arrays as forever-valid hits.
+function migrateLegacyArrayEntry(value: string[]): CacheEntry {
+  // Pre-Phase-1 array format. Empty arrays migrate as expired misses so they
+  // get re-fetched; non-empty arrays migrate as Phase 1-style hits (no
+  // richVersion, so a richer-lookup caller will trigger a refetch).
   return {
     genres: value,
     cachedAt: value.length > 0 ? Date.now() : 0,
@@ -70,8 +89,8 @@ function loadCache(): GenreCache {
       const parsed = JSON.parse(raw) as GenreCache | LegacyGenreCache;
       const migrated: GenreCache = {};
       for (const [key, value] of Object.entries(parsed)) {
-        if (isLegacyEntry(value)) {
-          migrated[key] = migrateLegacyEntry(value);
+        if (isLegacyArrayEntry(value)) {
+          migrated[key] = migrateLegacyArrayEntry(value);
         } else if (value && typeof value === "object" && Array.isArray((value as CacheEntry).genres)) {
           migrated[key] = value as CacheEntry;
         }
@@ -117,9 +136,26 @@ function scheduleCacheSave(): void {
   saveTimer.unref?.();
 }
 
-function isCacheEntryFresh(entry: CacheEntry): boolean {
+function isCacheEntryFreshForGenre(entry: CacheEntry): boolean {
   if (entry.status === "hit") return true;
   return Date.now() - entry.cachedAt < NEGATIVE_CACHE_TTL_MS;
+}
+
+function isCacheEntryFreshForRich(entry: CacheEntry): boolean {
+  // Phase 1 hits (no richVersion) need a refetch to get MBIDs and year.
+  if (entry.status === "hit") return entry.richVersion === RICH_SCHEMA_VERSION;
+  return Date.now() - entry.cachedAt < NEGATIVE_CACHE_TTL_MS;
+}
+
+function entryToMetadata(entry: CacheEntry): RecordingMetadata | null {
+  if (entry.status === "miss") return null;
+  return {
+    genres: entry.genres,
+    recordingMbid: entry.recordingMbid,
+    releaseGroupMbid: entry.releaseGroupMbid,
+    artistMbid: entry.artistMbid,
+    year: entry.year
+  };
 }
 
 async function waitForRateLimit(): Promise<void> {
@@ -131,11 +167,24 @@ async function waitForRateLimit(): Promise<void> {
   lastRequestTime = Date.now();
 }
 
+type MBTagOrGenre = { name?: string; count?: number };
+type MBArtistCredit = { artist?: { id?: string; name?: string }; joinphrase?: string };
+type MBReleaseGroup = {
+  id?: string;
+  "first-release-date"?: string;
+  "primary-type"?: string;
+};
+type MBRelease = {
+  id?: string;
+  date?: string;
+  "release-group"?: MBReleaseGroup;
+};
+
 type MBRecording = {
   id?: string;
   score?: number;
-  tags?: Array<{ name?: string; count?: number }>;
-  genres?: Array<{ name?: string; count?: number }>;
+  tags?: MBTagOrGenre[];
+  genres?: MBTagOrGenre[];
 };
 
 type MBSearchResult = {
@@ -143,8 +192,11 @@ type MBSearchResult = {
 };
 
 type MBRecordingDetail = {
-  genres?: Array<{ name?: string; count?: number }>;
-  tags?: Array<{ name?: string; count?: number }>;
+  id?: string;
+  genres?: MBTagOrGenre[];
+  tags?: MBTagOrGenre[];
+  "artist-credit"?: MBArtistCredit[];
+  releases?: MBRelease[];
 };
 
 function extractGenres(recording: MBRecording | MBRecordingDetail): string[] {
@@ -167,6 +219,61 @@ function extractGenres(recording: MBRecording | MBRecordingDetail): string[] {
   }
 
   return genres;
+}
+
+function extractYearFromDate(date: string | undefined): number | undefined {
+  if (!date) return undefined;
+  const match = /^(\d{4})/.exec(date);
+  if (!match) return undefined;
+  const year = Number.parseInt(match[1]!, 10);
+  if (!Number.isInteger(year) || year < 1000 || year > 2999) return undefined;
+  return year;
+}
+
+type CanonicalRelease = {
+  releaseGroupMbid: string | undefined;
+  year: number | undefined;
+};
+
+function pickCanonicalRelease(detail: MBRecordingDetail): CanonicalRelease {
+  const releases = detail.releases ?? [];
+  const albums = releases.filter(
+    (r) => r["release-group"]?.["primary-type"] === "Album" && r["release-group"]?.id
+  );
+  const candidates = albums.length > 0
+    ? albums
+    : releases.filter((r) => r["release-group"]?.id);
+
+  if (candidates.length === 0) {
+    return { releaseGroupMbid: undefined, year: undefined };
+  }
+
+  let bestId: string | undefined;
+  let bestYear: number | undefined;
+
+  for (const rel of candidates) {
+    const rg = rel["release-group"]!;
+    const year = extractYearFromDate(rg["first-release-date"]);
+    if (year !== undefined) {
+      if (bestYear === undefined || year < bestYear) {
+        bestYear = year;
+        bestId = rg.id;
+      }
+    } else if (bestId === undefined) {
+      bestId = rg.id;
+    }
+  }
+
+  return { releaseGroupMbid: bestId, year: bestYear };
+}
+
+function extractArtistMbid(detail: MBRecordingDetail): string | undefined {
+  const credits = detail["artist-credit"] ?? [];
+  for (const credit of credits) {
+    const id = credit.artist?.id;
+    if (typeof id === "string" && id.trim()) return id.trim();
+  }
+  return undefined;
 }
 
 const LUCENE_SPECIAL = /([+\-!(){}\[\]^"~*?:\\/]|&&|\|\|)/g;
@@ -247,45 +354,66 @@ async function searchRecording(artist: string, title: string): Promise<SearchOut
   return { kind: "hit", recording: best };
 }
 
-async function fetchRecordingDetail(recordingId: string): Promise<MBRecordingDetail | null> {
+type DetailOutcome =
+  | { kind: "ok"; detail: MBRecordingDetail }
+  | { kind: "transient" }
+  | { kind: "missing" };
+
+async function fetchRecordingDetail(recordingId: string, withReleaseGroups: boolean): Promise<DetailOutcome> {
   await waitForRateLimit();
 
-  const detailUrl = `${MB_BASE_URL}/recording/${recordingId}?inc=genres+tags&fmt=json`;
+  const inc = withReleaseGroups
+    ? "genres+tags+artist-credits+releases+release-groups"
+    : "genres+tags";
+  const detailUrl = `${MB_BASE_URL}/recording/${recordingId}?inc=${inc}&fmt=json`;
+  let response: Response;
   try {
-    const detailResponse = await fetch(detailUrl, {
+    response = await fetch(detailUrl, {
       headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
     });
-    if (!detailResponse.ok) return null;
-    return (await detailResponse.json()) as MBRecordingDetail;
   } catch (error) {
     log.warn("MusicBrainz detail fetch failed", {
       recordingId,
       error: error instanceof Error ? error.message : String(error)
     });
-    return null;
+    return { kind: "transient" };
+  }
+
+  if (response.status >= 500 || response.status === 429) {
+    return { kind: "transient" };
+  }
+  if (!response.ok) {
+    return { kind: "missing" };
+  }
+
+  try {
+    const detail = (await response.json()) as MBRecordingDetail;
+    return { kind: "ok", detail };
+  } catch (error) {
+    log.warn("MusicBrainz detail returned invalid JSON", {
+      recordingId,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return { kind: "transient" };
   }
 }
 
-type LookupResult =
+type LookupGenreResult =
   | { kind: "resolved"; genres: string[]; status: "hit" | "miss" }
   | { kind: "transient" };
 
-async function lookupGenresUncached(artist: string, title: string): Promise<LookupResult> {
-  const passes: string[] = [title];
-  const simplified = simplifyTitle(title);
-  if (simplified && simplified.toLowerCase() !== title.toLowerCase()) {
-    passes.push(simplified);
-  }
+type LookupRichResult =
+  | { kind: "resolved"; metadata: RecordingMetadata | null }
+  | { kind: "transient" };
+
+async function lookupGenresUncached(artist: string, title: string): Promise<LookupGenreResult> {
+  const passes = buildTitlePasses(title);
 
   for (const candidateTitle of passes) {
     const outcome = await searchRecording(artist, candidateTitle);
-    if (outcome.kind === "transient") {
-      return { kind: "transient" };
-    }
-    if (outcome.kind === "miss") {
-      continue;
-    }
+    if (outcome.kind === "transient") return { kind: "transient" };
+    if (outcome.kind === "miss") continue;
 
     const fromSearch = extractGenres(outcome.recording);
     if (fromSearch.length > 0) {
@@ -294,16 +422,62 @@ async function lookupGenresUncached(artist: string, title: string): Promise<Look
 
     if (!outcome.recording.id) continue;
 
-    const detail = await fetchRecordingDetail(outcome.recording.id);
-    if (!detail) continue;
+    const detail = await fetchRecordingDetail(outcome.recording.id, false);
+    if (detail.kind === "transient") return { kind: "transient" };
+    if (detail.kind === "missing") continue;
 
-    const fromDetail = extractGenres(detail);
+    const fromDetail = extractGenres(detail.detail);
     if (fromDetail.length > 0) {
       return { kind: "resolved", genres: fromDetail, status: "hit" };
     }
   }
 
   return { kind: "resolved", genres: [], status: "miss" };
+}
+
+async function lookupRecordingMetadataUncached(artist: string, title: string): Promise<LookupRichResult> {
+  const passes = buildTitlePasses(title);
+
+  for (const candidateTitle of passes) {
+    const outcome = await searchRecording(artist, candidateTitle);
+    if (outcome.kind === "transient") return { kind: "transient" };
+    if (outcome.kind === "miss") continue;
+    if (!outcome.recording.id) continue;
+
+    const detail = await fetchRecordingDetail(outcome.recording.id, true);
+    if (detail.kind === "transient") return { kind: "transient" };
+    if (detail.kind === "missing") continue;
+
+    const genres = (() => {
+      const fromSearch = extractGenres(outcome.recording);
+      if (fromSearch.length > 0) return fromSearch;
+      return extractGenres(detail.detail);
+    })();
+    const { releaseGroupMbid, year } = pickCanonicalRelease(detail.detail);
+    const artistMbid = extractArtistMbid(detail.detail);
+
+    return {
+      kind: "resolved",
+      metadata: {
+        genres,
+        recordingMbid: outcome.recording.id,
+        releaseGroupMbid,
+        artistMbid,
+        year
+      }
+    };
+  }
+
+  return { kind: "resolved", metadata: null };
+}
+
+function buildTitlePasses(title: string): string[] {
+  const passes: string[] = [title];
+  const simplified = simplifyTitle(title);
+  if (simplified && simplified.toLowerCase() !== title.toLowerCase()) {
+    passes.push(simplified);
+  }
+  return passes;
 }
 
 export function lookupGenre(artist: string, title: string): Promise<string[]> {
@@ -315,22 +489,20 @@ export function lookupGenre(artist: string, title: string): Promise<string[]> {
   const key = cacheKey(artist, title);
 
   const existing = c[key];
-  if (existing && isCacheEntryFresh(existing)) {
+  if (existing && isCacheEntryFreshForGenre(existing)) {
     return Promise.resolve(existing.genres);
   }
 
-  const inflightPromise = inflight.get(key);
-  if (inflightPromise) {
-    return inflightPromise;
-  }
+  const inflightPromise = inflightGenre.get(key);
+  if (inflightPromise) return inflightPromise;
 
   const promise = (async (): Promise<string[]> => {
     try {
       const result = await lookupGenresUncached(artist, title);
-      if (result.kind === "transient") {
-        return [];
-      }
+      if (result.kind === "transient") return [];
+      const previous = c[key];
       c[key] = {
+        ...previous,
         genres: result.genres,
         cachedAt: Date.now(),
         status: result.status
@@ -338,11 +510,52 @@ export function lookupGenre(artist: string, title: string): Promise<string[]> {
       scheduleCacheSave();
       return result.genres;
     } finally {
-      inflight.delete(key);
+      inflightGenre.delete(key);
     }
   })();
 
-  inflight.set(key, promise);
+  inflightGenre.set(key, promise);
+  return promise;
+}
+
+export function lookupRecordingMetadata(artist: string, title: string): Promise<RecordingMetadata | null> {
+  if (!artist.trim() || !title.trim()) {
+    return Promise.resolve(null);
+  }
+
+  const c = loadCache();
+  const key = cacheKey(artist, title);
+
+  const existing = c[key];
+  if (existing && isCacheEntryFreshForRich(existing)) {
+    return Promise.resolve(entryToMetadata(existing));
+  }
+
+  const inflightPromise = inflightRich.get(key);
+  if (inflightPromise) return inflightPromise;
+
+  const promise = (async (): Promise<RecordingMetadata | null> => {
+    try {
+      const result = await lookupRecordingMetadataUncached(artist, title);
+      if (result.kind === "transient") return null;
+      c[key] = {
+        cachedAt: Date.now(),
+        status: result.metadata ? "hit" : "miss",
+        richVersion: RICH_SCHEMA_VERSION,
+        genres: result.metadata?.genres ?? [],
+        recordingMbid: result.metadata?.recordingMbid,
+        releaseGroupMbid: result.metadata?.releaseGroupMbid,
+        artistMbid: result.metadata?.artistMbid,
+        year: result.metadata?.year
+      };
+      scheduleCacheSave();
+      return result.metadata;
+    } finally {
+      inflightRich.delete(key);
+    }
+  })();
+
+  inflightRich.set(key, promise);
   return promise;
 }
 
@@ -353,7 +566,8 @@ export function getGenreCacheStats(): { entries: number } {
 
 export function clearGenreCache(): void {
   cache = {};
-  inflight.clear();
+  inflightGenre.clear();
+  inflightRich.clear();
   cacheDirty = true;
   flushCacheNow();
 }

--- a/backend/src/services/indexer/metadataOverrideStore.test.ts
+++ b/backend/src/services/indexer/metadataOverrideStore.test.ts
@@ -87,6 +87,49 @@ describe("metadataOverrideStore", () => {
     });
     await pruneTrackMetadataOverrides(["keep"]);
     const after = await readTrackMetadataOverrides();
-    expect(after).toEqual({ keep: { title: "Kept", artist: undefined, album: undefined, year: undefined, genre: undefined } });
+    expect(after).toEqual({
+      keep: {
+        title: "Kept",
+        artist: undefined,
+        album: undefined,
+        year: undefined,
+        genre: undefined,
+        mbidRecording: undefined,
+        mbidReleaseGroup: undefined,
+        mbidArtist: undefined
+      }
+    });
+  });
+
+  it("persists MBID fields and validates UUID shape", async () => {
+    const validMbid = "0123abcd-1234-5678-9abc-def012345678";
+    const result = await mergeTrackMetadataOverrides({
+      "track-1": {
+        genre: ["Rock"],
+        mbidRecording: validMbid,
+        mbidReleaseGroup: validMbid,
+        mbidArtist: validMbid
+      }
+    });
+    expect(result["track-1"]?.mbidRecording).toBe(validMbid);
+    expect(result["track-1"]?.mbidReleaseGroup).toBe(validMbid);
+    expect(result["track-1"]?.mbidArtist).toBe(validMbid);
+
+    // Round-trip through readTrackMetadataOverrides
+    const readBack = await readTrackMetadataOverrides();
+    expect(readBack["track-1"]?.mbidRecording).toBe(validMbid);
+  });
+
+  it("rejects invalid MBID values silently", async () => {
+    const result = await mergeTrackMetadataOverrides({
+      "track-1": {
+        title: "X",
+        mbidRecording: "not-a-uuid" as unknown as string,
+        mbidArtist: "" as unknown as string
+      }
+    });
+    expect(result["track-1"]?.title).toBe("X");
+    expect(result["track-1"]?.mbidRecording).toBeUndefined();
+    expect(result["track-1"]?.mbidArtist).toBeUndefined();
   });
 });

--- a/backend/src/services/indexer/metadataOverrideStore.ts
+++ b/backend/src/services/indexer/metadataOverrideStore.ts
@@ -7,7 +7,12 @@ export type TrackMetadataOverride = {
   album?: string;
   year?: number;
   genre?: string[];
+  mbidRecording?: string;
+  mbidReleaseGroup?: string;
+  mbidArtist?: string;
 };
+
+const MBID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 type TrackMetadataOverridesMap = Record<string, TrackMetadataOverride>;
 
@@ -41,6 +46,12 @@ function normalizeGenre(value: unknown): string[] | undefined {
   return genres.length > 0 ? genres : undefined;
 }
 
+function normalizeMbid(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim().toLowerCase();
+  return MBID_PATTERN.test(trimmed) ? trimmed : undefined;
+}
+
 function normalizeOverride(override: unknown): TrackMetadataOverride | undefined {
   if (!override || typeof override !== "object") {
     return undefined;
@@ -52,8 +63,20 @@ function normalizeOverride(override: unknown): TrackMetadataOverride | undefined
   const title = normalizeField(record.title);
   const year = normalizeYear(record.year);
   const genre = normalizeGenre(record.genre);
+  const mbidRecording = normalizeMbid(record.mbidRecording);
+  const mbidReleaseGroup = normalizeMbid(record.mbidReleaseGroup);
+  const mbidArtist = normalizeMbid(record.mbidArtist);
 
-  if (!title && !artist && !album && year === undefined && !genre) {
+  if (
+    !title &&
+    !artist &&
+    !album &&
+    year === undefined &&
+    !genre &&
+    !mbidRecording &&
+    !mbidReleaseGroup &&
+    !mbidArtist
+  ) {
     return undefined;
   }
 
@@ -62,7 +85,10 @@ function normalizeOverride(override: unknown): TrackMetadataOverride | undefined
     artist,
     album,
     year,
-    genre
+    genre,
+    mbidRecording,
+    mbidReleaseGroup,
+    mbidArtist
   };
 }
 
@@ -125,7 +151,10 @@ export async function mergeTrackMetadataOverrides(
           existing?.artist === cleanOverride.artist &&
           existing?.album === cleanOverride.album &&
           existing?.year === cleanOverride.year &&
-          JSON.stringify(existing?.genre) === JSON.stringify(cleanOverride.genre)
+          JSON.stringify(existing?.genre) === JSON.stringify(cleanOverride.genre) &&
+          existing?.mbidRecording === cleanOverride.mbidRecording &&
+          existing?.mbidReleaseGroup === cleanOverride.mbidReleaseGroup &&
+          existing?.mbidArtist === cleanOverride.mbidArtist
         ) {
           continue;
         }


### PR DESCRIPTION
> Stacked on top of #170 (Phase 1). Diff shown here is Phase 2 only; the diff against master will include Phase 1 once #170 merges.

## Summary

Builds on the Phase 1 cache infrastructure to extract more value from each MB lookup. The bulk enrichment pass now closes year and cover gaps in addition to genre, and persists MBIDs so future re-lookups can be deterministic instead of name-search-based.

**MB lookup (\`musicBrainzService.ts\`)**
- New \`lookupRecordingMetadata(artist, title)\` returns \`{ genres, recordingMbid, releaseGroupMbid, artistMbid, year } | null\`.
- Year is extracted from the earliest release-group whose primary-type is \"Album\"; if no Album exists, the earliest release-group of any type is used.
- Detail fetch now uses \`inc=genres+tags+artist-credits+releases+release-groups\` so a single fetch grabs everything needed.
- Cache schema gained an optional \`richVersion\` marker. Phase 1 hits keep serving \`lookupGenre\` from cache, but trigger a refetch on \`lookupRecordingMetadata\` so MBIDs/year populate without invalidating prior genre work.

**Override store (\`metadataOverrideStore.ts\`)**
- \`TrackMetadataOverride\` gains optional \`mbidRecording\`, \`mbidReleaseGroup\`, \`mbidArtist\`. UUIDs are validated; malformed values are silently dropped.
- Change detection in \`mergeTrackMetadataOverrides\` accounts for the new fields so MBID-only patches actually persist.

**Cover Art Archive (\`coverArtArchiveService.ts\`, new)**
- \`fetchAndSaveCoverArt(trackId, releaseGroupMbid)\` downloads \`https://coverartarchive.org/release-group/<mbid>/front-500\` and writes it atomically to \`coversRoot/<trackId>.jpg\`.
- 404s are remembered in a 30-day negative cache so we don't re-hit CAA every enrichment run.
- 5xx, 429, and network errors are NOT cached as misses; the next run retries.

**Enrichment orchestration (\`genreEnrichmentService.ts\`)**
- New \`enrichTrackMetadata(input)\` is the single per-track unit of work. Looks up MB, fills missing genre/year/MBIDs in the override (preserving anything the admin manually edited), and downloads the front cover from CAA when the track has no embedded art and we have a \`releaseGroupMbid\`.
- \`runBackgroundEnrichment\`'s gate broadened from \"missing genre\" to \"missing genre OR year OR cover\".
- \`enrichTrackGenre\` kept as a back-compat wrapper for the upload-time hook in \`api/upload/ingest.ts\`.

**Tests (+16)**
- Rich lookup: full metadata extraction, earliest-Album preference, fallback to non-Album, miss caching, transient error not cached, Phase 1 hit triggers refetch.
- Override store: MBID round-trip, malformed MBID rejected.
- Cover Art Archive: download + atomic write, 404 negative caching with 30-day TTL, 5xx not cached, network throw not cached, separate release-groups don't share negative cache.

## Cache invalidation behavior on first deploy

Existing Phase 1 cache entries continue to serve genre lookups, but the first \`lookupRecordingMetadata\` for each (artist, title) pair triggers one fresh MB call to populate MBIDs/year. Misses from Phase 1 stay respected by their original 7-day TTL.

## Test plan
- [ ] Run enrichment on a library where some tracks lack year — confirm year override is set without overwriting embedded years.
- [ ] Run enrichment on a track that already has a manually-edited year — confirm the override is preserved.
- [ ] Run enrichment on a track without embedded cover but with a known release-group on CAA — confirm \`coversRoot/<trackId>.jpg\` appears and the UI shows it.
- [ ] Run enrichment on a track whose release-group has no CAA art — confirm subsequent runs don't re-hit CAA.
- [ ] Inspect \`track-metadata-overrides.json\` and confirm \`mbidRecording\`/\`mbidReleaseGroup\`/\`mbidArtist\` fields are populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)