### PR TITLE
feat(musicbrainz): phase 3 - admin observability and per-track control

### DIFF
--- a/backend/src/api/genreRoutes.ts
+++ b/backend/src/api/genreRoutes.ts
@@ -4,9 +4,15 @@ import { requireAdmin, requireAuth } from "../auth/middleware";
 import type { IndexStore } from "../services/indexer/indexStore";
 import {
   getEnrichmentStatus,
+  reEnrichTrack,
+  reapplySynonymsToOverrides,
   runBackgroundEnrichment,
   stopEnrichment
 } from "../services/genre/genreEnrichmentService";
+import {
+  clearEnrichmentLog,
+  readEnrichmentLog
+} from "../services/genre/enrichmentLogStore";
 import {
   getSynonyms,
   setSynonym,
@@ -45,6 +51,54 @@ export function createGenreRouter(indexStore: IndexStore): Router {
     res.json({ stopped: true });
   });
 
+  router.get("/genre/enrichment/log", requireAuth, requireAdmin, async (req, res, next) => {
+    try {
+      const limitRaw = typeof req.query.limit === "string" ? Number(req.query.limit) : 100;
+      const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.floor(limitRaw) : 100;
+      const entries = await readEnrichmentLog(limit);
+      res.json({ entries });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.delete("/genre/enrichment/log", requireAuth, requireAdmin, async (req, res, next) => {
+    try {
+      await clearEnrichmentLog();
+      log.info("Enrichment log cleared", { userId: req.authUser?.id ?? "unknown" });
+      res.json({ cleared: true });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/genre/enrichment/track/:trackId", requireAuth, requireAdmin, async (req, res, next) => {
+    try {
+      const trackId = req.params.trackId;
+      if (!trackId) {
+        return next(new AppError("Track id is required", 400));
+      }
+      const track = indexStore.getTrackById(trackId);
+      if (!track) {
+        return next(new AppError("Track not found", 404));
+      }
+      if (!track.tags.artist || !track.tags.title) {
+        return next(new AppError("Track is missing artist or title; cannot re-enrich", 400));
+      }
+
+      log.info("Track re-enrichment requested", {
+        trackId,
+        title: track.tags.title,
+        userId: req.authUser?.id ?? "unknown"
+      });
+
+      const result = await reEnrichTrack(track, indexStore);
+      res.json({ trackId, result });
+    } catch (error) {
+      next(error);
+    }
+  });
+
   router.get("/genre/synonyms", requireAuth, requireAdmin, (_req, res) => {
     res.json(getSynonyms());
   });
@@ -79,6 +133,20 @@ export function createGenreRouter(indexStore: IndexStore): Router {
     resetSynonymsToDefaults();
     log.info("Genre synonyms reset to defaults", { userId: _req.authUser?.id ?? "unknown" });
     res.json({ reset: true });
+  });
+
+  router.post("/genre/synonyms/reapply", requireAuth, requireAdmin, async (req, res, next) => {
+    try {
+      const result = await reapplySynonymsToOverrides(indexStore);
+      log.info("Genre synonyms reapplied to library", {
+        scanned: result.scanned,
+        updated: result.updated,
+        userId: req.authUser?.id ?? "unknown"
+      });
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
   });
 
   router.get("/genre/cache/stats", requireAuth, requireAdmin, (_req, res) => {

--- a/backend/src/services/genre/coverArtArchiveService.test.ts
+++ b/backend/src/services/genre/coverArtArchiveService.test.ts
@@ -57,7 +57,7 @@ beforeEach(async () => {
     const result = fetchHandler(url);
     if (result.throw) throw result.throw;
     const body = result.body ?? Buffer.alloc(0);
-    return new Response(body, {
+    return new Response(body as unknown as BodyInit, {
       status: result.status ?? 200
     });
   }));

--- a/backend/src/services/genre/enrichmentLogStore.test.ts
+++ b/backend/src/services/genre/enrichmentLogStore.test.ts
@@ -1,0 +1,138 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { tmpDir } = vi.hoisted(() => {
+  const fsS = require("node:fs") as typeof import("node:fs");
+  const osM = require("node:os") as typeof import("node:os");
+  const pathM = require("node:path") as typeof import("node:path");
+  return {
+    tmpDir: fsS.mkdtempSync(pathM.join(osM.tmpdir(), "enrichment-log-test-"))
+  };
+});
+
+vi.mock("../../utils/paths", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../utils/paths")>()),
+  cacheRoot: tmpDir
+}));
+
+vi.mock("../../utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+const LOG_FILE = path.join(tmpDir, "musicbrainz-enrichment-log.jsonl");
+
+beforeEach(async () => {
+  vi.resetModules();
+  for (const entry of await fs.readdir(tmpDir).catch(() => [])) {
+    await fs.rm(path.join(tmpDir, entry), { recursive: true, force: true });
+  }
+});
+
+afterAll(() => {
+  fsSync.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function loadModule(): Promise<typeof import("./enrichmentLogStore")> {
+  return await import("./enrichmentLogStore");
+}
+
+describe("enrichmentLogStore", () => {
+  it("appends an entry and reads it back", async () => {
+    const { appendEnrichmentLog, readEnrichmentLog } = await loadModule();
+    appendEnrichmentLog({
+      timestamp: "2026-05-08T12:00:00Z",
+      trackId: "t-1",
+      artist: "Artist",
+      title: "Title",
+      source: "bulk",
+      status: "hit",
+      filledGenre: ["Rock"],
+      filledYear: 1979
+    });
+
+    const entries = await readEnrichmentLog(10);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.trackId).toBe("t-1");
+    expect(entries[0]?.filledGenre).toEqual(["Rock"]);
+    expect(entries[0]?.filledYear).toBe(1979);
+  });
+
+  it("returns most recent first and respects the limit", async () => {
+    const { appendEnrichmentLog, readEnrichmentLog } = await loadModule();
+    for (let i = 0; i < 5; i++) {
+      appendEnrichmentLog({
+        timestamp: `2026-05-08T12:00:0${i}Z`,
+        trackId: `t-${i}`,
+        artist: "A",
+        title: `Title ${i}`,
+        source: "bulk",
+        status: "hit"
+      });
+    }
+    const entries = await readEnrichmentLog(3);
+    expect(entries).toHaveLength(3);
+    expect(entries.map((e) => e.trackId)).toEqual(["t-4", "t-3", "t-2"]);
+  });
+
+  it("returns empty array when no log file exists", async () => {
+    const { readEnrichmentLog } = await loadModule();
+    const entries = await readEnrichmentLog(10);
+    expect(entries).toEqual([]);
+  });
+
+  it("clears the log file", async () => {
+    const { appendEnrichmentLog, clearEnrichmentLog, readEnrichmentLog } = await loadModule();
+    appendEnrichmentLog({
+      timestamp: "2026-05-08T12:00:00Z",
+      trackId: "t-1",
+      artist: "A",
+      title: "T",
+      source: "bulk",
+      status: "hit"
+    });
+    expect(fsSync.existsSync(LOG_FILE)).toBe(true);
+    await clearEnrichmentLog();
+    expect(fsSync.existsSync(LOG_FILE)).toBe(false);
+    expect(await readEnrichmentLog(10)).toEqual([]);
+  });
+
+  it("skips malformed lines without throwing", async () => {
+    fsSync.mkdirSync(tmpDir, { recursive: true });
+    fsSync.writeFileSync(
+      LOG_FILE,
+      `{"trackId":"good","timestamp":"2026-05-08T12:00:00Z","artist":"A","title":"T","source":"bulk","status":"hit"}\nnot-json\n{"missing-track-id":true}\n`,
+      "utf8"
+    );
+    const { readEnrichmentLog } = await loadModule();
+    const entries = await readEnrichmentLog(10);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.trackId).toBe("good");
+  });
+
+  it("trims the log when it grows beyond the threshold", async () => {
+    const { appendEnrichmentLog, readEnrichmentLog } = await loadModule();
+    // Append 1300 entries; module trims back to 1000 once it crosses 1200.
+    for (let i = 0; i < 1300; i++) {
+      appendEnrichmentLog({
+        timestamp: `2026-05-08T12:00:00.${String(i).padStart(4, "0")}Z`,
+        trackId: `t-${i}`,
+        artist: "A",
+        title: `T${i}`,
+        source: "bulk",
+        status: "hit"
+      });
+    }
+    const all = await readEnrichmentLog(2000);
+    expect(all.length).toBeLessThanOrEqual(1000);
+    // The most recent entry should still be present and at the front
+    expect(all[0]?.trackId).toBe("t-1299");
+  });
+});

--- a/backend/src/services/genre/enrichmentLogStore.ts
+++ b/backend/src/services/genre/enrichmentLogStore.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { cacheRoot } from "../../utils/paths";
+
+const log = createLogger("enrichment-log");
+
+const LOG_FILE = path.join(cacheRoot, "musicbrainz-enrichment-log.jsonl");
+const MAX_ENTRIES = 1000;
+const TRIM_THRESHOLD = 1200; // trim back to MAX_ENTRIES when this is exceeded
+
+export type EnrichmentLogEntry = {
+  timestamp: string;
+  trackId: string;
+  artist: string;
+  title: string;
+  source: "bulk" | "single" | "upload";
+  status: "hit" | "miss" | "skipped" | "failed";
+  filledGenre?: string[];
+  filledYear?: number;
+  filledRecordingMbid?: string;
+  filledReleaseGroupMbid?: string;
+  filledArtistMbid?: string;
+  coverFetched?: boolean;
+  errorMessage?: string;
+};
+
+let lineCount = -1; // -1 means "not yet counted"
+
+function ensureDirSync(): void {
+  fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
+}
+
+function countLinesSync(): number {
+  if (!fs.existsSync(LOG_FILE)) return 0;
+  try {
+    const raw = fs.readFileSync(LOG_FILE, "utf8");
+    return raw.split("\n").filter((line) => line.length > 0).length;
+  } catch {
+    return 0;
+  }
+}
+
+function trimIfNeeded(): void {
+  if (lineCount < TRIM_THRESHOLD) return;
+  try {
+    const raw = fs.readFileSync(LOG_FILE, "utf8");
+    const lines = raw.split("\n").filter((line) => line.length > 0);
+    if (lines.length <= MAX_ENTRIES) {
+      lineCount = lines.length;
+      return;
+    }
+    const kept = lines.slice(lines.length - MAX_ENTRIES);
+    const tmpPath = `${LOG_FILE}.tmp`;
+    fs.writeFileSync(tmpPath, `${kept.join("\n")}\n`, "utf8");
+    fs.renameSync(tmpPath, LOG_FILE);
+    lineCount = kept.length;
+  } catch (error) {
+    log.warn("Failed to trim enrichment log", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+export function appendEnrichmentLog(entry: EnrichmentLogEntry): void {
+  try {
+    ensureDirSync();
+    if (lineCount < 0) lineCount = countLinesSync();
+    fs.appendFileSync(LOG_FILE, `${JSON.stringify(entry)}\n`, "utf8");
+    lineCount++;
+    trimIfNeeded();
+  } catch (error) {
+    log.warn("Failed to append enrichment log entry", {
+      trackId: entry.trackId,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+export async function readEnrichmentLog(limit: number): Promise<EnrichmentLogEntry[]> {
+  const safeLimit = Math.max(1, Math.min(1000, Math.floor(limit)));
+  let raw: string;
+  try {
+    raw = await fsp.readFile(LOG_FILE, "utf8");
+  } catch {
+    return [];
+  }
+
+  const lines = raw.split("\n").filter((line) => line.length > 0);
+  const slice = lines.slice(-safeLimit).reverse();
+  const entries: EnrichmentLogEntry[] = [];
+  for (const line of slice) {
+    try {
+      const parsed = JSON.parse(line) as EnrichmentLogEntry;
+      if (typeof parsed?.trackId === "string" && typeof parsed?.timestamp === "string") {
+        entries.push(parsed);
+      }
+    } catch {
+      // skip malformed line
+    }
+  }
+  return entries;
+}
+
+export async function clearEnrichmentLog(): Promise<void> {
+  try {
+    await fsp.unlink(LOG_FILE);
+  } catch {
+    // ignore missing file
+  }
+  lineCount = 0;
+}

--- a/backend/src/services/genre/genreEnrichmentService.ts
+++ b/backend/src/services/genre/genreEnrichmentService.ts
@@ -9,13 +9,21 @@ import type { Track } from "../../types/library";
 import { fetchAndSaveCoverArt, flushCoverArtNegativeCache } from "./coverArtArchiveService";
 import {
   flushGenreCache,
+  invalidateCacheEntry,
   lookupRecordingMetadata,
   type RecordingMetadata
 } from "./musicBrainzService";
 import { normalizeGenreLabels } from "./genreSynonymService";
+import { appendEnrichmentLog, type EnrichmentLogEntry } from "./enrichmentLogStore";
 import { createLogger } from "../../utils/logger";
 
 const log = createLogger("genre-enrichment");
+
+export type EnrichmentCurrentTrack = {
+  trackId: string;
+  artist: string;
+  title: string;
+};
 
 export type EnrichmentStatus = {
   running: boolean;
@@ -24,6 +32,7 @@ export type EnrichmentStatus = {
   enriched: number;
   failed: number;
   startedAt: string | null;
+  currentTrack: EnrichmentCurrentTrack | null;
 };
 
 let status: EnrichmentStatus = {
@@ -32,7 +41,8 @@ let status: EnrichmentStatus = {
   processed: 0,
   enriched: 0,
   failed: 0,
-  startedAt: null
+  startedAt: null,
+  currentTrack: null
 };
 
 let abortController: AbortController | null = null;
@@ -48,6 +58,8 @@ export function stopEnrichment(): void {
   }
 }
 
+export type EnrichmentSource = "bulk" | "single" | "upload";
+
 export type TrackEnrichmentInput = {
   id: string;
   artist: string;
@@ -55,6 +67,7 @@ export type TrackEnrichmentInput = {
   hasGenre: boolean;
   hasYear: boolean;
   hasCover: boolean;
+  source?: EnrichmentSource;
 };
 
 export type TrackEnrichmentResult = {
@@ -106,6 +119,42 @@ function metadataDiffersFromOverride(
   return changed;
 }
 
+function buildLogEntry(
+  input: TrackEnrichmentInput,
+  result: TrackEnrichmentResult,
+  metadataReturned: boolean,
+  source: EnrichmentSource
+): EnrichmentLogEntry {
+  const wroteAnything =
+    result.genres !== null ||
+    result.year !== null ||
+    result.mbidRecording !== null ||
+    result.mbidReleaseGroup !== null ||
+    result.mbidArtist !== null ||
+    result.coverFetched;
+
+  const status: EnrichmentLogEntry["status"] = !metadataReturned
+    ? "miss"
+    : wroteAnything
+      ? "hit"
+      : "skipped";
+
+  return {
+    timestamp: new Date().toISOString(),
+    trackId: input.id,
+    artist: input.artist,
+    title: input.title,
+    source,
+    status,
+    ...(result.genres ? { filledGenre: result.genres } : {}),
+    ...(result.year !== null ? { filledYear: result.year } : {}),
+    ...(result.mbidRecording ? { filledRecordingMbid: result.mbidRecording } : {}),
+    ...(result.mbidReleaseGroup ? { filledReleaseGroupMbid: result.mbidReleaseGroup } : {}),
+    ...(result.mbidArtist ? { filledArtistMbid: result.mbidArtist } : {}),
+    ...(result.coverFetched ? { coverFetched: true } : {})
+  };
+}
+
 /**
  * Enrich a single track. Looks up the recording on MusicBrainz, fills missing
  * genre/year/MBID overrides without clobbering existing ones, and downloads
@@ -123,7 +172,10 @@ export async function enrichTrackMetadata(input: TrackEnrichmentInput): Promise<
   };
 
   const metadata = await lookupRecordingMetadata(input.artist, input.title);
-  if (!metadata) return result;
+  if (!metadata) {
+    appendEnrichmentLog(buildLogEntry(input, result, false, input.source ?? "bulk"));
+    return result;
+  }
 
   const normalizedGenres = normalizeGenreLabels(metadata.genres);
   const fillGenre = !input.hasGenre;
@@ -162,6 +214,7 @@ export async function enrichTrackMetadata(input: TrackEnrichmentInput): Promise<
     }
   }
 
+  appendEnrichmentLog(buildLogEntry(input, result, true, input.source ?? "bulk"));
   return result;
 }
 
@@ -184,9 +237,56 @@ export async function enrichTrackGenre(
     title,
     hasGenre: false,
     hasYear: options.hasYear ?? true,
-    hasCover: options.hasCover ?? true
+    hasCover: options.hasCover ?? true,
+    source: "upload"
   });
   return result.genres;
+}
+
+/**
+ * Trigger a fresh MB lookup for one specific track. Drops the cached entry
+ * for (artist, title) so the next call hits MusicBrainz, then fills any
+ * currently-missing fields. Used by the admin "re-enrich" button.
+ */
+export async function reEnrichTrack(track: Track, indexStore?: IndexStore): Promise<TrackEnrichmentResult> {
+  const artist = track.tags.artist;
+  const title = track.tags.title;
+  if (!artist || !title) {
+    return {
+      genres: null,
+      year: null,
+      mbidRecording: null,
+      mbidReleaseGroup: null,
+      mbidArtist: null,
+      coverFetched: false
+    };
+  }
+
+  invalidateCacheEntry(artist, title);
+
+  const cover = await findCoverFileByTrackId(track.id);
+  const result = await enrichTrackMetadata({
+    id: track.id,
+    artist,
+    title,
+    hasGenre: Array.isArray(track.tags.genre) && track.tags.genre.length > 0,
+    hasYear: typeof track.tags.year === "number",
+    hasCover: cover !== null,
+    source: "single"
+  });
+
+  const wroteMetadata =
+    result.genres !== null ||
+    result.year !== null ||
+    result.mbidRecording !== null ||
+    result.mbidReleaseGroup !== null ||
+    result.mbidArtist !== null;
+
+  if (wroteMetadata && indexStore) {
+    await indexStore.rebuild();
+  }
+
+  return result;
 }
 
 function describeTrackEnrichmentNeeds(track: Track, hasCover: boolean): TrackEnrichmentInput | null {
@@ -205,7 +305,8 @@ function describeTrackEnrichmentNeeds(track: Track, hasCover: boolean): TrackEnr
     title,
     hasGenre,
     hasYear,
-    hasCover
+    hasCover,
+    source: "bulk"
   };
 }
 
@@ -233,7 +334,8 @@ export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<v
       processed: 0,
       enriched: 0,
       failed: 0,
-      startedAt: new Date().toISOString()
+      startedAt: new Date().toISOString(),
+      currentTrack: null
     };
     return;
   }
@@ -247,7 +349,8 @@ export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<v
     processed: 0,
     enriched: 0,
     failed: 0,
-    startedAt: new Date().toISOString()
+    startedAt: new Date().toISOString(),
+    currentTrack: null
   };
 
   log.info(`Starting metadata enrichment for ${candidates.length} tracks`);
@@ -259,6 +362,12 @@ export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<v
       log.info("Metadata enrichment aborted");
       break;
     }
+
+    status.currentTrack = {
+      trackId: candidate.id,
+      artist: candidate.artist,
+      title: candidate.title
+    };
 
     try {
       const result = await enrichTrackMetadata(candidate);
@@ -287,10 +396,20 @@ export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<v
       log.warn(`Failed to enrich "${candidate.title}" by "${candidate.artist}"`, {
         error: error instanceof Error ? error.message : String(error)
       });
+      appendEnrichmentLog({
+        timestamp: new Date().toISOString(),
+        trackId: candidate.id,
+        artist: candidate.artist,
+        title: candidate.title,
+        source: "bulk",
+        status: "failed",
+        errorMessage: error instanceof Error ? error.message : String(error)
+      });
     }
   }
 
   status.running = false;
+  status.currentTrack = null;
   abortController = null;
   flushGenreCache();
   flushCoverArtNegativeCache();
@@ -300,4 +419,33 @@ export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<v
   log.info(
     `Metadata enrichment complete: ${status.enriched} enriched, ${status.failed} failed, ${status.processed} processed out of ${status.total}`
   );
+}
+
+/**
+ * Re-apply the current synonym table to all existing genre overrides.
+ * Used when the admin updates synonyms and wants to fix up the library
+ * without re-running an MB enrichment. Returns counts of changed/scanned
+ * tracks. Triggers an index rebuild if anything changed.
+ */
+export async function reapplySynonymsToOverrides(indexStore: IndexStore): Promise<{ scanned: number; updated: number }> {
+  const overrides = await readTrackMetadataOverrides();
+  let scanned = 0;
+  let updated = 0;
+  const patch: Record<string, TrackMetadataOverride> = {};
+
+  for (const [trackId, override] of Object.entries(overrides)) {
+    if (!override.genre || override.genre.length === 0) continue;
+    scanned++;
+    const renormalized = normalizeGenreLabels(override.genre);
+    if (JSON.stringify(renormalized) === JSON.stringify(override.genre)) continue;
+    patch[trackId] = { ...override, genre: renormalized };
+    updated++;
+  }
+
+  if (updated > 0) {
+    await mergeTrackMetadataOverrides(patch);
+    await indexStore.rebuild();
+  }
+
+  return { scanned, updated };
 }

--- a/backend/src/services/genre/musicBrainzService.ts
+++ b/backend/src/services/genre/musicBrainzService.ts
@@ -575,3 +575,14 @@ export function clearGenreCache(): void {
 export function flushGenreCache(): void {
   flushCacheNow();
 }
+
+export function invalidateCacheEntry(artist: string, title: string): boolean {
+  if (!artist.trim() || !title.trim()) return false;
+  const c = loadCache();
+  const key = cacheKey(artist, title);
+  if (!(key in c)) return false;
+  delete c[key];
+  cacheDirty = true;
+  scheduleCacheSave();
+  return true;
+}

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -184,7 +184,7 @@ export function AuthenticatedApp({
   // ── Commands ──────────────────────────────────────────────────────────
   const {
     handleUpload, handleInspectUploadFile, handleRebuildIndex,
-    handleDeleteTrack, handleUpdateTrackMetadata,
+    handleDeleteTrack, handleUpdateTrackMetadata, handleReEnrichTrack,
     handleBulkDeleteTracks, handleBulkUpdateTrackMetadata,
     handleCreatePlaylist, handleAddTrackToPlaylist,
     handlePatchPlaylist, handleDeletePlaylist,
@@ -542,6 +542,7 @@ export function AuthenticatedApp({
         onRefreshTracks: refreshAllTracks,
         onDeleteTrack: handleDeleteTrack,
         onUpdateTrackMetadata: handleUpdateTrackMetadata,
+        onReEnrichTrack: handleReEnrichTrack,
         onBulkDeleteTracks: handleBulkDeleteTracks,
         onBulkUpdateTrackMetadata: handleBulkUpdateTrackMetadata
       }}

--- a/frontend/src/api/genre.ts
+++ b/frontend/src/api/genre.ts
@@ -25,6 +25,12 @@ export async function resetGenreSynonyms(): Promise<void> {
   await requestJson<{ ok: boolean }>("/api/genre/synonyms/reset", { method: "POST" });
 }
 
+export type EnrichmentCurrentTrack = {
+  trackId: string;
+  artist: string;
+  title: string;
+};
+
 export type EnrichmentStatus = {
   running: boolean;
   processed: number;
@@ -32,6 +38,7 @@ export type EnrichmentStatus = {
   enriched: number;
   failed: number;
   startedAt: string | null;
+  currentTrack: EnrichmentCurrentTrack | null;
 };
 
 export async function getEnrichmentStatus(): Promise<EnrichmentStatus> {
@@ -44,6 +51,58 @@ export async function startEnrichment(): Promise<void> {
 
 export async function stopEnrichment(): Promise<void> {
   await requestJson<{ ok: boolean }>("/api/genre/enrichment/stop", { method: "POST" });
+}
+
+export type EnrichmentLogEntry = {
+  timestamp: string;
+  trackId: string;
+  artist: string;
+  title: string;
+  source: "bulk" | "single" | "upload";
+  status: "hit" | "miss" | "skipped" | "failed";
+  filledGenre?: string[];
+  filledYear?: number;
+  filledRecordingMbid?: string;
+  filledReleaseGroupMbid?: string;
+  filledArtistMbid?: string;
+  coverFetched?: boolean;
+  errorMessage?: string;
+};
+
+export async function getEnrichmentLog(limit = 100): Promise<EnrichmentLogEntry[]> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  const payload = await requestJson<{ entries: EnrichmentLogEntry[] }>(
+    `/api/genre/enrichment/log?${params.toString()}`
+  );
+  return payload.entries;
+}
+
+export async function clearEnrichmentLog(): Promise<void> {
+  await requestJson<{ cleared: boolean }>("/api/genre/enrichment/log", { method: "DELETE" });
+}
+
+export type ReEnrichResult = {
+  trackId: string;
+  result: {
+    genres: string[] | null;
+    year: number | null;
+    mbidRecording: string | null;
+    mbidReleaseGroup: string | null;
+    mbidArtist: string | null;
+    coverFetched: boolean;
+  };
+};
+
+export async function reEnrichTrack(trackId: string): Promise<ReEnrichResult> {
+  return requestJson<ReEnrichResult>(`/api/genre/enrichment/track/${encodeURIComponent(trackId)}`, {
+    method: "POST"
+  });
+}
+
+export async function reapplyGenreSynonyms(): Promise<{ scanned: number; updated: number }> {
+  return requestJson<{ scanned: number; updated: number }>("/api/genre/synonyms/reapply", {
+    method: "POST"
+  });
 }
 
 export type GenreCacheStats = {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -91,10 +91,21 @@ export {
   getEnrichmentStatus,
   startEnrichment,
   stopEnrichment,
+  getEnrichmentLog,
+  clearEnrichmentLog,
+  reEnrichTrack,
+  reapplyGenreSynonyms,
   getGenreCacheStats,
   clearGenreCache
 } from "./genre";
-export type { GenreSynonyms, EnrichmentStatus, GenreCacheStats } from "./genre";
+export type {
+  GenreSynonyms,
+  EnrichmentStatus,
+  EnrichmentCurrentTrack,
+  EnrichmentLogEntry,
+  ReEnrichResult,
+  GenreCacheStats
+} from "./genre";
 
 export {
   getSystemStats,

--- a/frontend/src/components/AdminLibraryView.tsx
+++ b/frontend/src/components/AdminLibraryView.tsx
@@ -1,19 +1,23 @@
 import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
 
 import {
+  clearEnrichmentLog,
   clearGenreCache,
   deleteGenreSynonym,
   getAutoPlaylistConfig,
+  getEnrichmentLog,
   getEnrichmentStatus,
   getGenreCacheStats,
   getGenreSynonyms,
   patchAutoPlaylistConfig,
   putGenreSynonym,
+  reapplyGenreSynonyms,
   regenerateAutoPlaylists,
   resetGenreSynonyms,
   startEnrichment,
   stopEnrichment,
   type AutoPlaylistConfig,
+  type EnrichmentLogEntry,
   type EnrichmentStatus,
   type GenreCacheStats,
   type GenreSynonyms
@@ -39,6 +43,10 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
   // ── Cache ──────────────────────────────────────────────────────
   const [cacheStats, setCacheStats] = useState<GenreCacheStats | null>(null);
 
+  // ── Enrichment activity log ────────────────────────────────────
+  const [logEntries, setLogEntries] = useState<EnrichmentLogEntry[]>([]);
+  const [reapplying, setReapplying] = useState(false);
+
   // ── Auto-playlist config ───────────────────────────────────────
   const [config, setConfig] = useState<AutoPlaylistConfig | null>(null);
   const [loadingConfig, setLoadingConfig] = useState(true);
@@ -56,10 +64,14 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
     try {
       const status = await getEnrichmentStatus();
       setEnrichStatus(status);
-      // Also refresh cache stats while enrichment runs
+      // Also refresh cache stats and log while enrichment runs
       if (status.running) {
-        const stats = await getGenreCacheStats();
-        setCacheStats(stats);
+        const [stats, log] = await Promise.all([
+          getGenreCacheStats().catch(() => null),
+          getEnrichmentLog(50).catch(() => null)
+        ]);
+        if (stats) setCacheStats(stats);
+        if (log) setLogEntries(log);
       }
       return status;
     } catch {
@@ -96,7 +108,15 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
     void pollEnrichStatus();
     void loadCacheStats();
     void loadConfig();
+    void loadLog();
   }, [pollEnrichStatus]);
+
+  async function loadLog(): Promise<void> {
+    try {
+      const entries = await getEnrichmentLog(50);
+      setLogEntries(entries);
+    } catch {}
+  }
 
   async function loadSynonyms(): Promise<void> {
     setLoadingSynonyms(true);
@@ -162,6 +182,23 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
     } catch {}
   }
 
+  async function handleReapplySynonyms(): Promise<void> {
+    setReapplying(true);
+    setSynonymMessage(null);
+    try {
+      const { scanned, updated } = await reapplyGenreSynonyms();
+      setSynonymMessage(
+        updated > 0
+          ? `Reapplied synonyms: ${updated} of ${scanned} tracks updated.`
+          : `Reapplied synonyms: nothing to change (${scanned} tracks scanned).`
+      );
+    } catch (err) {
+      setSynonymMessage(err instanceof Error ? err.message : "Failed to reapply synonyms.");
+    } finally {
+      setReapplying(false);
+    }
+  }
+
   // ── Enrichment handlers ────────────────────────────────────────
 
   async function handleToggleEnrichment(): Promise<void> {
@@ -189,6 +226,13 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
     try {
       await clearGenreCache();
       await loadCacheStats();
+    } catch {}
+  }
+
+  async function handleClearLog(): Promise<void> {
+    try {
+      await clearEnrichmentLog();
+      setLogEntries([]);
     } catch {}
   }
 
@@ -243,13 +287,23 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
       <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <h3 className="font-display text-xl text-flaque-ink">Genre Synonyms</h3>
-          <button
-            type="button"
-            className="rounded-xl border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream"
-            onClick={() => { void handleResetSynonyms(); }}
-          >
-            Reset to defaults
-          </button>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              className="rounded-xl border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => { void handleReapplySynonyms(); }}
+              disabled={reapplying}
+            >
+              {reapplying ? "Reapplying..." : "Reapply to library"}
+            </button>
+            <button
+              type="button"
+              className="rounded-xl border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+              onClick={() => { void handleResetSynonyms(); }}
+            >
+              Reset to defaults
+            </button>
+          </div>
         </div>
 
         <form className="mt-3 flex flex-wrap items-end gap-2" onSubmit={(e) => { void handleAddSynonym(e); }}>
@@ -359,6 +413,14 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
                 />
               </div>
             ) : null}
+            {enrichStatus.currentTrack ? (
+              <p className="text-xs text-flaque-steel">
+                <span className="text-flaque-steel/60">Now: </span>
+                <span className="text-flaque-ink">{enrichStatus.currentTrack.title}</span>
+                <span className="text-flaque-steel/60"> — </span>
+                <span className="text-flaque-steel">{enrichStatus.currentTrack.artist}</span>
+              </p>
+            ) : null}
             <div className="flex gap-3 text-xs text-flaque-steel">
               <span className="text-green-600">{enrichStatus.enriched} enriched</span>
               {enrichStatus.failed > 0 ? (
@@ -394,6 +456,85 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
             </button>
           </div>
         ) : null}
+      </section>
+
+      {/* ── Recent enrichment activity ───────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="font-display text-xl text-flaque-ink">Recent enrichment activity</h3>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="rounded-xl border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+              onClick={() => { void loadLog(); }}
+            >
+              Refresh
+            </button>
+            {logEntries.length > 0 ? (
+              <button
+                type="button"
+                className="rounded-xl border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+                onClick={() => { void handleClearLog(); }}
+              >
+                Clear log
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        {logEntries.length === 0 ? (
+          <p className="mt-3 text-sm text-flaque-steel">No enrichment activity yet.</p>
+        ) : (
+          <div className="mt-3 max-h-80 overflow-y-auto rounded-xl border border-flaque-clay/40">
+            <table className="w-full text-left text-xs">
+              <thead className="sticky top-0 bg-flaque-cream/95 text-flaque-ink">
+                <tr>
+                  <th className="px-3 py-2 font-medium">When</th>
+                  <th className="px-3 py-2 font-medium">Track</th>
+                  <th className="px-3 py-2 font-medium">Source</th>
+                  <th className="px-3 py-2 font-medium">Outcome</th>
+                  <th className="px-3 py-2 font-medium">Filled</th>
+                </tr>
+              </thead>
+              <tbody>
+                {logEntries.map((entry, i) => (
+                  <tr key={`${entry.timestamp}-${entry.trackId}-${i}`} className="border-t border-flaque-clay/30">
+                    <td className="whitespace-nowrap px-3 py-1.5 text-flaque-steel">
+                      {new Date(entry.timestamp).toLocaleString()}
+                    </td>
+                    <td className="px-3 py-1.5">
+                      <span className="text-flaque-ink">{entry.title}</span>
+                      <span className="text-flaque-steel/60"> — </span>
+                      <span className="text-flaque-steel">{entry.artist}</span>
+                    </td>
+                    <td className="px-3 py-1.5 text-flaque-steel">{entry.source}</td>
+                    <td className={`px-3 py-1.5 ${
+                      entry.status === "hit" ? "text-green-600" :
+                      entry.status === "miss" ? "text-flaque-steel" :
+                      entry.status === "failed" ? "text-red-500" :
+                      "text-flaque-steel/60"
+                    }`}>
+                      {entry.status}
+                    </td>
+                    <td className="px-3 py-1.5 text-flaque-steel">
+                      {(() => {
+                        const parts: string[] = [];
+                        if (entry.filledGenre && entry.filledGenre.length > 0) {
+                          parts.push(`genre: ${entry.filledGenre.join(", ")}`);
+                        }
+                        if (entry.filledYear !== undefined) parts.push(`year: ${entry.filledYear}`);
+                        if (entry.coverFetched) parts.push("cover");
+                        if (entry.filledRecordingMbid) parts.push("MBID");
+                        if (entry.errorMessage) parts.push(`error: ${entry.errorMessage}`);
+                        return parts.length > 0 ? parts.join(" · ") : "—";
+                      })()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </section>
 
       {/* ── Auto-Playlist Config ────────────────────────────────── */}

--- a/frontend/src/components/ConfigView.tsx
+++ b/frontend/src/components/ConfigView.tsx
@@ -15,6 +15,7 @@ export type ConfigViewProps = {
   onRefreshTracks: () => Promise<void>;
   onDeleteTrack: (trackId: string) => Promise<void>;
   onUpdateTrackMetadata: (trackId: string, patch: TrackMetadataPatch) => Promise<void>;
+  onReEnrichTrack: (trackId: string) => Promise<void>;
   onBulkDeleteTracks: (trackIds: string[]) => Promise<void>;
   onBulkUpdateTrackMetadata: (trackIds: string[], patch: TrackMetadataPatch) => Promise<void>;
   activeSection: ConfigSection;
@@ -31,6 +32,7 @@ export function ConfigView({
   onRefreshTracks,
   onDeleteTrack,
   onUpdateTrackMetadata,
+  onReEnrichTrack,
   onBulkDeleteTracks,
   onBulkUpdateTrackMetadata,
   activeSection
@@ -62,6 +64,7 @@ export function ConfigView({
           ownerNameById={ownerNameById}
           onDeleteTrack={onDeleteTrack}
           onUpdateTrackMetadata={onUpdateTrackMetadata}
+          onReEnrichTrack={onReEnrichTrack}
           onBulkDeleteTracks={onBulkDeleteTracks}
           onBulkUpdateTrackMetadata={onBulkUpdateTrackMetadata}
         />

--- a/frontend/src/components/config/FilesSection.tsx
+++ b/frontend/src/components/config/FilesSection.tsx
@@ -17,6 +17,7 @@ type FilesSectionProps = {
   ownerNameById?: Record<string, string>;
   onDeleteTrack: (trackId: string) => Promise<void>;
   onUpdateTrackMetadata: (trackId: string, patch: TrackMetadataPatch) => Promise<void>;
+  onReEnrichTrack: (trackId: string) => Promise<void>;
   onBulkDeleteTracks: (trackIds: string[]) => Promise<void>;
   onBulkUpdateTrackMetadata: (trackIds: string[], patch: TrackMetadataPatch) => Promise<void>;
 };
@@ -38,6 +39,7 @@ export function FilesSection({
   ownerNameById,
   onDeleteTrack,
   onUpdateTrackMetadata,
+  onReEnrichTrack,
   onBulkDeleteTracks,
   onBulkUpdateTrackMetadata
 }: FilesSectionProps): JSX.Element {
@@ -119,6 +121,17 @@ export function FilesSection({
     } finally {
       setActiveTrackActionId(null);
       setDeletingTrack(false);
+    }
+  }
+
+  async function handleReEnrichClicked(track: Track): Promise<void> {
+    setActiveTrackActionId(track.id);
+    try {
+      await onReEnrichTrack(track.id);
+    } catch (error) {
+      void error;
+    } finally {
+      setActiveTrackActionId(null);
     }
   }
 
@@ -461,6 +474,15 @@ export function FilesSection({
                           onClick={() => openEditModal(track)}
                         >
                           Edit
+                        </button>
+                        <button
+                          className="rounded-lg border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+                          type="button"
+                          disabled={runningAction}
+                          onClick={() => { void handleReEnrichClicked(track); }}
+                          title="Force a fresh MusicBrainz lookup for this track"
+                        >
+                          Re-enrich
                         </button>
                         <button
                           className="rounded-lg border border-red-300 bg-white px-3 py-1.5 text-xs text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"

--- a/frontend/src/hooks/useLibraryCommands.ts
+++ b/frontend/src/hooks/useLibraryCommands.ts
@@ -9,6 +9,7 @@ import {
   heartPlaylist,
   patchPlaylist,
   rebuildIndex,
+  reEnrichTrack,
   reportPlaylistListen,
   updateTrackMetadata,
   uploadTracks,
@@ -50,6 +51,7 @@ type UseLibraryCommandsResult = {
   handleRebuildIndex: () => Promise<void>;
   handleDeleteTrack: (trackId: string) => Promise<void>;
   handleUpdateTrackMetadata: (trackId: string, patch: TrackMetadataPatch) => Promise<void>;
+  handleReEnrichTrack: (trackId: string) => Promise<void>;
   handleCreatePlaylist: (input: { name: string; visibility: PlaylistVisibility; description?: string }) => Promise<void>;
   handleAddTrackToPlaylist: (input: { trackId: string; playlistId: string }) => Promise<void>;
   handlePatchPlaylist: (playlistId: string, patch: { name?: string; visibility?: PlaylistVisibility; trackIds?: string[]; description?: string; collaborators?: string[] }) => Promise<Playlist>;
@@ -157,6 +159,28 @@ export function useLibraryCommands({
     refreshPaginatedLibrary();
   }
 
+  async function handleReEnrichTrack(trackId: string): Promise<void> {
+    const { result } = await reEnrichTrack(trackId);
+    const filled: string[] = [];
+    if (result.genres) filled.push(`genre: ${result.genres.join(", ")}`);
+    if (result.year !== null) filled.push(`year: ${result.year}`);
+    if (result.coverFetched) filled.push("cover art");
+    if (filled.length === 0 && result.mbidRecording) filled.push("MBIDs");
+
+    setAppNotice({
+      tone: filled.length > 0 ? "success" : "info",
+      message: filled.length > 0
+        ? `Re-enriched: ${filled.join(", ")}.`
+        : "Re-enrichment ran but no new data was found on MusicBrainz."
+    });
+
+    if (filled.length > 0) {
+      await Promise.all([refreshCurrentLibrary(), refreshAllTracks()]);
+      refreshRecentlyUploaded();
+      refreshPaginatedLibrary();
+    }
+  }
+
   async function handleCreatePlaylist(input: {
     name: string;
     visibility: PlaylistVisibility;
@@ -254,6 +278,7 @@ export function useLibraryCommands({
     handleRebuildIndex,
     handleDeleteTrack,
     handleUpdateTrackMetadata,
+    handleReEnrichTrack,
     handleBulkDeleteTracks,
     handleBulkUpdateTrackMetadata,
     handleCreatePlaylist,


### PR DESCRIPTION
> Stacked on top of #170 (Phase 1+2). The diff shown here is Phase 3 only; the diff against master will include Phase 1+2 once #170 merges.

## Summary

Builds on Phase 2 to give admins visibility into what enrichment is doing and the ability to fix individual tracks without re-running the whole pass.

**Per-track activity log**
- New \`enrichmentLogStore\` writes one JSONL line per \`enrichTrackMetadata\` call to \`cache/musicbrainz-enrichment-log.jsonl\` — timestamp, track, source (\`bulk\` / \`single\` / \`upload\`), status (\`hit\` / \`miss\` / \`skipped\` / \`failed\`), and what was filled.
- Capped at 1000 entries; trimmed back when it crosses 1200.
- \`GET /api/genre/enrichment/log?limit=N\` returns most-recent first; \`DELETE\` clears.

**Real-time progress**
- \`EnrichmentStatus\` now carries \`currentTrack: { trackId, artist, title } | null\`, set before each per-track lookup. UI shows it inline with the progress bar.

**Single-track re-enrich**
- New \`reEnrichTrack(track, indexStore)\` invalidates the cache entry for \`(artist, title)\`, re-runs the rich MB lookup, fills any gaps, rebuilds the index if anything changed.
- \`POST /api/genre/enrichment/track/:trackId\` (admin only).
- New per-row **Re-enrich** button on every admin track row, with a notice that summarises what was filled or notes nothing new was found.

**Reapply synonyms**
- New \`reapplySynonymsToOverrides(indexStore)\` re-runs \`normalizeGenreLabels\` over every existing genre override and persists the diff.
- \`POST /api/genre/synonyms/reapply\` (admin only).
- New **Reapply to library** button next to **Reset to defaults**.

**Tests (+6 backend, all passing — 440 backend + 168 frontend = 608 total)**
- \`enrichmentLogStore\`: append + read round-trip, most-recent-first ordering with limit, empty-on-missing-file, clear, malformed-line resilience, trim past threshold.

## Test plan
- [ ] Start a bulk enrichment — confirm the progress display shows the currently-processing track.
- [ ] Open the \"Recent enrichment activity\" section — confirm entries appear with correct status colors and outcome text.
- [ ] On an admin track row, click \"Re-enrich\" — confirm the status banner reflects what was filled (or \"no new data\" when MB returns the same).
- [ ] Add a synonym (e.g. \`hiphop\` → \`Hip-Hop\`), then click \"Reapply to library\" — confirm tracks with raw \`hiphop\` genre get updated to \`Hip-Hop\` without an MB call.
- [ ] Delete the log via the UI — confirm the file disappears and subsequent enrichment writes new entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)