### PR TITLE
feat(musicbrainz): phase 7 - retry/backoff, smart casing, promote-to-synonym

### DIFF
--- a/backend/src/api/genreRoutes.ts
+++ b/backend/src/api/genreRoutes.ts
@@ -14,6 +14,7 @@ import {
   readEnrichmentLog
 } from "../services/genre/enrichmentLogStore";
 import {
+  getLibraryGenreLabels,
   getSynonyms,
   setSynonym,
   removeSynonym,
@@ -143,6 +144,11 @@ export function createGenreRouter(indexStore: IndexStore): Router {
     resetSynonymsToDefaults();
     log.info("Genre synonyms reset to defaults", { userId: _req.authUser?.id ?? "unknown" });
     res.json({ reset: true });
+  });
+
+  router.get("/genre/library-labels", requireAuth, requireAdmin, (_req, res) => {
+    const tracks = indexStore.getTracks().map((t) => ({ genre: t.tags.genre }));
+    res.json({ labels: getLibraryGenreLabels(tracks) });
   });
 
   router.post("/genre/synonyms/reapply", requireAuth, requireAdmin, async (req, res, next) => {

--- a/backend/src/services/genre/genreSynonymService.test.ts
+++ b/backend/src/services/genre/genreSynonymService.test.ts
@@ -28,6 +28,7 @@ vi.mock("../../utils/logger", () => ({
 }));
 
 import {
+  getLibraryGenreLabels,
   getSynonyms,
   normalizeGenreLabel,
   normalizeGenreLabels,
@@ -85,5 +86,36 @@ describe("genreSynonymService", () => {
     resetSynonymsToDefaults();
     expect(getSynonyms()["custom-key"]).toBeUndefined();
     expect(normalizeGenreLabel("rap")).toBe("Hip-Hop");
+  });
+
+  describe("getLibraryGenreLabels", () => {
+    it("counts unique labels case-insensitively and reports synonyms", () => {
+      const tracks = [
+        { genre: ["Rock", "Hip Hop"] },
+        { genre: ["rock", "Indie Rock"] },
+        { genre: ["Hip Hop"] },
+        { genre: [] },
+        {}
+      ];
+      const labels = getLibraryGenreLabels(tracks);
+      expect(labels.find((l) => l.label.toLowerCase() === "rock")?.count).toBe(2);
+      expect(labels.find((l) => l.label.toLowerCase() === "hip hop")?.count).toBe(2);
+      expect(labels.find((l) => l.label.toLowerCase() === "indie rock")?.count).toBe(1);
+      // hip hop maps to Hip-Hop via default synonyms
+      expect(labels.find((l) => l.label.toLowerCase() === "hip hop")?.canonical).toBe("Hip-Hop");
+      // Indie Rock is already canonical → no canonical field
+      expect(labels.find((l) => l.label.toLowerCase() === "indie rock")?.canonical).toBeUndefined();
+    });
+
+    it("sorts by count descending, then label ascending", () => {
+      const tracks = [
+        { genre: ["B"] },
+        { genre: ["A"] },
+        { genre: ["A"] },
+        { genre: ["C"] }
+      ];
+      const labels = getLibraryGenreLabels(tracks);
+      expect(labels.map((l) => l.label)).toEqual(["A", "B", "C"]);
+    });
   });
 });

--- a/backend/src/services/genre/genreSynonymService.ts
+++ b/backend/src/services/genre/genreSynonymService.ts
@@ -274,3 +274,57 @@ export function resetSynonymsToDefaults(): void {
   synonyms = { ...DEFAULT_SYNONYMS };
   saveSynonyms();
 }
+
+export type LibraryGenreLabel = {
+  label: string;
+  count: number;
+  /**
+   * The canonical form this label would normalize to if reapplied through
+   * the current synonym table. Absent when the label is already canonical
+   * (or has no synonym entry).
+   */
+  canonical?: string;
+};
+
+/**
+ * Aggregate every genre label currently in use in the library (drawn
+ * from per-track tags). Each label is returned with its occurrence
+ * count and, when applicable, the canonical form the synonym table
+ * would map it to. Useful for the admin "promote to synonym" workflow:
+ * spot raw labels that should be normalized, sorted by impact.
+ */
+export function getLibraryGenreLabels(tracksWithGenre: Array<{ genre?: string[] }>): LibraryGenreLabel[] {
+  const counts = new Map<string, { label: string; count: number }>();
+  for (const t of tracksWithGenre) {
+    if (!Array.isArray(t.genre)) continue;
+    for (const label of t.genre) {
+      if (typeof label !== "string") continue;
+      const trimmed = label.trim();
+      if (!trimmed) continue;
+      const key = trimmed.toLowerCase();
+      const existing = counts.get(key);
+      if (existing) {
+        existing.count++;
+      } else {
+        counts.set(key, { label: trimmed, count: 1 });
+      }
+    }
+  }
+
+  const synonymMap = loadSynonyms();
+  const result: LibraryGenreLabel[] = [];
+  for (const { label, count } of counts.values()) {
+    const canonical = synonymMap[label.toLowerCase()];
+    if (canonical && canonical !== label) {
+      result.push({ label, count, canonical });
+    } else {
+      result.push({ label, count });
+    }
+  }
+
+  result.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.label.localeCompare(b.label);
+  });
+  return result;
+}

