### PR TITLE
feat(musicbrainz): phase 4 - AcoustID fingerprint fallback

### DIFF
--- a/backend/src/api/genreRoutes.ts
+++ b/backend/src/api/genreRoutes.ts
@@ -20,6 +20,16 @@ import {
   resetSynonymsToDefaults
 } from "../services/genre/genreSynonymService";
 import { getGenreCacheStats, clearGenreCache } from "../services/genre/musicBrainzService";
+import {
+  clearAcoustIdCache,
+  getAcoustIdCacheStats,
+  isAcoustIdConfigured
+} from "../services/genre/acoustIdService";
+import {
+  clearFingerprintCache,
+  getFingerprintCacheStats,
+  isFingerprintingDisabled
+} from "../services/genre/fingerprintService";
 import { AppError } from "../utils/AppError";
 import { createLogger } from "../utils/logger";
 
@@ -150,12 +160,23 @@ export function createGenreRouter(indexStore: IndexStore): Router {
   });
 
   router.get("/genre/cache/stats", requireAuth, requireAdmin, (_req, res) => {
-    res.json(getGenreCacheStats());
+    const mbStats = getGenreCacheStats();
+    const fingerprintStats = getFingerprintCacheStats();
+    const acoustIdStats = getAcoustIdCacheStats();
+    res.json({
+      ...mbStats,
+      fingerprints: fingerprintStats.entries,
+      acoustid: acoustIdStats.entries,
+      acoustIdConfigured: isAcoustIdConfigured(),
+      fingerprintingAvailable: !isFingerprintingDisabled()
+    });
   });
 
   router.post("/genre/cache/clear", requireAuth, requireAdmin, (_req, res) => {
     clearGenreCache();
-    log.info("MusicBrainz genre cache cleared", { userId: _req.authUser?.id ?? "unknown" });
+    clearFingerprintCache();
+    clearAcoustIdCache();
+    log.info("MusicBrainz / fingerprint / AcoustID caches cleared", { userId: _req.authUser?.id ?? "unknown" });
     res.json({ cleared: true });
   });
 

--- a/backend/src/services/genre/acoustIdService.test.ts
+++ b/backend/src/services/genre/acoustIdService.test.ts
@@ -1,0 +1,168 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { tmpDir } = vi.hoisted(() => {
+  const fsS = require("node:fs") as typeof import("node:fs");
+  const osM = require("node:os") as typeof import("node:os");
+  const pathM = require("node:path") as typeof import("node:path");
+  return {
+    tmpDir: fsS.mkdtempSync(pathM.join(osM.tmpdir(), "acoustid-test-"))
+  };
+});
+
+vi.mock("../../utils/paths", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../utils/paths")>()),
+  cacheRoot: tmpDir
+}));
+
+vi.mock("../../utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+const CACHE_FILE = path.join(tmpDir, "acoustid-cache.json");
+
+type FetchHandler = (url: string, init?: RequestInit) => { status?: number; body?: unknown; throw?: Error };
+
+let fetchHandler: FetchHandler = () => ({ status: 200, body: { status: "ok", results: [] } });
+let fetchCalls: Array<{ url: string; body: string }> = [];
+
+beforeEach(async () => {
+  vi.resetModules();
+  for (const entry of await fs.readdir(tmpDir).catch(() => [])) {
+    await fs.rm(path.join(tmpDir, entry), { recursive: true, force: true });
+  }
+  fetchHandler = () => ({ status: 200, body: { status: "ok", results: [] } });
+  fetchCalls = [];
+  process.env.ACOUSTID_API_KEY = "test-key";
+  vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body = typeof init?.body === "string" ? init.body : "";
+    fetchCalls.push({ url, body });
+    const result = fetchHandler(url, init);
+    if (result.throw) throw result.throw;
+    return new Response(JSON.stringify(result.body ?? {}), {
+      status: result.status ?? 200,
+      headers: { "Content-Type": "application/json" }
+    });
+  }));
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+  delete process.env.ACOUSTID_API_KEY;
+  fsSync.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function loadModule(): Promise<typeof import("./acoustIdService")> {
+  return await import("./acoustIdService");
+}
+
+describe("acoustIdService", () => {
+  it("returns null when no API key is configured", async () => {
+    delete process.env.ACOUSTID_API_KEY;
+    const { lookupRecordingByFingerprint, isAcoustIdConfigured } = await loadModule();
+    expect(isAcoustIdConfigured()).toBe(false);
+    expect(await lookupRecordingByFingerprint("fp", 200)).toBeNull();
+    expect(fetchCalls).toEqual([]);
+  });
+
+  it("returns the highest-scoring recording above threshold", async () => {
+    fetchHandler = () => ({
+      status: 200,
+      body: {
+        status: "ok",
+        results: [
+          { score: 0.7, recordings: [{ id: "low-score" }] },
+          { score: 0.95, recordings: [{ id: "high-score" }] },
+          { score: 0.88, recordings: [{ id: "mid-score" }] }
+        ]
+      }
+    });
+    const { lookupRecordingByFingerprint } = await loadModule();
+    const result = await lookupRecordingByFingerprint("fp", 200);
+    expect(result?.recordingMbid).toBe("high-score");
+    expect(result?.score).toBe(0.95);
+  });
+
+  it("rejects results below the score threshold", async () => {
+    fetchHandler = () => ({
+      status: 200,
+      body: { status: "ok", results: [{ score: 0.7, recordings: [{ id: "x" }] }] }
+    });
+    const { lookupRecordingByFingerprint } = await loadModule();
+    expect(await lookupRecordingByFingerprint("fp", 200)).toBeNull();
+  });
+
+  it("posts the fingerprint and duration to the lookup endpoint", async () => {
+    fetchHandler = () => ({
+      status: 200,
+      body: { status: "ok", results: [{ score: 0.95, recordings: [{ id: "abc" }] }] }
+    });
+    const { lookupRecordingByFingerprint } = await loadModule();
+    await lookupRecordingByFingerprint("FP123", 234.6);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]!.url).toBe("https://api.acoustid.org/v2/lookup");
+    expect(fetchCalls[0]!.body).toContain("client=test-key");
+    expect(fetchCalls[0]!.body).toContain("duration=235");
+    expect(fetchCalls[0]!.body).toContain("fingerprint=FP123");
+    expect(fetchCalls[0]!.body).toContain("meta=recordings");
+  });
+
+  it("caches a successful hit so the next call returns from cache", async () => {
+    fetchHandler = () => ({
+      status: 200,
+      body: { status: "ok", results: [{ score: 0.95, recordings: [{ id: "cached-mbid" }] }] }
+    });
+    const { lookupRecordingByFingerprint } = await loadModule();
+    await lookupRecordingByFingerprint("FP", 200);
+    fetchCalls = [];
+    const second = await lookupRecordingByFingerprint("FP", 200);
+    expect(second?.recordingMbid).toBe("cached-mbid");
+    expect(fetchCalls).toEqual([]);
+  });
+
+  it("caches a confirmed miss for 7 days", async () => {
+    fetchHandler = () => ({ status: 200, body: { status: "ok", results: [] } });
+    const { lookupRecordingByFingerprint } = await loadModule();
+    expect(await lookupRecordingByFingerprint("FP", 200)).toBeNull();
+    fetchCalls = [];
+    expect(await lookupRecordingByFingerprint("FP", 200)).toBeNull();
+    expect(fetchCalls).toEqual([]);
+  });
+
+  it("does NOT cache transient errors (5xx)", async () => {
+    fetchHandler = () => ({ status: 503 });
+    const { lookupRecordingByFingerprint, flushAcoustIdCache } = await loadModule();
+    expect(await lookupRecordingByFingerprint("FP", 200)).toBeNull();
+    flushAcoustIdCache();
+    expect(fsSync.existsSync(CACHE_FILE)).toBe(false);
+  });
+
+  it("does NOT cache transient errors (network throw)", async () => {
+    fetchHandler = () => ({ throw: new Error("ECONNRESET") });
+    const { lookupRecordingByFingerprint, flushAcoustIdCache } = await loadModule();
+    expect(await lookupRecordingByFingerprint("FP", 200)).toBeNull();
+    flushAcoustIdCache();
+    expect(fsSync.existsSync(CACHE_FILE)).toBe(false);
+  });
+
+  it("treats AcoustID error responses as a miss (not transient)", async () => {
+    fetchHandler = () => ({
+      status: 200,
+      body: { status: "error", error: { message: "invalid fingerprint" } }
+    });
+    const { lookupRecordingByFingerprint, flushAcoustIdCache } = await loadModule();
+    expect(await lookupRecordingByFingerprint("FP", 200)).toBeNull();
+    flushAcoustIdCache();
+    // Misses are written to cache
+    expect(fsSync.existsSync(CACHE_FILE)).toBe(true);
+  });
+});

