### PR TITLE
feat(musicbrainz): phase 6 - album-level enrichment cohorts

### DIFF
--- a/backend/src/services/genre/genreEnrichmentService.test.ts
+++ b/backend/src/services/genre/genreEnrichmentService.test.ts
@@ -206,6 +206,82 @@ describe("enrichTrackMetadata", () => {
     expect(overrides["track-1"]?.provenance?.year).toBe("auto");
   });
 
+  it("applyAlbumMetadataToTrack fills year and genre from a ReleaseGroupMetadata, stamping auto", async () => {
+    const { enrichment, overrideStore } = await loadModules();
+
+    const rgMeta = {
+      releaseGroupMbid: RELEASE_GROUP_MBID,
+      year: 1989,
+      genres: ["Rock", "Indie Rock"],
+      artistMbid: ARTIST_MBID
+    };
+
+    const result = await enrichment.applyAlbumMetadataToTrack(
+      {
+        id: "track-1",
+        artist: "Pixies",
+        title: "Debaser",
+        hasGenre: false,
+        hasYear: false,
+        hasCover: true, // skip cover fetch
+        source: "bulk",
+        album: "Doolittle"
+      },
+      rgMeta
+    );
+
+    expect(result.year).toBe(1989);
+    expect(result.genres).toEqual(["Rock", "Indie Rock"]);
+    expect(result.mbidReleaseGroup).toBe(RELEASE_GROUP_MBID);
+    expect(result.mbidArtist).toBe(ARTIST_MBID);
+
+    const overrides = await overrideStore.readTrackMetadataOverrides();
+    expect(overrides["track-1"]?.year).toBe(1989);
+    expect(overrides["track-1"]?.genre).toEqual(["Rock", "Indie Rock"]);
+    expect(overrides["track-1"]?.mbidReleaseGroup).toBe(RELEASE_GROUP_MBID);
+    expect(overrides["track-1"]?.mbidArtist).toBe(ARTIST_MBID);
+    expect(overrides["track-1"]?.provenance?.year).toBe("auto");
+    expect(overrides["track-1"]?.provenance?.genre).toBe("auto");
+  });
+
+  it("applyAlbumMetadataToTrack respects manual provenance and does not overwrite", async () => {
+    const { enrichment, overrideStore } = await loadModules();
+
+    // Track has manual genre. Cohort offers a different one.
+    await overrideStore.mergeTrackMetadataOverrides({
+      "track-1": {
+        genre: ["Indie"],
+        provenance: { genre: "manual" }
+      }
+    });
+
+    await enrichment.applyAlbumMetadataToTrack(
+      {
+        id: "track-1",
+        artist: "Pixies",
+        title: "Debaser",
+        hasGenre: true,
+        hasYear: false,
+        hasCover: true,
+        source: "bulk",
+        album: "Doolittle"
+      },
+      {
+        releaseGroupMbid: RELEASE_GROUP_MBID,
+        year: 1989,
+        genres: ["Rock"],
+        artistMbid: ARTIST_MBID
+      }
+    );
+
+    const overrides = await overrideStore.readTrackMetadataOverrides();
+    expect(overrides["track-1"]?.genre).toEqual(["Indie"]);
+    expect(overrides["track-1"]?.provenance?.genre).toBe("manual");
+    // Year still gets filled because no manual gate on it.
+    expect(overrides["track-1"]?.year).toBe(1989);
+    expect(overrides["track-1"]?.provenance?.year).toBe("auto");
+  });
+
   it("preserves an existing manual provenance entry on subsequent enrichment", async () => {
     const { enrichment, overrideStore } = await loadModules();
 

--- a/backend/src/services/genre/genreEnrichmentService.ts
+++ b/backend/src/services/genre/genreEnrichmentService.ts
@@ -25,7 +25,9 @@ import {
   invalidateMbidCacheEntry,
   lookupRecordingMetadata,
   lookupRecordingMetadataByMbid,
-  type RecordingMetadata
+  lookupReleaseGroup,
+  type RecordingMetadata,
+  type ReleaseGroupMetadata
 } from "./musicBrainzService";
 import { normalizeGenreLabels } from "./genreSynonymService";
 import { appendEnrichmentLog, type EnrichmentLogEntry } from "./enrichmentLogStore";
@@ -87,6 +89,11 @@ export type TrackEnrichmentInput = {
    * fingerprint fallback. When omitted, fingerprint lookup is skipped.
    */
   absolutePath?: string;
+  /**
+   * Track's album tag, if any. Used by the bulk runner to group tracks
+   * into album cohorts for single-lookup enrichment.
+   */
+  album?: string;
 };
 
 export type TrackEnrichmentResult = {
@@ -389,8 +396,87 @@ function describeTrackEnrichmentNeeds(track: Track, hasCover: boolean): TrackEnr
     hasYear,
     hasCover,
     source: "bulk",
-    absolutePath: resolveTrackAbsolutePath(track.path)
+    absolutePath: resolveTrackAbsolutePath(track.path),
+    album: track.tags.album
   };
+}
+
+/**
+ * Apply album-level metadata (year, genre, release-group MBID, artist
+ * MBID) and a Cover Art Archive cover to a single track. Mirrors
+ * enrichTrackMetadata's writing/provenance logic but uses a pre-fetched
+ * ReleaseGroupMetadata so we don't hit MB per track. recordingMbid is
+ * NOT touched — that remains a per-recording lookup concern.
+ */
+export async function applyAlbumMetadataToTrack(
+  input: TrackEnrichmentInput,
+  rgMeta: ReleaseGroupMetadata
+): Promise<TrackEnrichmentResult> {
+  const result: TrackEnrichmentResult = {
+    genres: null,
+    year: null,
+    mbidRecording: null,
+    mbidReleaseGroup: null,
+    mbidArtist: null,
+    coverFetched: false,
+    resolvedViaFingerprint: false
+  };
+
+  const allOverrides = await readTrackMetadataOverrides();
+  const existingOverride = allOverrides[input.id];
+  const provenance = existingOverride?.provenance;
+  const normalizedGenres = normalizeGenreLabels(rgMeta.genres);
+
+  const fillGenre = provenance?.genre !== "manual" && !input.hasGenre && normalizedGenres.length > 0;
+  const fillYear = provenance?.year !== "manual" && !input.hasYear && rgMeta.year !== undefined;
+  const setReleaseGroup = !!rgMeta.releaseGroupMbid && existingOverride?.mbidReleaseGroup !== rgMeta.releaseGroupMbid;
+  const setArtist = !!rgMeta.artistMbid && existingOverride?.mbidArtist !== rgMeta.artistMbid;
+
+  if (fillGenre || fillYear || setReleaseGroup || setArtist) {
+    const next: TrackMetadataOverride = { ...(existingOverride ?? {}) };
+    const nextProvenance: TrackMetadataProvenance = { ...(existingOverride?.provenance ?? {}) };
+    if (fillGenre) {
+      next.genre = normalizedGenres;
+      nextProvenance.genre = "auto";
+    }
+    if (fillYear) {
+      next.year = rgMeta.year;
+      nextProvenance.year = "auto";
+    }
+    if (setReleaseGroup) next.mbidReleaseGroup = rgMeta.releaseGroupMbid;
+    if (setArtist) next.mbidArtist = rgMeta.artistMbid;
+    next.provenance = Object.keys(nextProvenance).length > 0 ? nextProvenance : undefined;
+    await mergeTrackMetadataOverrides({ [input.id]: next });
+  }
+
+  if (fillGenre) result.genres = normalizedGenres;
+  if (fillYear && rgMeta.year !== undefined) result.year = rgMeta.year;
+  result.mbidReleaseGroup = rgMeta.releaseGroupMbid;
+  result.mbidArtist = rgMeta.artistMbid ?? null;
+
+  if (!input.hasCover && rgMeta.releaseGroupMbid) {
+    const fetchResult = await fetchAndSaveCoverArt(input.id, rgMeta.releaseGroupMbid);
+    if (fetchResult.kind === "saved") result.coverFetched = true;
+  }
+
+  appendEnrichmentLog({
+    ...buildLogEntry(input, result, true, input.source ?? "bulk")
+  });
+  return result;
+}
+
+/**
+ * True when the track has nothing left to gain from a per-recording
+ * lookup after the album cohort filled what it could. Cover is treated
+ * as best-effort: if the cohort's release-group has no art (or the
+ * fetch was throttled), per-track lookup wouldn't find a different
+ * cover for the same release-group, so we don't fall through on a
+ * cover-only miss.
+ */
+function trackIsFullyCoveredByCohort(input: TrackEnrichmentInput, result: TrackEnrichmentResult): boolean {
+  const stillNeedsGenre = !input.hasGenre && result.genres === null;
+  const stillNeedsYear = !input.hasYear && result.year === null;
+  return !stillNeedsGenre && !stillNeedsYear;
 }
 
 export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<void> {
@@ -436,11 +522,138 @@ export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<v
     currentTrack: null
   };
 
-  log.info(`Starting metadata enrichment for ${candidates.length} tracks`);
+  // Group candidates into album cohorts. Tracks without an album, or
+  // albums with a single member, go straight to per-track lookup —
+  // there's no efficiency win for a singleton.
+  const cohortMap = new Map<string, TrackEnrichmentInput[]>();
+  const singletons: TrackEnrichmentInput[] = [];
+  for (const candidate of candidates) {
+    const albumKey = candidate.album?.trim();
+    if (!albumKey) {
+      singletons.push(candidate);
+      continue;
+    }
+    const key = `${candidate.artist.trim().toLowerCase()}|||${albumKey.toLowerCase()}`;
+    const existing = cohortMap.get(key);
+    if (existing) existing.push(candidate);
+    else cohortMap.set(key, [candidate]);
+  }
+
+  const perTrackQueue: TrackEnrichmentInput[] = [...singletons];
+  for (const members of cohortMap.values()) {
+    if (members.length < 2) {
+      perTrackQueue.push(...members);
+    }
+  }
+
+  log.info(
+    `Starting metadata enrichment for ${candidates.length} tracks ` +
+    `(${[...cohortMap.values()].filter((m) => m.length >= 2).length} album cohort(s), ` +
+    `${perTrackQueue.length} per-track)`
+  );
 
   let anyMetadataWritten = false;
 
-  for (const candidate of candidates) {
+  const recordTrackResult = (
+    input: TrackEnrichmentInput,
+    result: TrackEnrichmentResult
+  ): void => {
+    status.processed++;
+    const wroteMetadata =
+      result.genres !== null ||
+      result.year !== null ||
+      result.mbidRecording !== null ||
+      result.mbidReleaseGroup !== null ||
+      result.mbidArtist !== null;
+    if (wroteMetadata || result.coverFetched) {
+      status.enriched++;
+      if (wroteMetadata) anyMetadataWritten = true;
+      log.debug(`Enriched "${input.title}" by "${input.artist}"`, {
+        genres: result.genres ?? undefined,
+        year: result.year ?? undefined,
+        coverFetched: result.coverFetched
+      });
+    }
+  };
+
+  const recordTrackFailure = (input: TrackEnrichmentInput, error: unknown): void => {
+    status.processed++;
+    status.failed++;
+    log.warn(`Failed to enrich "${input.title}" by "${input.artist}"`, {
+      error: error instanceof Error ? error.message : String(error)
+    });
+    appendEnrichmentLog({
+      timestamp: new Date().toISOString(),
+      trackId: input.id,
+      artist: input.artist,
+      title: input.title,
+      source: "bulk",
+      status: "failed",
+      errorMessage: error instanceof Error ? error.message : String(error)
+    });
+  };
+
+  // Album cohort pass: one MB lookup per album, applied to every member.
+  for (const [, members] of cohortMap) {
+    if (signal.aborted) {
+      log.info("Metadata enrichment aborted");
+      break;
+    }
+    if (members.length < 2) continue;
+
+    const first = members[0]!;
+    status.currentTrack = {
+      trackId: first.id,
+      artist: first.artist,
+      title: `${first.album ?? ""} (album)`
+    };
+
+    let rgMeta: ReleaseGroupMetadata | null = null;
+    try {
+      rgMeta = await lookupReleaseGroup(first.artist, first.album!);
+    } catch (error) {
+      log.warn(`Album cohort lookup failed for "${first.album}" by "${first.artist}"`, {
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+
+    if (!rgMeta) {
+      // Cohort lookup missed — fall back to per-track for every member.
+      perTrackQueue.push(...members);
+      continue;
+    }
+
+    for (const member of members) {
+      if (signal.aborted) break;
+      status.currentTrack = {
+        trackId: member.id,
+        artist: member.artist,
+        title: member.title
+      };
+      try {
+        const result = await applyAlbumMetadataToTrack(member, rgMeta);
+        recordTrackResult(member, result);
+        if (!trackIsFullyCoveredByCohort(member, result)) {
+          // Cohort didn't fully cover this track (e.g. missing genre
+          // because rgMeta had none, or cover failed). Queue for the
+          // per-track path to take another swing.
+          perTrackQueue.push(member);
+          // Roll back the cohort-pass processed count so the per-track
+          // pass increments it again — avoids double-counting.
+          status.processed--;
+          if (result.genres || result.year || result.coverFetched || result.mbidReleaseGroup || result.mbidArtist) {
+            status.enriched--;
+          }
+        }
+      } catch (error) {
+        recordTrackFailure(member, error);
+      }
+    }
+  }
+
+  // Per-track pass: singletons and tracks the cohort path couldn't fully
+  // cover.
+  for (const candidate of perTrackQueue) {
     if (signal.aborted) {
       log.info("Metadata enrichment aborted");
       break;
@@ -454,40 +667,9 @@ export async function runBackgroundEnrichment(indexStore: IndexStore): Promise<v
 
     try {
       const result = await enrichTrackMetadata(candidate);
-      status.processed++;
-      const wroteMetadata =
-        result.genres !== null ||
-        result.year !== null ||
-        result.mbidRecording !== null ||
-        result.mbidReleaseGroup !== null ||
-        result.mbidArtist !== null;
-      if (wroteMetadata || result.coverFetched) {
-        status.enriched++;
-        if (wroteMetadata) anyMetadataWritten = true;
-        log.debug(
-          `Enriched "${candidate.title}" by "${candidate.artist}"`,
-          {
-            genres: result.genres ?? undefined,
-            year: result.year ?? undefined,
-            coverFetched: result.coverFetched
-          }
-        );
-      }
+      recordTrackResult(candidate, result);
     } catch (error) {
-      status.processed++;
-      status.failed++;
-      log.warn(`Failed to enrich "${candidate.title}" by "${candidate.artist}"`, {
-        error: error instanceof Error ? error.message : String(error)
-      });
-      appendEnrichmentLog({
-        timestamp: new Date().toISOString(),
-        trackId: candidate.id,
-        artist: candidate.artist,
-        title: candidate.title,
-        source: "bulk",
-        status: "failed",
-        errorMessage: error instanceof Error ? error.message : String(error)
-      });
+      recordTrackFailure(candidate, error);
     }
   }
 

--- a/backend/src/services/genre/musicBrainzService.test.ts
+++ b/backend/src/services/genre/musicBrainzService.test.ts
@@ -442,6 +442,59 @@ describe("musicBrainzService.lookupRecordingMetadata", () => {
     expect(fetchCalls).toEqual([]);
   });
 
+  it("lookupReleaseGroup picks the best Album match, fetches detail, and caches", async () => {
+    let phase = 0;
+    fetchHandler = (url) => {
+      phase++;
+      if (phase === 1) {
+        expect(url).toMatch(/\/release-group\?query=/);
+        return {
+          status: 200,
+          body: {
+            "release-groups": [
+              { id: "rg-non-album", score: 95, "primary-type": "Single", "first-release-date": "1990-01-01" },
+              { id: RELEASE_GROUP_MBID, score: 95, "primary-type": "Album", "first-release-date": "1989-09-21" },
+              { id: "rg-low", score: 50, "primary-type": "Album", "first-release-date": "1991-01-01" }
+            ]
+          }
+        };
+      }
+      // Detail fetch for the selected release-group
+      expect(url).toMatch(new RegExp(`/release-group/${RELEASE_GROUP_MBID}`));
+      return {
+        status: 200,
+        body: {
+          id: RELEASE_GROUP_MBID,
+          "first-release-date": "1989-09-21",
+          "primary-type": "Album",
+          "artist-credit": [{ artist: { id: ARTIST_MBID } }],
+          tags: [{ name: "rock" }, { name: "indie rock" }]
+        }
+      };
+    };
+    const { lookupReleaseGroup } = await loadModule();
+    const result = await lookupReleaseGroup("Pixies", "Doolittle");
+    expect(result?.releaseGroupMbid).toBe(RELEASE_GROUP_MBID);
+    expect(result?.year).toBe(1989);
+    expect(result?.artistMbid).toBe(ARTIST_MBID);
+    expect(result?.genres).toEqual(["Rock", "Indie Rock"]);
+
+    // Subsequent call serves from cache (no fetch)
+    fetchCalls = [];
+    const cached = await lookupReleaseGroup("Pixies", "Doolittle");
+    expect(cached?.year).toBe(1989);
+    expect(fetchCalls).toEqual([]);
+  });
+
+  it("lookupReleaseGroup returns null when no result meets the score threshold", async () => {
+    fetchHandler = () => ({
+      status: 200,
+      body: { "release-groups": [{ id: "rg-low", score: 50, "primary-type": "Album" }] }
+    });
+    const { lookupReleaseGroup } = await loadModule();
+    expect(await lookupReleaseGroup("X", "Y")).toBeNull();
+  });
+
   it("lookupRecordingMetadataByMbid fetches detail directly and caches the result", async () => {
     fetchHandler = (url) => {
       expect(url).toMatch(/\/recording\/11111111-1111-4111-8111-111111111111/);

--- a/backend/src/services/genre/musicBrainzService.ts
+++ b/backend/src/services/genre/musicBrainzService.ts
@@ -37,6 +37,13 @@ export type RecordingMetadata = {
   year?: number;
 };
 
+export type ReleaseGroupMetadata = {
+  releaseGroupMbid: string;
+  year: number | undefined;
+  genres: string[];
+  artistMbid: string | undefined;
+};
+
 type CacheEntry = {
   cachedAt: number;
   status: "hit" | "miss";
@@ -406,6 +413,228 @@ type LookupGenreResult =
 type LookupRichResult =
   | { kind: "resolved"; metadata: RecordingMetadata | null }
   | { kind: "transient" };
+
+type LookupReleaseGroupResult =
+  | { kind: "resolved"; metadata: ReleaseGroupMetadata | null }
+  | { kind: "transient" };
+
+type MBReleaseGroupSearchEntry = {
+  id?: string;
+  score?: number;
+  "first-release-date"?: string;
+  "primary-type"?: string;
+};
+
+type MBReleaseGroupSearchResult = {
+  "release-groups"?: MBReleaseGroupSearchEntry[];
+};
+
+type MBReleaseGroupDetail = {
+  id?: string;
+  "first-release-date"?: string;
+  "primary-type"?: string;
+  genres?: MBTagOrGenre[];
+  tags?: MBTagOrGenre[];
+  "artist-credit"?: MBArtistCredit[];
+};
+
+type ReleaseGroupSearchOutcome =
+  | { kind: "hit"; entry: MBReleaseGroupSearchEntry }
+  | { kind: "miss" }
+  | { kind: "transient" };
+
+async function searchReleaseGroup(artist: string, album: string): Promise<ReleaseGroupSearchOutcome> {
+  await waitForRateLimit();
+
+  const query = `releasegroup:"${escapeLucene(album)}" AND artist:"${escapeLucene(artist)}"`;
+  const url = `${MB_BASE_URL}/release-group?query=${encodeURIComponent(query)}&fmt=json&limit=${RECORDING_SEARCH_LIMIT}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    });
+  } catch (error) {
+    log.warn("MusicBrainz release-group search failed", {
+      artist,
+      album,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return { kind: "transient" };
+  }
+
+  if (response.status >= 500 || response.status === 429) {
+    log.warn(`MusicBrainz release-group search returned ${response.status}`, { artist, album });
+    return { kind: "transient" };
+  }
+  if (!response.ok) {
+    log.warn(`MusicBrainz release-group search returned ${response.status}`, { artist, album });
+    return { kind: "miss" };
+  }
+
+  let payload: MBReleaseGroupSearchResult;
+  try {
+    payload = (await response.json()) as MBReleaseGroupSearchResult;
+  } catch (error) {
+    log.warn("MusicBrainz release-group search returned invalid JSON", {
+      artist,
+      album,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return { kind: "transient" };
+  }
+
+  const entries = payload["release-groups"] ?? [];
+  // Prefer Album-type matches with score >= threshold; fall back to any
+  // matching primary type that still meets the score threshold.
+  const albums = entries.filter(
+    (e) => typeof e.score === "number" && e.score >= MIN_SCORE_THRESHOLD && e["primary-type"] === "Album"
+  );
+  const pool = albums.length > 0
+    ? albums
+    : entries.filter((e) => typeof e.score === "number" && e.score >= MIN_SCORE_THRESHOLD);
+
+  const best = pool.find((e) => typeof e.id === "string" && e.id.length > 0);
+  if (!best) return { kind: "miss" };
+  return { kind: "hit", entry: best };
+}
+
+async function fetchReleaseGroupDetail(rgMbid: string): Promise<MBReleaseGroupDetail | null> {
+  await waitForRateLimit();
+  const url = `${MB_BASE_URL}/release-group/${rgMbid}?inc=genres+tags+artist-credits&fmt=json`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    });
+  } catch (error) {
+    log.warn("MusicBrainz release-group detail fetch failed", {
+      rgMbid,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return null;
+  }
+  if (!response.ok) return null;
+  try {
+    return (await response.json()) as MBReleaseGroupDetail;
+  } catch {
+    return null;
+  }
+}
+
+function releaseGroupCacheKey(artist: string, album: string): string {
+  return `rg:${artist.toLowerCase().trim()}|||${album.toLowerCase().trim()}`;
+}
+
+async function lookupReleaseGroupUncached(artist: string, album: string): Promise<LookupReleaseGroupResult> {
+  const passes: string[] = [album];
+  const simplified = simplifyTitle(album);
+  if (simplified && simplified.toLowerCase() !== album.toLowerCase()) {
+    passes.push(simplified);
+  }
+
+  for (const candidate of passes) {
+    const outcome = await searchReleaseGroup(artist, candidate);
+    if (outcome.kind === "transient") return { kind: "transient" };
+    if (outcome.kind === "miss") continue;
+    const rgMbid = outcome.entry.id!;
+
+    // Prefer detail genres + artist-credit; if detail call fails, fall back
+    // to the search result's first-release-date for at least the year.
+    const detail = await fetchReleaseGroupDetail(rgMbid);
+    const year =
+      extractYearFromDate(detail?.["first-release-date"]) ??
+      extractYearFromDate(outcome.entry["first-release-date"]);
+    const genres = detail ? extractGenres(detail) : [];
+    const artistMbid = detail ? extractArtistMbid(detail) : undefined;
+
+    return {
+      kind: "resolved",
+      metadata: { releaseGroupMbid: rgMbid, year, genres, artistMbid }
+    };
+  }
+
+  return { kind: "resolved", metadata: null };
+}
+
+/**
+ * Look up a release-group by (artist, album). Returns the canonical
+ * release-group MBID, its first-release year, album-level genres, and
+ * the credited artist MBID — enough to fill the year/cover/MBID slots
+ * for every track on the album with a single MusicBrainz round-trip.
+ *
+ * Per-recording specifics (recordingMbid, recording-level genres) still
+ * require the per-track path; this is meant as a coarse-grained
+ * complement to lookupRecordingMetadata.
+ */
+export function lookupReleaseGroup(artist: string, album: string): Promise<ReleaseGroupMetadata | null> {
+  if (!artist.trim() || !album.trim()) return Promise.resolve(null);
+
+  const c = loadCache();
+  const key = releaseGroupCacheKey(artist, album);
+  const existing = c[key];
+  if (existing && isCacheEntryFreshForRich(existing)) {
+    if (existing.status === "miss" || !existing.releaseGroupMbid) return Promise.resolve(null);
+    return Promise.resolve({
+      releaseGroupMbid: existing.releaseGroupMbid,
+      year: existing.year,
+      genres: existing.genres,
+      artistMbid: existing.artistMbid
+    });
+  }
+
+  const inflightPromise = inflightRich.get(key);
+  if (inflightPromise) {
+    return inflightPromise.then((m) => {
+      if (!m || !m.releaseGroupMbid) return null;
+      return {
+        releaseGroupMbid: m.releaseGroupMbid,
+        year: m.year,
+        genres: m.genres,
+        artistMbid: m.artistMbid
+      };
+    });
+  }
+
+  const promise = (async (): Promise<RecordingMetadata | null> => {
+    try {
+      const result = await lookupReleaseGroupUncached(artist, album);
+      if (result.kind === "transient") return null;
+      c[key] = {
+        cachedAt: Date.now(),
+        status: result.metadata ? "hit" : "miss",
+        richVersion: RICH_SCHEMA_VERSION,
+        genres: result.metadata?.genres ?? [],
+        releaseGroupMbid: result.metadata?.releaseGroupMbid,
+        artistMbid: result.metadata?.artistMbid,
+        year: result.metadata?.year
+      };
+      scheduleCacheSave();
+      if (!result.metadata) return null;
+      return {
+        genres: result.metadata.genres,
+        releaseGroupMbid: result.metadata.releaseGroupMbid,
+        artistMbid: result.metadata.artistMbid,
+        year: result.metadata.year
+      };
+    } finally {
+      inflightRich.delete(key);
+    }
+  })();
+
+  inflightRich.set(key, promise);
+  return promise.then((m) => {
+    if (!m || !m.releaseGroupMbid) return null;
+    return {
+      releaseGroupMbid: m.releaseGroupMbid,
+      year: m.year,
+      genres: m.genres,
+      artistMbid: m.artistMbid
+    };
+  });
+}
 
 async function lookupGenresUncached(artist: string, title: string): Promise<LookupGenreResult> {
   const passes = buildTitlePasses(title);


### PR DESCRIPTION
> Stacked on #174 (Phase 5). Diff shown here is Phase 6 only.

## Summary

Groups bulk enrichment candidates into album cohorts so a 12-track album costs **one** MusicBrainz lookup (search + detail) instead of twelve. Per-track lookup remains as a fallback for singletons and tracks the cohort can't fully cover.

**MusicBrainz service**
- New \`lookupReleaseGroup(artist, album)\` searches \`/release-group\` with a Lucene-escaped \`releasegroup:\"…\" AND artist:\"…\"\` query, prefers Album-type matches with \`score >= 80\`, fetches the release-group detail with \`inc=genres+tags+artist-credits\`, and returns \`{ releaseGroupMbid, year, genres, artistMbid }\`. Cached under an \`rg:\` key in the existing MB cache file with the same hit-forever / miss-7-days / no-cache-on-transient semantics.
- Title-simplification fallback (strip parens / \"feat.\" / trailing \" - qualifier\") applies to album names too, so \`\"Doolittle (Deluxe Edition)\"\` still matches.
- New \`ReleaseGroupMetadata\` type exported.

**Enrichment service**
- New \`applyAlbumMetadataToTrack(input, rgMeta)\` writes year, genre, releaseGroupMbid, and artistMbid for a single track using a pre-fetched \`ReleaseGroupMetadata\`. Respects manual provenance gates (Phase 5), stamps filled fields as \`\"auto\"\`, attempts CAA cover with the cohort's release-group. Does **not** touch \`recordingMbid\` — that remains the per-track path's concern.
- \`runBackgroundEnrichment\` reworked: groups candidates by \`(artist, album)\` into cohorts. The **album-cohort pass** runs one \`lookupReleaseGroup\` per cohort and applies the result to every member. The **per-track pass** then handles singletons, cohort misses, and tracks the cohort couldn't fully cover (still missing genre or year). Status counts are deduped — a track that flows through both passes is counted once.
- \`TrackEnrichmentInput\` gains optional \`album\`; \`describeTrackEnrichmentNeeds\` populates it from \`track.tags.album\`.

**Net effect** for typical libraries: an album with 12 tracks missing year + cover now costs 2 MB requests total (search + detail) instead of 24. Year and genre are also guaranteed consistent across album members.

## Tests (+4, 468 backend total)
- MB: \`lookupReleaseGroup\` picks the highest-scored Album-type entry from a mixed search response, fetches detail, caches; score-threshold rejection returns null.
- Enrichment: \`applyAlbumMetadataToTrack\` fills year + genre + MBIDs and stamps \`auto\` provenance; respects manual provenance and fills only the un-gated fields.

## Test plan
- [ ] Upload a 10-track album with no year and no cover. Run bulk enrichment. Confirm in the activity log that the cohort runs one search + one detail call total (not 10 of each), and every track gets the same year and cover.
- [ ] Run bulk enrichment on a library that contains both album cohorts and singles. Confirm singles go through the per-track path (visible as separate log entries) while album members share metadata.
- [ ] On an album with a typo (e.g. \"Doolitle\" instead of \"Doolittle\"), confirm cohort lookup misses and each track falls through to per-track enrichment (which may still match by recording).
- [ ] Pre-mark one track of an album with \`provenance.genre = \"manual\"\` and a different genre. Run bulk. Confirm that track keeps its manual genre while the rest of the album gets the cohort's genre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)