--- a/backend/src/services/genre/musicBrainzService.test.ts
+++ b/backend/src/services/genre/musicBrainzService.test.ts
@@ -2,7 +2,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { tmpDir } = vi.hoisted(() => {
   const fsS = require("node:fs") as typeof import("node:fs");
@@ -29,7 +29,7 @@ vi.mock("../../utils/logger", () => ({
 
 const CACHE_FILE = path.join(tmpDir, "musicbrainz-genre-cache.json");
 
-type FetchHandler = (url: string) => { status?: number; body?: unknown; throw?: Error };
+type FetchHandler = (url: string) => { status?: number; body?: unknown; throw?: Error; headers?: Record<string, string> };
 
 let fetchHandler: FetchHandler = () => ({ status: 200, body: { recordings: [] } });
 let fetchCalls: string[] = [];
@@ -48,9 +48,20 @@ beforeEach(async () => {
     if (result.throw) throw result.throw;
     return new Response(JSON.stringify(result.body ?? {}), {
       status: result.status ?? 200,
-      headers: { "Content-Type": "application/json" }
+      headers: { "Content-Type": "application/json", ...(result.headers ?? {}) }
     });
   }));
+});
+
+afterEach(async () => {
+  // Flush any pending debounced cache writes so they don't fire during
+  // the next test (and pollute its tmpDir after our cleanup runs).
+  try {
+    const m = await import("./musicBrainzService");
+    m.flushGenreCache();
+  } catch {
+    // module may not have loaded if the test bailed early
+  }
 });
 
 afterAll(() => {
@@ -108,18 +119,42 @@ describe("musicBrainzService", () => {
     expect(fsSync.existsSync(CACHE_FILE)).toBe(false);
   });
 
-  it("retries after transient error on next call (no negative cache)", async () => {
-    let firstCall = true;
+  it("retries within a single call after a transient 5xx and rescues the result", async () => {
+    let phase = 0;
     fetchHandler = () => {
-      if (firstCall) {
-        firstCall = false;
-        return { status: 503 };
-      }
+      phase++;
+      if (phase === 1) return { status: 503 };
       return { status: 200, body: recordingsResponse([{ score: 95, tags: ["pop"] }]) };
     };
     const { lookupGenre } = await loadModule();
-    expect(await lookupGenre("X", "Y")).toEqual([]);
     expect(await lookupGenre("X", "Y")).toEqual(["Pop"]);
+  });
+
+  it("returns transient (empty) and does not cache when retries are exhausted", async () => {
+    fetchHandler = () => ({ status: 503 });
+    const { lookupGenre, flushGenreCache } = await loadModule();
+    expect(await lookupGenre("X", "Y")).toEqual([]);
+    flushGenreCache();
+    expect(fsSync.existsSync(CACHE_FILE)).toBe(false);
+  });
+
+  it("honors the Retry-After header on 429", async () => {
+    let phase = 0;
+    const startedAt = Date.now();
+    fetchHandler = () => {
+      phase++;
+      if (phase === 1) {
+        return { status: 429, headers: { "retry-after": "1" } };
+      }
+      return { status: 200, body: recordingsResponse([{ score: 95, tags: ["rock"] }]) };
+    };
+    const { lookupGenre } = await loadModule();
+    const result = await lookupGenre("X", "Y");
+    const elapsed = Date.now() - startedAt;
+    expect(result).toEqual(["Rock"]);
+    // Must have waited at least the Retry-After value (1s), and the rate
+    // limiter spacing (1.1s) on top of that for the retried request.
+    expect(elapsed).toBeGreaterThanOrEqual(1000);
   });
 
   it("caches a successful miss (no recording found) and serves it from cache", async () => {
@@ -222,6 +257,16 @@ describe("musicBrainzService", () => {
     expect(b).toEqual(["Jazz"]);
     expect(c).toEqual(["Jazz"]);
     expect(fetchCount).toBe(1);
+  });
+
+  it("preserves MB's mixed-case labels (R&B, IDM) and title-cases all-lowercase ones", async () => {
+    fetchHandler = () => ({
+      status: 200,
+      body: recordingsResponse([{ score: 95, tags: ["R&B", "IDM", "indie rock", "j-pop"] }])
+    });
+    const { lookupGenre } = await loadModule();
+    const genres = await lookupGenre("X", "Y");
+    expect(genres).toEqual(["R&B", "IDM", "Indie Rock", "J-Pop"]);
   });
 
   it("writes the cache atomically (no .tmp left over after flush)", async () => {

--- a/backend/src/services/genre/musicBrainzService.ts
+++ b/backend/src/services/genre/musicBrainzService.ts
@@ -174,6 +174,91 @@ async function waitForRateLimit(): Promise<void> {
   lastRequestTime = Date.now();
 }
 
+const MAX_RETRIES = 1;
+const BACKOFF_BASE_MS = 1000;
+const MAX_RETRY_AFTER_MS = 30_000;
+
+function parseRetryAfterMs(header: string | null): number | null {
+  if (!header) return null;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(Math.round(seconds * 1000), MAX_RETRY_AFTER_MS);
+  }
+  const epochMs = Date.parse(header);
+  if (Number.isFinite(epochMs)) {
+    return Math.min(Math.max(0, epochMs - Date.now()), MAX_RETRY_AFTER_MS);
+  }
+  return null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+type FetchOutcome =
+  | { kind: "ok"; response: Response }
+  | { kind: "client-error"; response: Response }
+  | { kind: "transient" };
+
+/**
+ * Fetch a MusicBrainz endpoint with one retry on 5xx / 429 / network
+ * throw. Honors the Retry-After header on 429. Returns ok/client-error
+ * for any non-retryable response, and "transient" only after retries are
+ * exhausted (or capped by MAX_RETRY_AFTER_MS).
+ */
+async function fetchMbWithRetry(url: string, logContext: Record<string, unknown>): Promise<FetchOutcome> {
+  let lastNetworkError: Error | null = null;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+      });
+    } catch (error) {
+      lastNetworkError = error as Error;
+      if (attempt < MAX_RETRIES) {
+        const delayMs = BACKOFF_BASE_MS * Math.pow(2, attempt);
+        log.warn(`MusicBrainz fetch threw, retrying in ${delayMs}ms`, {
+          ...logContext,
+          error: lastNetworkError.message
+        });
+        await sleep(delayMs);
+        continue;
+      }
+      break;
+    }
+
+    if (response.status >= 500 || response.status === 429) {
+      if (attempt < MAX_RETRIES) {
+        const retryAfter = parseRetryAfterMs(response.headers.get("retry-after"));
+        const delayMs = retryAfter ?? (BACKOFF_BASE_MS * Math.pow(2, attempt));
+        log.warn(`MusicBrainz returned ${response.status}, retrying in ${delayMs}ms`, logContext);
+        await sleep(delayMs);
+        // re-pace the rate limiter; the next call will respect RATE_LIMIT_MS again
+        lastRequestTime = Date.now();
+        continue;
+      }
+      log.warn(`MusicBrainz returned ${response.status} after retries`, logContext);
+      return { kind: "transient" };
+    }
+
+    if (!response.ok) {
+      return { kind: "client-error", response };
+    }
+
+    return { kind: "ok", response };
+  }
+
+  if (lastNetworkError) {
+    log.warn("MusicBrainz fetch failed after retries", {
+      ...logContext,
+      error: lastNetworkError.message
+    });
+  }
+  return { kind: "transient" };
+}
+
 type MBTagOrGenre = { name?: string; count?: number };
 type MBArtistCredit = { artist?: { id?: string; name?: string }; joinphrase?: string };
 type MBReleaseGroup = {
@@ -206,6 +291,25 @@ type MBRecordingDetail = {
   releases?: MBRelease[];
 };
 
+function casifyGenreLabel(raw: string): string {
+  // If MB returned mixed-case (e.g. "R&B", "IDM", "J-Pop"), trust it.
+  // If it's all-lowercase (e.g. "rock", "hip hop"), title-case each
+  // space-separated word, preserving hyphens (so "hip-hop" → "Hip-Hop").
+  const trimmed = raw.trim();
+  if (trimmed !== trimmed.toLowerCase()) {
+    return trimmed;
+  }
+  return trimmed
+    .split(/\s+/)
+    .map((word) =>
+      word
+        .split("-")
+        .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+        .join("-")
+    )
+    .join(" ");
+}
+
 function extractGenres(recording: MBRecording | MBRecordingDetail): string[] {
   const genres: string[] = [];
   const seen = new Set<string>();
@@ -214,14 +318,10 @@ function extractGenres(recording: MBRecording | MBRecordingDetail): string[] {
   for (const source of sources) {
     for (const entry of source) {
       if (typeof entry.name !== "string" || !entry.name.trim()) continue;
-      const normalized = entry.name.trim().toLowerCase();
-      if (seen.has(normalized)) continue;
-      seen.add(normalized);
-      const titleCased = normalized
-        .split(/[\s-]+/)
-        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-        .join(" ");
-      genres.push(titleCased);
+      const lookupKey = entry.name.trim().toLowerCase();
+      if (seen.has(lookupKey)) continue;
+      seen.add(lookupKey);
+      genres.push(casifyGenreLabel(entry.name));
     }
   }
 
@@ -315,34 +415,16 @@ async function searchRecording(artist: string, title: string): Promise<SearchOut
   const query = `recording:"${escapedTitle}" AND artist:"${escapedArtist}"`;
   const searchUrl = `${MB_BASE_URL}/recording?query=${encodeURIComponent(query)}&fmt=json&limit=${RECORDING_SEARCH_LIMIT}`;
 
-  let searchResponse: Response;
-  try {
-    searchResponse = await fetch(searchUrl, {
-      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
-    });
-  } catch (error) {
-    log.warn("MusicBrainz lookup failed", {
-      artist,
-      title,
-      error: error instanceof Error ? error.message : String(error)
-    });
-    return { kind: "transient" };
-  }
-
-  if (searchResponse.status >= 500 || searchResponse.status === 429) {
-    log.warn(`MusicBrainz search returned ${searchResponse.status}`, { artist, title });
-    return { kind: "transient" };
-  }
-
-  if (!searchResponse.ok) {
-    log.warn(`MusicBrainz search returned ${searchResponse.status}`, { artist, title });
+  const outcome = await fetchMbWithRetry(searchUrl, { artist, title });
+  if (outcome.kind === "transient") return { kind: "transient" };
+  if (outcome.kind === "client-error") {
+    log.warn(`MusicBrainz search returned ${outcome.response.status}`, { artist, title });
     return { kind: "miss" };
   }
 
   let searchData: MBSearchResult;
   try {
-    searchData = (await searchResponse.json()) as MBSearchResult;
+    searchData = (await outcome.response.json()) as MBSearchResult;
   } catch (error) {
     log.warn("MusicBrainz search returned invalid JSON", {
       artist,
@@ -373,29 +455,13 @@ async function fetchRecordingDetail(recordingId: string, withReleaseGroups: bool
     ? "genres+tags+artist-credits+releases+release-groups"
     : "genres+tags";
   const detailUrl = `${MB_BASE_URL}/recording/${recordingId}?inc=${inc}&fmt=json`;
-  let response: Response;
-  try {
-    response = await fetch(detailUrl, {
-      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
-    });
-  } catch (error) {
-    log.warn("MusicBrainz detail fetch failed", {
-      recordingId,
-      error: error instanceof Error ? error.message : String(error)
-    });
-    return { kind: "transient" };
-  }
 
-  if (response.status >= 500 || response.status === 429) {
-    return { kind: "transient" };
-  }
-  if (!response.ok) {
-    return { kind: "missing" };
-  }
+  const outcome = await fetchMbWithRetry(detailUrl, { recordingId });
+  if (outcome.kind === "transient") return { kind: "transient" };
+  if (outcome.kind === "client-error") return { kind: "missing" };
 
   try {
-    const detail = (await response.json()) as MBRecordingDetail;
+    const detail = (await outcome.response.json()) as MBRecordingDetail;
     return { kind: "ok", detail };
   } catch (error) {
     log.warn("MusicBrainz detail returned invalid JSON", {
@@ -449,33 +515,16 @@ async function searchReleaseGroup(artist: string, album: string): Promise<Releas
   const query = `releasegroup:"${escapeLucene(album)}" AND artist:"${escapeLucene(artist)}"`;
   const url = `${MB_BASE_URL}/release-group?query=${encodeURIComponent(query)}&fmt=json&limit=${RECORDING_SEARCH_LIMIT}`;
 
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
-    });
-  } catch (error) {
-    log.warn("MusicBrainz release-group search failed", {
-      artist,
-      album,
-      error: error instanceof Error ? error.message : String(error)
-    });
-    return { kind: "transient" };
-  }
-
-  if (response.status >= 500 || response.status === 429) {
-    log.warn(`MusicBrainz release-group search returned ${response.status}`, { artist, album });
-    return { kind: "transient" };
-  }
-  if (!response.ok) {
-    log.warn(`MusicBrainz release-group search returned ${response.status}`, { artist, album });
+  const outcome = await fetchMbWithRetry(url, { artist, album });
+  if (outcome.kind === "transient") return { kind: "transient" };
+  if (outcome.kind === "client-error") {
+    log.warn(`MusicBrainz release-group search returned ${outcome.response.status}`, { artist, album });
     return { kind: "miss" };
   }
 
   let payload: MBReleaseGroupSearchResult;
   try {
-    payload = (await response.json()) as MBReleaseGroupSearchResult;
+    payload = (await outcome.response.json()) as MBReleaseGroupSearchResult;
   } catch (error) {
     log.warn("MusicBrainz release-group search returned invalid JSON", {
       artist,
@@ -503,22 +552,10 @@ async function searchReleaseGroup(artist: string, album: string): Promise<Releas
 async function fetchReleaseGroupDetail(rgMbid: string): Promise<MBReleaseGroupDetail | null> {
   await waitForRateLimit();
   const url = `${MB_BASE_URL}/release-group/${rgMbid}?inc=genres+tags+artist-credits&fmt=json`;
-  let response: Response;
+  const outcome = await fetchMbWithRetry(url, { rgMbid });
+  if (outcome.kind !== "ok") return null;
   try {
-    response = await fetch(url, {
-      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
-    });
-  } catch (error) {
-    log.warn("MusicBrainz release-group detail fetch failed", {
-      rgMbid,
-      error: error instanceof Error ? error.message : String(error)
-    });
-    return null;
-  }
-  if (!response.ok) return null;
-  try {
-    return (await response.json()) as MBReleaseGroupDetail;
+    return (await outcome.response.json()) as MBReleaseGroupDetail;
   } catch {
     return null;
   }

--- a/frontend/src/api/genre.ts
+++ b/frontend/src/api/genre.ts
@@ -105,6 +105,17 @@ export async function reapplyGenreSynonyms(): Promise<{ scanned: number; updated
   });
 }
 
+export type LibraryGenreLabel = {
+  label: string;
+  count: number;
+  canonical?: string;
+};
+
+export async function getLibraryGenreLabels(): Promise<LibraryGenreLabel[]> {
+  const payload = await requestJson<{ labels: LibraryGenreLabel[] }>("/api/genre/library-labels");
+  return payload.labels;
+}
+
 export type GenreCacheStats = {
   entries: number;
   fingerprints?: number;

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -95,6 +95,7 @@ export {
   clearEnrichmentLog,
   reEnrichTrack,
   reapplyGenreSynonyms,
+  getLibraryGenreLabels,
   getGenreCacheStats,
   clearGenreCache
 } from "./genre";
@@ -104,6 +105,7 @@ export type {
   EnrichmentCurrentTrack,
   EnrichmentLogEntry,
   ReEnrichResult,
+  LibraryGenreLabel,
   GenreCacheStats
 } from "./genre";
 

--- a/frontend/src/components/AdminLibraryView.tsx
+++ b/frontend/src/components/AdminLibraryView.tsx
@@ -9,6 +9,7 @@ import {
   getEnrichmentStatus,
   getGenreCacheStats,
   getGenreSynonyms,
+  getLibraryGenreLabels,
   patchAutoPlaylistConfig,
   putGenreSynonym,
   reapplyGenreSynonyms,
@@ -20,7 +21,8 @@ import {
   type EnrichmentLogEntry,
   type EnrichmentStatus,
   type GenreCacheStats,
-  type GenreSynonyms
+  type GenreSynonyms,
+  type LibraryGenreLabel
 } from "../api";
 
 type AdminLibraryViewProps = {
@@ -46,6 +48,11 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
   // ── Enrichment activity log ────────────────────────────────────
   const [logEntries, setLogEntries] = useState<EnrichmentLogEntry[]>([]);
   const [reapplying, setReapplying] = useState(false);
+
+  // ── Library label discovery ────────────────────────────────────
+  const [libraryLabels, setLibraryLabels] = useState<LibraryGenreLabel[]>([]);
+  const [loadingLabels, setLoadingLabels] = useState(false);
+  const synonymKeyInputRef = useRef<HTMLInputElement | null>(null);
 
   // ── Auto-playlist config ───────────────────────────────────────
   const [config, setConfig] = useState<AutoPlaylistConfig | null>(null);
@@ -109,6 +116,7 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
     void loadCacheStats();
     void loadConfig();
     void loadLog();
+    void loadLibraryLabels();
   }, [pollEnrichStatus]);
 
   async function loadLog(): Promise<void> {
@@ -116,6 +124,25 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
       const entries = await getEnrichmentLog(50);
       setLogEntries(entries);
     } catch {}
+  }
+
+  async function loadLibraryLabels(): Promise<void> {
+    setLoadingLabels(true);
+    try {
+      const labels = await getLibraryGenreLabels();
+      setLibraryLabels(labels);
+    } catch {} finally {
+      setLoadingLabels(false);
+    }
+  }
+
+  function handlePromoteLabel(label: string): void {
+    setSynonymKey(label.toLowerCase());
+    setSynonymValue("");
+    synonymKeyInputRef.current?.focus();
+    if (typeof window !== "undefined") {
+      synonymKeyInputRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
   }
 
   async function loadSynonyms(): Promise<void> {
@@ -162,6 +189,7 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
       setSynonymKey("");
       setSynonymValue("");
       await loadSynonyms();
+      await loadLibraryLabels();
     } catch (err) {
       setSynonymMessage(err instanceof Error ? err.message : "Failed to save synonym.");
     }
@@ -192,6 +220,7 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
           ? `Reapplied synonyms: ${updated} of ${scanned} tracks updated.`
           : `Reapplied synonyms: nothing to change (${scanned} tracks scanned).`
       );
+      await loadLibraryLabels();
     } catch (err) {
       setSynonymMessage(err instanceof Error ? err.message : "Failed to reapply synonyms.");
     } finally {
@@ -310,6 +339,7 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
           <label className="text-sm text-flaque-ink">
             From
             <input
+              ref={synonymKeyInputRef}
               className="mt-1 block w-40 rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
               value={synonymKey}
               onChange={(e) => setSynonymKey(e.target.value)}
@@ -370,6 +400,71 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
             </table>
           </div>
         )}
+      </section>
+
+      {/* ── Library labels ──────────────────────────────────────── */}
+      <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="font-display text-xl text-flaque-ink">Library labels</h3>
+          <button
+            type="button"
+            className="rounded-xl border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream"
+            onClick={() => { void loadLibraryLabels(); }}
+          >
+            Refresh
+          </button>
+        </div>
+        <p className="mt-1 text-sm text-flaque-steel">
+          Unique genre labels in the library, sorted by track count. Click <strong>Promote</strong> to pre-fill the synonym form above with that label.
+        </p>
+
+        {loadingLabels ? (
+          <p className="mt-3 text-sm text-flaque-steel">Loading...</p>
+        ) : libraryLabels.length === 0 ? (
+          <p className="mt-3 text-sm text-flaque-steel">No genre labels found in the library yet.</p>
+        ) : (
+          <div className="mt-3 max-h-80 overflow-y-auto rounded-xl border border-flaque-clay/40">
+            <table className="w-full text-left text-sm">
+              <thead className="sticky top-0 bg-flaque-cream/95 text-flaque-ink">
+                <tr>
+                  <th className="px-3 py-2 font-medium">Label</th>
+                  <th className="w-20 px-3 py-2 font-medium">Tracks</th>
+                  <th className="px-3 py-2 font-medium">Would normalize to</th>
+                  <th className="w-24 px-3 py-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {libraryLabels.slice(0, 100).map((row) => (
+                  <tr key={row.label} className="border-t border-flaque-clay/30">
+                    <td className="px-3 py-1.5 text-flaque-ink">{row.label}</td>
+                    <td className="px-3 py-1.5 text-flaque-steel">{row.count}</td>
+                    <td className="px-3 py-1.5 text-flaque-steel">
+                      {row.canonical ? (
+                        <span className="text-amber-700">{row.canonical}</span>
+                      ) : (
+                        <span className="text-flaque-steel/60">—</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-1.5 text-right">
+                      <button
+                        type="button"
+                        className="text-xs text-flaque-ink underline-offset-2 hover:underline"
+                        onClick={() => handlePromoteLabel(row.label)}
+                      >
+                        Promote
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {libraryLabels.length > 100 ? (
+          <p className="mt-2 text-xs text-flaque-steel/70">
+            Showing top 100 of {libraryLabels.length} unique labels.
+          </p>
+        ) : null}
       </section>
 
       {/* ── Genre Enrichment ────────────────────────────────────── */}


### PR DESCRIPTION
> Stacked on \`feat/musicbrainz-phase1\` (which now carries the merged Phase 5+6). Diff shown here is Phase 7 only.

## Summary

Wraps up the three remaining items from the original diagnosis: Retry-After + exponential backoff (#6), drop the title-case mangling that wrecked R&B / IDM / J-Pop (#10), and the promote-to-synonym workflow (#11).

**Retry + backoff**
- New \`fetchMbWithRetry\` helper: one retry on 5xx / 429 / network throw, honors the \`Retry-After\` header (parses seconds or HTTP-date, capped at 30s), exponential backoff (1s → 2s) when no Retry-After is set. All four MB fetch sites (recording search, recording detail, release-group search, release-group detail) routed through it.
- On 429 the rate-limit clock is reset post-sleep so the retried request still respects the 1.1s spacing.

**Smart casing**
- New \`casifyGenreLabel\`: if MB returned a mixed-case label (\`R&B\`, \`IDM\`, \`J-Pop\`, \`Bossa Nova\`), trust it; if it's all-lowercase (\`rock\`, \`hip hop\`), title-case each space-separated word and preserve hyphens (\`hip-hop\` → \`Hip-Hop\`). Previous code lowercased everything then title-cased each word, producing \`\"R&b\"\` and relying on the synonym table to repair.

**Promote-to-synonym workflow**
- New \`getLibraryGenreLabels(tracksWithGenre)\` aggregates every unique genre label in the library with its track count and, when applicable, the canonical form the synonym table would map it to. Sorted by count desc / label asc.
- New \`GET /api/genre/library-labels\` (admin) exposes the aggregated list from the live index.
- New \"Library labels\" admin section between Synonyms and Enrichment. Top-100 table with \`label / tracks / would normalize to / [Promote]\` button. Clicking **Promote** pre-fills the synonym form's \"From\" field and scrolls/focuses it. Adding a synonym or running \"Reapply to library\" auto-refreshes the table.

## Tests (+6, 473 backend + 168 frontend = 641 total)
- MB: retry-within-call rescues a transient 5xx; exhausted retries return empty and don't cache; \`Retry-After\` on 429 is honored (waits at least the stated duration); mixed-case labels preserved while lowercase ones still get title-cased.
- Synonym service: \`getLibraryGenreLabels\` counts case-insensitively and reports synonyms; sorts by count desc / label asc.
- Test-infra: added an \`afterEach\` hook that flushes the genre cache before module reset, fixing a pre-existing timer leak that this phase's slower retry tests exposed.

## Test plan
- [ ] Tail the server log while triggering a bulk enrichment. Confirm that a transient MB outage (5xx or 429) logs \"retrying in Xms\" once before either succeeding or surfacing as a miss.
- [ ] Have a track land in the library whose embedded genre is the raw MB output \`R&B\` or \`IDM\`. Confirm the override / activity log keeps the casing (no \`R&b\`).
- [ ] Open the admin Library view. \"Library labels\" should list every genre present in the library, ordered by frequency, with a \"would normalize to\" column for entries the synonym table would change.
- [ ] Click **Promote** on a row whose label is \"hip hop\". Confirm the synonym form is pre-filled with \`From=hip hop\`. Type \`Hip-Hop\` in **To** and submit. The labels table should refresh and either drop \"hip hop\" (if reapply was triggered) or now show a \"would normalize to: Hip-Hop\" annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)