--- a/backend/src/services/genre/acoustIdService.ts
+++ b/backend/src/services/genre/acoustIdService.ts
@@ -1,0 +1,256 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { cacheRoot } from "../../utils/paths";
+
+const log = createLogger("acoustid");
+
+const CACHE_FILE = path.join(cacheRoot, "acoustid-cache.json");
+const CACHE_FLUSH_DEBOUNCE_MS = 500;
+const NEGATIVE_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const REQUEST_TIMEOUT_MS = 15_000;
+const MIN_SCORE_THRESHOLD = 0.85;
+
+const ACOUSTID_BASE_URL = "https://api.acoustid.org/v2";
+
+function getApiKey(): string | null {
+  const key = (process.env.ACOUSTID_API_KEY ?? "").trim();
+  return key.length > 0 ? key : null;
+}
+
+export function isAcoustIdConfigured(): boolean {
+  return getApiKey() !== null;
+}
+
+type CacheEntry = {
+  cachedAt: number;
+  status: "hit" | "miss";
+  recordingMbid?: string;
+  score?: number;
+};
+
+type AcoustIdCache = Record<string, CacheEntry>;
+
+let cache: AcoustIdCache | null = null;
+let cacheDirty = false;
+let saveTimer: NodeJS.Timeout | null = null;
+const inflight = new Map<string, Promise<AcoustIdLookupResult | null>>();
+
+function cacheKeyForFingerprint(fingerprint: string, duration: number): string {
+  return `${Math.round(duration)}|${fingerprint}`;
+}
+
+function loadCache(): AcoustIdCache {
+  if (cache) return cache;
+  try {
+    if (fs.existsSync(CACHE_FILE)) {
+      const raw = fs.readFileSync(CACHE_FILE, "utf8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const cleaned: AcoustIdCache = {};
+      for (const [key, value] of Object.entries(parsed)) {
+        if (
+          value &&
+          typeof value === "object" &&
+          typeof (value as CacheEntry).cachedAt === "number" &&
+          ((value as CacheEntry).status === "hit" || (value as CacheEntry).status === "miss")
+        ) {
+          cleaned[key] = value as CacheEntry;
+        }
+      }
+      cache = cleaned;
+      return cache;
+    }
+  } catch {
+    log.warn("Failed to load AcoustID cache, starting fresh");
+  }
+  cache = {};
+  return cache;
+}
+
+function flushCacheNow(): void {
+  if (saveTimer) {
+    clearTimeout(saveTimer);
+    saveTimer = null;
+  }
+  if (!cache || !cacheDirty) return;
+  try {
+    fs.mkdirSync(path.dirname(CACHE_FILE), { recursive: true });
+    const tmpPath = `${CACHE_FILE}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(cache, null, 2), "utf8");
+    fs.renameSync(tmpPath, CACHE_FILE);
+    cacheDirty = false;
+  } catch (error) {
+    log.warn("Failed to save AcoustID cache", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+function scheduleCacheSave(): void {
+  cacheDirty = true;
+  if (saveTimer) return;
+  saveTimer = setTimeout(() => {
+    saveTimer = null;
+    flushCacheNow();
+  }, CACHE_FLUSH_DEBOUNCE_MS);
+  saveTimer.unref?.();
+}
+
+function isCacheEntryFresh(entry: CacheEntry): boolean {
+  if (entry.status === "hit") return true;
+  return Date.now() - entry.cachedAt < NEGATIVE_CACHE_TTL_MS;
+}
+
+type AcoustIdRecordingHit = { id?: string };
+type AcoustIdResult = {
+  id?: string;
+  score?: number;
+  recordings?: AcoustIdRecordingHit[];
+};
+type AcoustIdResponse = {
+  status?: string;
+  results?: AcoustIdResult[];
+  error?: { message?: string };
+};
+
+export type AcoustIdLookupResult = {
+  recordingMbid: string;
+  score: number;
+};
+
+function pickBestHit(results: AcoustIdResult[]): AcoustIdLookupResult | null {
+  let best: AcoustIdLookupResult | null = null;
+  for (const result of results) {
+    const score = typeof result.score === "number" ? result.score : 0;
+    if (score < MIN_SCORE_THRESHOLD) continue;
+    const recordings = result.recordings ?? [];
+    for (const rec of recordings) {
+      if (typeof rec.id !== "string" || rec.id.length === 0) continue;
+      if (!best || score > best.score) {
+        best = { recordingMbid: rec.id, score };
+      }
+    }
+  }
+  return best;
+}
+
+type LookupOutcome =
+  | { kind: "resolved"; hit: AcoustIdLookupResult | null }
+  | { kind: "transient" };
+
+async function performLookup(fingerprint: string, duration: number, apiKey: string): Promise<LookupOutcome> {
+  const body = new URLSearchParams({
+    client: apiKey,
+    duration: String(Math.round(duration)),
+    fingerprint,
+    meta: "recordings"
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(`${ACOUSTID_BASE_URL}/lookup`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    });
+  } catch (error) {
+    log.warn("AcoustID lookup failed", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return { kind: "transient" };
+  }
+
+  if (response.status >= 500 || response.status === 429) {
+    log.warn(`AcoustID returned ${response.status}`);
+    return { kind: "transient" };
+  }
+  if (!response.ok) {
+    log.warn(`AcoustID returned ${response.status}`);
+    return { kind: "resolved", hit: null };
+  }
+
+  let payload: AcoustIdResponse;
+  try {
+    payload = (await response.json()) as AcoustIdResponse;
+  } catch (error) {
+    log.warn("AcoustID returned invalid JSON", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return { kind: "transient" };
+  }
+
+  if (payload.status !== "ok") {
+    log.warn(`AcoustID error: ${payload.error?.message ?? "unknown"}`);
+    return { kind: "resolved", hit: null };
+  }
+
+  const hit = pickBestHit(payload.results ?? []);
+  return { kind: "resolved", hit };
+}
+
+/**
+ * Look up a Chromaprint fingerprint via AcoustID and return the best
+ * matching recording MBID, or null on miss/transient/unconfigured. Results
+ * are cached locally with the same TTL semantics as the MB cache: hits
+ * are forever, misses last 7 days, transient errors are not cached.
+ */
+export async function lookupRecordingByFingerprint(
+  fingerprint: string,
+  duration: number
+): Promise<AcoustIdLookupResult | null> {
+  if (!fingerprint.trim() || !Number.isFinite(duration) || duration <= 0) return null;
+  const apiKey = getApiKey();
+  if (!apiKey) return null;
+
+  const c = loadCache();
+  const key = cacheKeyForFingerprint(fingerprint, duration);
+  const existing = c[key];
+  if (existing && isCacheEntryFresh(existing)) {
+    if (existing.status === "miss") return null;
+    if (existing.recordingMbid) {
+      return { recordingMbid: existing.recordingMbid, score: existing.score ?? 1 };
+    }
+  }
+
+  const inflightPromise = inflight.get(key);
+  if (inflightPromise) return inflightPromise;
+
+  const promise = (async (): Promise<AcoustIdLookupResult | null> => {
+    try {
+      const outcome = await performLookup(fingerprint, duration, apiKey);
+      if (outcome.kind === "transient") return null;
+      c[key] = outcome.hit
+        ? {
+            cachedAt: Date.now(),
+            status: "hit",
+            recordingMbid: outcome.hit.recordingMbid,
+            score: outcome.hit.score
+          }
+        : { cachedAt: Date.now(), status: "miss" };
+      scheduleCacheSave();
+      return outcome.hit;
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+
+  inflight.set(key, promise);
+  return promise;
+}
+
+export function flushAcoustIdCache(): void {
+  flushCacheNow();
+}
+
+export function clearAcoustIdCache(): void {
+  cache = {};
+  inflight.clear();
+  cacheDirty = true;
+  flushCacheNow();
+}
+
+export function getAcoustIdCacheStats(): { entries: number } {
+  return { entries: Object.keys(loadCache()).length };
+}

--- a/backend/src/services/genre/enrichmentLogStore.ts
+++ b/backend/src/services/genre/enrichmentLogStore.ts
@@ -24,6 +24,7 @@ export type EnrichmentLogEntry = {
   filledReleaseGroupMbid?: string;
   filledArtistMbid?: string;
   coverFetched?: boolean;
+  resolvedViaFingerprint?: boolean;
   errorMessage?: string;
 };
 

--- a/backend/src/services/genre/fingerprintService.test.ts
+++ b/backend/src/services/genre/fingerprintService.test.ts
@@ -1,0 +1,162 @@
+import { EventEmitter } from "node:events";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { tmpDir } = vi.hoisted(() => {
+  const fsS = require("node:fs") as typeof import("node:fs");
+  const osM = require("node:os") as typeof import("node:os");
+  const pathM = require("node:path") as typeof import("node:path");
+  return {
+    tmpDir: fsS.mkdtempSync(pathM.join(osM.tmpdir(), "fingerprint-test-"))
+  };
+});
+
+vi.mock("../../utils/paths", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../utils/paths")>()),
+  cacheRoot: tmpDir
+}));
+
+vi.mock("../../utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}));
+
+type SpawnBehavior = {
+  errorCode?: string;
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+};
+
+let spawnBehavior: SpawnBehavior = { exitCode: 0, stdout: '{"fingerprint":"FAKE","duration":234}' };
+
+vi.mock("node:child_process", () => {
+  return {
+    spawn: vi.fn(() => {
+      const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter; kill: (sig: string) => void };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {};
+      // Schedule events for the next tick so listeners attach first.
+      setImmediate(() => {
+        if (spawnBehavior.errorCode) {
+          const err = new Error("spawn failed") as NodeJS.ErrnoException;
+          err.code = spawnBehavior.errorCode;
+          child.emit("error", err);
+          return;
+        }
+        if (spawnBehavior.stdout) child.stdout.emit("data", Buffer.from(spawnBehavior.stdout, "utf8"));
+        if (spawnBehavior.stderr) child.stderr.emit("data", Buffer.from(spawnBehavior.stderr, "utf8"));
+        child.emit("close", spawnBehavior.exitCode ?? 0);
+      });
+      return child;
+    })
+  };
+});
+
+const CACHE_FILE = path.join(tmpDir, "track-fingerprints.json");
+
+beforeEach(async () => {
+  vi.resetModules();
+  for (const entry of await fs.readdir(tmpDir).catch(() => [])) {
+    await fs.rm(path.join(tmpDir, entry), { recursive: true, force: true });
+  }
+  spawnBehavior = { exitCode: 0, stdout: '{"fingerprint":"FAKE","duration":234}' };
+});
+
+afterAll(() => {
+  fsSync.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function loadModule(): Promise<typeof import("./fingerprintService")> {
+  return await import("./fingerprintService");
+}
+
+async function makeAudioFile(name: string, body = "fake-audio"): Promise<string> {
+  const filePath = path.join(tmpDir, name);
+  fsSync.writeFileSync(filePath, body, "utf8");
+  return filePath;
+}
+
+describe("fingerprintService", () => {
+  it("computes a fingerprint via fpcalc and caches it", async () => {
+    const filePath = await makeAudioFile("a.mp3");
+    const { computeTrackFingerprint, flushFingerprintCache } = await loadModule();
+    const result = await computeTrackFingerprint("track-1", filePath);
+    expect(result?.fingerprint).toBe("FAKE");
+    expect(result?.duration).toBe(234);
+    flushFingerprintCache();
+    expect(fsSync.existsSync(CACHE_FILE)).toBe(true);
+  });
+
+  it("returns the cached fingerprint when file mtime/size are unchanged", async () => {
+    const filePath = await makeAudioFile("a.mp3");
+    const { computeTrackFingerprint } = await loadModule();
+    await computeTrackFingerprint("track-1", filePath);
+
+    // Change the spawn behavior so a re-call would yield a different fingerprint
+    spawnBehavior = { exitCode: 0, stdout: '{"fingerprint":"NEW","duration":99}' };
+    const second = await computeTrackFingerprint("track-1", filePath);
+    expect(second?.fingerprint).toBe("FAKE");
+    expect(second?.duration).toBe(234);
+  });
+
+  it("re-computes when the file has been modified", async () => {
+    const filePath = await makeAudioFile("a.mp3");
+    const { computeTrackFingerprint } = await loadModule();
+    await computeTrackFingerprint("track-1", filePath);
+
+    // Modify the file to change mtime + size
+    await new Promise((r) => setTimeout(r, 10));
+    fsSync.writeFileSync(filePath, "fake-audio-with-more-bytes", "utf8");
+    spawnBehavior = { exitCode: 0, stdout: '{"fingerprint":"NEW","duration":99}' };
+
+    const second = await computeTrackFingerprint("track-1", filePath);
+    expect(second?.fingerprint).toBe("NEW");
+  });
+
+  it("returns null when fpcalc is not installed", async () => {
+    spawnBehavior = { errorCode: "ENOENT" };
+    const filePath = await makeAudioFile("a.mp3");
+    const { computeTrackFingerprint, isFingerprintingDisabled } = await loadModule();
+    expect(await computeTrackFingerprint("track-1", filePath)).toBeNull();
+    expect(isFingerprintingDisabled()).toBe(true);
+  });
+
+  it("short-circuits subsequent calls once fpcalc is known to be missing", async () => {
+    spawnBehavior = { errorCode: "ENOENT" };
+    const filePath = await makeAudioFile("a.mp3");
+    const { computeTrackFingerprint } = await loadModule();
+    await computeTrackFingerprint("track-1", filePath);
+
+    // Even if spawn would now succeed, the module remembers fpcalc isn't available
+    spawnBehavior = { exitCode: 0, stdout: '{"fingerprint":"FAKE","duration":234}' };
+    expect(await computeTrackFingerprint("track-2", filePath)).toBeNull();
+  });
+
+  it("returns null when fpcalc exits with non-zero code", async () => {
+    spawnBehavior = { exitCode: 1, stderr: "could not decode" };
+    const filePath = await makeAudioFile("a.mp3");
+    const { computeTrackFingerprint } = await loadModule();
+    expect(await computeTrackFingerprint("track-1", filePath)).toBeNull();
+  });
+
+  it("returns null when fpcalc output is malformed JSON", async () => {
+    spawnBehavior = { exitCode: 0, stdout: "not-json" };
+    const filePath = await makeAudioFile("a.mp3");
+    const { computeTrackFingerprint } = await loadModule();
+    expect(await computeTrackFingerprint("track-1", filePath)).toBeNull();
+  });
+
+  it("returns null when the file does not exist", async () => {
+    const { computeTrackFingerprint } = await loadModule();
+    expect(await computeTrackFingerprint("track-1", path.join(tmpDir, "missing.mp3"))).toBeNull();
+  });
+});

--- a/backend/src/services/genre/fingerprintService.ts
+++ b/backend/src/services/genre/fingerprintService.ts
@@ -1,0 +1,222 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+import { createLogger } from "../../utils/logger";
+import { cacheRoot } from "../../utils/paths";
+
+const log = createLogger("fingerprint");
+
+const CACHE_FILE = path.join(cacheRoot, "track-fingerprints.json");
+const CACHE_FLUSH_DEBOUNCE_MS = 500;
+const FPCALC_TIMEOUT_MS = 30_000;
+
+function getFpcalcPath(): string {
+  return (process.env.FPCALC_PATH ?? "fpcalc").trim() || "fpcalc";
+}
+
+export type FingerprintEntry = {
+  fingerprint: string;
+  duration: number;
+  mtimeMs: number;
+  size: number;
+  computedAt: number;
+};
+
+type FingerprintCache = Record<string, FingerprintEntry>;
+
+let cache: FingerprintCache | null = null;
+let cacheDirty = false;
+let saveTimer: NodeJS.Timeout | null = null;
+let fpcalcAvailable: boolean | null = null;
+
+function loadCache(): FingerprintCache {
+  if (cache) return cache;
+  try {
+    if (fs.existsSync(CACHE_FILE)) {
+      const raw = fs.readFileSync(CACHE_FILE, "utf8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const cleaned: FingerprintCache = {};
+      for (const [key, value] of Object.entries(parsed)) {
+        if (
+          value &&
+          typeof value === "object" &&
+          typeof (value as FingerprintEntry).fingerprint === "string" &&
+          typeof (value as FingerprintEntry).duration === "number"
+        ) {
+          cleaned[key] = value as FingerprintEntry;
+        }
+      }
+      cache = cleaned;
+      return cache;
+    }
+  } catch {
+    log.warn("Failed to load fingerprint cache, starting fresh");
+  }
+  cache = {};
+  return cache;
+}
+
+function flushCacheNow(): void {
+  if (saveTimer) {
+    clearTimeout(saveTimer);
+    saveTimer = null;
+  }
+  if (!cache || !cacheDirty) return;
+  try {
+    fs.mkdirSync(path.dirname(CACHE_FILE), { recursive: true });
+    const tmpPath = `${CACHE_FILE}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(cache, null, 2), "utf8");
+    fs.renameSync(tmpPath, CACHE_FILE);
+    cacheDirty = false;
+  } catch (error) {
+    log.warn("Failed to save fingerprint cache", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+function scheduleCacheSave(): void {
+  cacheDirty = true;
+  if (saveTimer) return;
+  saveTimer = setTimeout(() => {
+    saveTimer = null;
+    flushCacheNow();
+  }, CACHE_FLUSH_DEBOUNCE_MS);
+  saveTimer.unref?.();
+}
+
+export type FingerprintResult = {
+  fingerprint: string;
+  duration: number;
+};
+
+function runFpcalc(filePath: string, fpcalcPath: string): Promise<FingerprintResult | null> {
+  return new Promise((resolve) => {
+    const child = spawn(fpcalcPath, ["-json", filePath], { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let done = false;
+
+    const timer = setTimeout(() => {
+      done = true;
+      try {
+        child.kill("SIGKILL");
+      } catch {}
+      log.warn("fpcalc timed out", { filePath });
+      resolve(null);
+    }, FPCALC_TIMEOUT_MS);
+    timer.unref?.();
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+      if (stderr.length > 4096) stderr = stderr.slice(-4096);
+    });
+
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      if (err.code === "ENOENT") {
+        // fpcalc not installed — record availability for next call
+        fpcalcAvailable = false;
+        log.info("fpcalc binary not available; AcoustID fingerprinting disabled", {
+          path: fpcalcPath
+        });
+      } else {
+        log.warn("fpcalc failed to start", { error: err.message });
+      }
+      resolve(null);
+    });
+
+    child.on("close", (code) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      if (code !== 0) {
+        log.warn(`fpcalc exited with code ${code}`, { stderr: stderr.trim() });
+        resolve(null);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(stdout) as { duration?: number; fingerprint?: string };
+        if (typeof parsed.fingerprint === "string" && typeof parsed.duration === "number") {
+          fpcalcAvailable = true;
+          resolve({ fingerprint: parsed.fingerprint, duration: parsed.duration });
+        } else {
+          log.warn("fpcalc output missing fingerprint or duration");
+          resolve(null);
+        }
+      } catch (error) {
+        log.warn("Failed to parse fpcalc output", {
+          error: error instanceof Error ? error.message : String(error)
+        });
+        resolve(null);
+      }
+    });
+  });
+}
+
+export function isFingerprintingDisabled(): boolean {
+  return fpcalcAvailable === false;
+}
+
+/**
+ * Compute or return a cached Chromaprint fingerprint for a track. The cache
+ * is keyed by trackId and invalidated when the file's mtime or size change.
+ * Returns null if fpcalc is unavailable or the file can't be analyzed.
+ */
+export async function computeTrackFingerprint(
+  trackId: string,
+  absolutePath: string
+): Promise<FingerprintResult | null> {
+  if (fpcalcAvailable === false) return null;
+
+  let stat: Awaited<ReturnType<typeof fsp.stat>>;
+  try {
+    stat = await fsp.stat(absolutePath);
+  } catch {
+    return null;
+  }
+
+  const c = loadCache();
+  const cached = c[trackId];
+  if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+    return { fingerprint: cached.fingerprint, duration: cached.duration };
+  }
+
+  const result = await runFpcalc(absolutePath, getFpcalcPath());
+  if (!result) return null;
+
+  c[trackId] = {
+    fingerprint: result.fingerprint,
+    duration: result.duration,
+    mtimeMs: stat.mtimeMs,
+    size: stat.size,
+    computedAt: Date.now()
+  };
+  scheduleCacheSave();
+  return result;
+}
+
+export function flushFingerprintCache(): void {
+  flushCacheNow();
+}
+
+export function clearFingerprintCache(): void {
+  cache = {};
+  cacheDirty = true;
+  flushCacheNow();
+}
+
+export function getFingerprintCacheStats(): { entries: number } {
+  return { entries: Object.keys(loadCache()).length };
+}
+
+export function _resetFingerprintAvailabilityForTesting(): void {
+  fpcalcAvailable = null;
+}

--- a/backend/src/services/genre/genreEnrichmentService.ts
+++ b/backend/src/services/genre/genreEnrichmentService.ts
@@ -5,12 +5,24 @@ import {
   type TrackMetadataOverride
 } from "../indexer/metadataOverrideStore";
 import { findCoverFileByTrackId } from "../storage/coverService";
+import { resolveTrackAbsolutePath } from "../storage/storageService";
 import type { Track } from "../../types/library";
+import {
+  flushAcoustIdCache,
+  isAcoustIdConfigured,
+  lookupRecordingByFingerprint
+} from "./acoustIdService";
 import { fetchAndSaveCoverArt, flushCoverArtNegativeCache } from "./coverArtArchiveService";
+import {
+  computeTrackFingerprint,
+  flushFingerprintCache,
+  isFingerprintingDisabled
+} from "./fingerprintService";
 import {
   flushGenreCache,
   invalidateCacheEntry,
   lookupRecordingMetadata,
+  lookupRecordingMetadataByMbid,
   type RecordingMetadata
 } from "./musicBrainzService";
 import { normalizeGenreLabels } from "./genreSynonymService";
@@ -68,6 +80,11 @@ export type TrackEnrichmentInput = {
   hasYear: boolean;
   hasCover: boolean;
   source?: EnrichmentSource;
+  /**
+   * Absolute path to the audio file on disk. Required for the AcoustID
+   * fingerprint fallback. When omitted, fingerprint lookup is skipped.
+   */
+  absolutePath?: string;
 };
 
 export type TrackEnrichmentResult = {
@@ -77,6 +94,7 @@ export type TrackEnrichmentResult = {
   mbidReleaseGroup: string | null;
   mbidArtist: string | null;
   coverFetched: boolean;
+  resolvedViaFingerprint: boolean;
 };
 
 function metadataDiffersFromOverride(
@@ -151,7 +169,8 @@ function buildLogEntry(
     ...(result.mbidRecording ? { filledRecordingMbid: result.mbidRecording } : {}),
     ...(result.mbidReleaseGroup ? { filledReleaseGroupMbid: result.mbidReleaseGroup } : {}),
     ...(result.mbidArtist ? { filledArtistMbid: result.mbidArtist } : {}),
-    ...(result.coverFetched ? { coverFetched: true } : {})
+    ...(result.coverFetched ? { coverFetched: true } : {}),
+    ...(result.resolvedViaFingerprint ? { resolvedViaFingerprint: true } : {})
   };
 }
 
@@ -168,10 +187,35 @@ export async function enrichTrackMetadata(input: TrackEnrichmentInput): Promise<
     mbidRecording: null,
     mbidReleaseGroup: null,
     mbidArtist: null,
-    coverFetched: false
+    coverFetched: false,
+    resolvedViaFingerprint: false
   };
 
-  const metadata = await lookupRecordingMetadata(input.artist, input.title);
+  let metadata = await lookupRecordingMetadata(input.artist, input.title);
+
+  // Fallback: if name-search missed and we have a file path + AcoustID is
+  // configured + fpcalc is available, try to resolve the recording by
+  // audio fingerprint. This rescues tracks with broken or generic tags
+  // (e.g. "Track 01" / "Unknown Artist").
+  if (
+    !metadata &&
+    input.absolutePath &&
+    isAcoustIdConfigured() &&
+    !isFingerprintingDisabled()
+  ) {
+    const fingerprint = await computeTrackFingerprint(input.id, input.absolutePath);
+    if (fingerprint) {
+      const acoustHit = await lookupRecordingByFingerprint(
+        fingerprint.fingerprint,
+        fingerprint.duration
+      );
+      if (acoustHit) {
+        metadata = await lookupRecordingMetadataByMbid(acoustHit.recordingMbid);
+        if (metadata) result.resolvedViaFingerprint = true;
+      }
+    }
+  }
+
   if (!metadata) {
     appendEnrichmentLog(buildLogEntry(input, result, false, input.source ?? "bulk"));
     return result;
@@ -258,7 +302,8 @@ export async function reEnrichTrack(track: Track, indexStore?: IndexStore): Prom
       mbidRecording: null,
       mbidReleaseGroup: null,
       mbidArtist: null,
-      coverFetched: false
+      coverFetched: false,
+      resolvedViaFingerprint: false
     };
   }
 
@@ -272,7 +317,8 @@ export async function reEnrichTrack(track: Track, indexStore?: IndexStore): Prom
     hasGenre: Array.isArray(track.tags.genre) && track.tags.genre.length > 0,
     hasYear: typeof track.tags.year === "number",
     hasCover: cover !== null,
-    source: "single"
+    source: "single",
+    absolutePath: resolveTrackAbsolutePath(track.path)
   });
 
   const wroteMetadata =
@@ -306,7 +352,8 @@ function describeTrackEnrichmentNeeds(track: Track, hasCover: boolean): TrackEnr
     hasGenre,
     hasYear,
     hasCover,
-    source: "bulk"
+    source: "bulk",
+    absolutePath: resolveTrackAbsolutePath(track.path)
   };
 }
 
@@ -413,6 +460,8 @@ export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<v
   abortController = null;
   flushGenreCache();
   flushCoverArtNegativeCache();
+  flushFingerprintCache();
+  flushAcoustIdCache();
   if (anyMetadataWritten) {
     await indexStore.rebuild();
   }

--- a/backend/src/services/genre/musicBrainzService.test.ts
+++ b/backend/src/services/genre/musicBrainzService.test.ts
@@ -441,4 +441,39 @@ describe("musicBrainzService.lookupRecordingMetadata", () => {
     expect(second?.releaseGroupMbid).toBe(RELEASE_GROUP_MBID);
     expect(fetchCalls).toEqual([]);
   });
+
+  it("lookupRecordingMetadataByMbid fetches detail directly and caches the result", async () => {
+    fetchHandler = (url) => {
+      expect(url).toMatch(/\/recording\/11111111-1111-4111-8111-111111111111/);
+      expect(url).toMatch(/inc=[^&]*release-groups/);
+      return {
+        status: 200,
+        body: {
+          id: RECORDING_MBID,
+          "artist-credit": [{ artist: { id: ARTIST_MBID } }],
+          releases: [
+            {
+              "release-group": {
+                id: RELEASE_GROUP_MBID,
+                "first-release-date": "1989-09-21",
+                "primary-type": "Album"
+              }
+            }
+          ],
+          tags: [{ name: "rock" }]
+        }
+      };
+    };
+    const { lookupRecordingMetadataByMbid } = await loadModule();
+    const result = await lookupRecordingMetadataByMbid(RECORDING_MBID);
+    expect(result?.recordingMbid).toBe(RECORDING_MBID);
+    expect(result?.releaseGroupMbid).toBe(RELEASE_GROUP_MBID);
+    expect(result?.year).toBe(1989);
+    expect(result?.genres).toEqual(["Rock"]);
+
+    fetchCalls = [];
+    const cached = await lookupRecordingMetadataByMbid(RECORDING_MBID);
+    expect(cached?.year).toBe(1989);
+    expect(fetchCalls).toEqual([]);
+  });
 });

--- a/backend/src/services/genre/musicBrainzService.ts
+++ b/backend/src/services/genre/musicBrainzService.ts
@@ -471,6 +471,65 @@ async function lookupRecordingMetadataUncached(artist: string, title: string): P
   return { kind: "resolved", metadata: null };
 }
 
+function recordingMetadataFromDetail(
+  recordingMbid: string,
+  detail: MBRecordingDetail
+): RecordingMetadata {
+  const genres = extractGenres(detail);
+  const { releaseGroupMbid, year } = pickCanonicalRelease(detail);
+  const artistMbid = extractArtistMbid(detail);
+  return { genres, recordingMbid, releaseGroupMbid, artistMbid, year };
+}
+
+/**
+ * Fetch rich metadata (genres, release-group, year, artist MBID) for a known
+ * recording MBID. Used by the AcoustID fingerprint fallback path: when the
+ * artist/title search misses but a fingerprint resolves to a recording, we
+ * still want the same downstream metadata.
+ *
+ * Cached under a `mbid:` key so repeated MBID lookups are deduped, but uses
+ * the same on-disk cache file as the artist/title path. Misses are NOT
+ * cached because we only get here for confirmed-via-fingerprint MBIDs.
+ */
+export async function lookupRecordingMetadataByMbid(recordingMbid: string): Promise<RecordingMetadata | null> {
+  if (!recordingMbid.trim()) return null;
+
+  const c = loadCache();
+  const key = `mbid:${recordingMbid.toLowerCase().trim()}`;
+  const existing = c[key];
+  if (existing && isCacheEntryFreshForRich(existing)) {
+    return entryToMetadata(existing);
+  }
+
+  const inflightPromise = inflightRich.get(key);
+  if (inflightPromise) return inflightPromise;
+
+  const promise = (async (): Promise<RecordingMetadata | null> => {
+    try {
+      const detail = await fetchRecordingDetail(recordingMbid, true);
+      if (detail.kind !== "ok") return null;
+      const metadata = recordingMetadataFromDetail(recordingMbid, detail.detail);
+      c[key] = {
+        cachedAt: Date.now(),
+        status: "hit",
+        richVersion: RICH_SCHEMA_VERSION,
+        genres: metadata.genres,
+        recordingMbid: metadata.recordingMbid,
+        releaseGroupMbid: metadata.releaseGroupMbid,
+        artistMbid: metadata.artistMbid,
+        year: metadata.year
+      };
+      scheduleCacheSave();
+      return metadata;
+    } finally {
+      inflightRich.delete(key);
+    }
+  })();
+
+  inflightRich.set(key, promise);
+  return promise;
+}
+
 function buildTitlePasses(title: string): string[] {
   const passes: string[] = [title];
   const simplified = simplifyTitle(title);

--- a/frontend/src/api/genre.ts
+++ b/frontend/src/api/genre.ts
@@ -107,6 +107,10 @@ export async function reapplyGenreSynonyms(): Promise<{ scanned: number; updated
 
 export type GenreCacheStats = {
   entries: number;
+  fingerprints?: number;
+  acoustid?: number;
+  acoustIdConfigured?: boolean;
+  fingerprintingAvailable?: boolean;
 };
 
 export async function getGenreCacheStats(): Promise<GenreCacheStats> {

--- a/frontend/src/components/AdminLibraryView.tsx
+++ b/frontend/src/components/AdminLibraryView.tsx
@@ -443,17 +443,47 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
         ) : null}
 
         {cacheStats ? (
-          <div className="mt-3 flex flex-wrap items-center gap-3">
-            <span className="text-sm text-flaque-steel">
-              Cache: {cacheStats.entries} {cacheStats.entries === 1 ? "entry" : "entries"}
-            </span>
-            <button
-              type="button"
-              className="rounded-lg border border-flaque-clay px-3 py-1 text-xs text-flaque-ink transition hover:bg-flaque-cream"
-              onClick={() => { void handleClearCache(); }}
-            >
-              Clear cache
-            </button>
+          <div className="mt-3 space-y-2">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="text-sm text-flaque-steel">
+                Cache: {cacheStats.entries} {cacheStats.entries === 1 ? "MB entry" : "MB entries"}
+                {typeof cacheStats.fingerprints === "number"
+                  ? ` · ${cacheStats.fingerprints} fingerprint${cacheStats.fingerprints === 1 ? "" : "s"}`
+                  : ""}
+                {typeof cacheStats.acoustid === "number"
+                  ? ` · ${cacheStats.acoustid} AcoustID`
+                  : ""}
+              </span>
+              <button
+                type="button"
+                className="rounded-lg border border-flaque-clay px-3 py-1 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+                onClick={() => { void handleClearCache(); }}
+              >
+                Clear cache
+              </button>
+            </div>
+            <div className="flex flex-wrap items-center gap-3 text-xs text-flaque-steel/80">
+              <span
+                className={`rounded px-2 py-0.5 ${
+                  cacheStats.acoustIdConfigured
+                    ? "bg-green-100 text-green-700"
+                    : "bg-flaque-clay/40 text-flaque-steel"
+                }`}
+                title="Set ACOUSTID_API_KEY on the server to enable fingerprint fallback for tracks with bad tags."
+              >
+                AcoustID: {cacheStats.acoustIdConfigured ? "configured" : "not configured"}
+              </span>
+              <span
+                className={`rounded px-2 py-0.5 ${
+                  cacheStats.fingerprintingAvailable
+                    ? "bg-green-100 text-green-700"
+                    : "bg-flaque-clay/40 text-flaque-steel"
+                }`}
+                title="Install the chromaprint (fpcalc) binary on the server to enable audio fingerprinting."
+              >
+                fpcalc: {cacheStats.fingerprintingAvailable ? "available" : "not detected"}
+              </span>
+            </div>
           </div>
         ) : null}
       </section>


### PR DESCRIPTION
> Stacked on #172 (Phase 3), which stacks on #170 (Phase 1+2). Diff shown here is Phase 4 only; the diff against master will narrow to Phase 4 once #170 and #172 merge.

## Summary

Adds Chromaprint-based audio fingerprinting + AcoustID lookup as a fallback when MusicBrainz name-search misses. Rescues tracks whose artist/title tags are slightly wrong (typos, alternate spellings) without changing how cleanly-tagged tracks are handled.

**Fingerprint service** (\`fingerprintService.ts\`, new)
- Shells out to \`fpcalc\` (the Chromaprint CLI), parses JSON, returns \`{ fingerprint, duration }\` or null.
- Cache keyed by \`trackId\`, invalidated when the file's mtime or size changes.
- \`ENOENT\` during spawn flips a process-wide flag so subsequent calls short-circuit instead of forking for every track.
- \`FPCALC_PATH\` env var overrides the binary path; defaults to \`fpcalc\` on PATH.

**AcoustID service** (\`acoustIdService.ts\`, new)
- \`lookupRecordingByFingerprint(fingerprint, duration)\` POSTs to AcoustID with \`meta=recordings\`, picks the highest-scoring result with \`score >= 0.85\`.
- Disabled when \`ACOUSTID_API_KEY\` is unset.
- Cache: hits forever, misses 7 days, transient (5xx / 429 / network throw) not cached. AcoustID \`status: error\` responses treated as legitimate misses.

**MusicBrainz**
- New \`lookupRecordingMetadataByMbid(recordingMbid)\` skips the search step and fetches \`/recording/{id}?inc=…releases+release-groups\` directly. Used by the fingerprint path; cached under a \`mbid:\` key.

**Enrichment integration**
- \`TrackEnrichmentInput\` gains \`absolutePath\`. When name-search misses AND \`absolutePath\` is provided AND AcoustID is configured AND fpcalc is available, enrichment computes the fingerprint, queries AcoustID, fetches by MBID, and fills missing fields as usual. Result tagged \`resolvedViaFingerprint: true\`.
- Both the bulk runner and \`reEnrichTrack\` resolve and pass \`absolutePath\` via \`resolveTrackAbsolutePath(track.path)\`.

**Admin UX**
- \`/api/genre/cache/stats\` now returns \`fingerprints\`, \`acoustid\`, \`acoustIdConfigured\`, \`fingerprintingAvailable\`. Two new pill badges in the admin UI surface \"AcoustID: configured/not configured\" and \"fpcalc: available/not detected\".
- \`/api/genre/cache/clear\` clears all three caches.

**Configuration**
- \`ACOUSTID_API_KEY\` — required to enable the fallback (free for non-commercial use at acoustid.org).
- \`FPCALC_PATH\` — optional, defaults to \`fpcalc\` on PATH. Without fpcalc, feature silently degrades.

**Tests (+17, 626 total)**
- AcoustID (9): unconfigured short-circuit, score threshold, request shape, hit/miss caching, no-cache on 5xx, no-cache on network throw, AcoustID-error treated as miss.
- Fingerprint (8): compute + cache, mtime/size invalidation, ENOENT detection + short-circuit, non-zero exit, malformed JSON, missing file.
- MB (+1): \`lookupRecordingMetadataByMbid\` direct fetch + caching.

## Test plan
- [ ] Without \`ACOUSTID_API_KEY\` set: confirm enrichment behavior is unchanged and the admin UI shows \"AcoustID: not configured\".
- [ ] With \`ACOUSTID_API_KEY\` set but no \`fpcalc\` binary: confirm enrichment falls back gracefully (one info log), \"fpcalc: not detected\" pill shown.
- [ ] With \`fpcalc\` and \`ACOUSTID_API_KEY\` set: deliberately edit a track to have a typo in the title (e.g. \"Hye Jude\"), then re-enrich — confirm AcoustID rescues it and the log entry shows \`resolvedViaFingerprint: true\`.
- [ ] After enrichment runs, \`cache/track-fingerprints.json\` and \`cache/acoustid-cache.json\` exist alongside \`musicbrainz-genre-cache.json\`.
- [ ] Click \"Clear cache\" — all three caches go to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)