### PR TITLE
fix(account): P0 — UX cleanup of the account page

### DIFF
--- a/frontend/src/components/AccountView.tsx
+++ b/frontend/src/components/AccountView.tsx
@@ -51,6 +51,42 @@ function getSessionTitle(session: UserSession): string {
   return "Unknown device";
 }
 
+const PASSWORD_MIN_LENGTH = 8;
+
+function StatTile({
+  value,
+  label,
+  gradient,
+  icon
+}: {
+  value: number;
+  label: string;
+  gradient: string;
+  icon: JSX.Element;
+}): JSX.Element {
+  return (
+    <div
+      className={`flex items-center gap-3 rounded-xl border border-flaque-clay/40 bg-gradient-to-br ${gradient} px-4 py-3`}
+    >
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white/70 text-flaque-ink">
+        <span className="block h-5 w-5">{icon}</span>
+      </span>
+      <div className="min-w-0">
+        <p className="font-display text-3xl leading-none text-flaque-ink">{value}</p>
+        <p className="mt-1 text-xs uppercase tracking-[0.08em] text-flaque-steel">{label}</p>
+      </div>
+    </div>
+  );
+}
+
+function RankChip({ rank }: { rank: number }): JSX.Element {
+  return (
+    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-flaque-ink/85 text-[11px] font-semibold text-flaque-cream">
+      {rank}
+    </span>
+  );
+}
+
 export function AccountView({
   user,
   setUser,
@@ -252,36 +288,45 @@ export function AccountView({
 
   const hasOtherSessions = sessions.some((session) => !session.current);
 
+  const newPasswordTooShort = newPassword.length > 0 && newPassword.length < PASSWORD_MIN_LENGTH;
+  const passwordMismatch =
+    newPassword.length > 0 && confirmPassword.length > 0 && newPassword !== confirmPassword;
+  const passwordFormValid =
+    currentPassword.length > 0 &&
+    newPassword.length >= PASSWORD_MIN_LENGTH &&
+    newPassword === confirmPassword;
+
   return (
     <div>
-      <section className="rounded-t-xl m-4 mb-0 border border-b-0 border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+      <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h2 className="mt-1 font-display text-2xl text-flaque-ink">Account</h2>
-          </div>
+          <h2 className="mt-1 font-display text-2xl text-flaque-ink">Account</h2>
 
-          <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
-            <button
-              className="rounded-xl bg-flaque-ink px-3 py-2 text-xs font-medium uppercase tracking-[0.1em] text-flaque-cream"
-              type="button"
+          <button
+            className="inline-flex items-center gap-1.5 rounded-xl border border-red-300 bg-red-50 px-3 py-2 text-xs font-medium uppercase tracking-[0.1em] text-red-700 transition hover:bg-red-100"
+            type="button"
+            onClick={() => {
+              void onLogout();
+            }}
+          >
+            <svg
+              className="h-3.5 w-3.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
             >
-              Edit profile
-            </button>
-
-            <button
-              className="rounded-xl border border-red-300 bg-red-50 px-3 py-2 text-xs font-medium uppercase tracking-[0.1em] text-red-700 transition hover:bg-red-100"
-              type="button"
-              onClick={() => {
-                void onLogout();
-              }}
-            >
-              Logout
-            </button>
-          </div>
+              <path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4" />
+              <polyline points="16 17 21 12 16 7" />
+              <line x1="21" y1="12" x2="9" y2="12" />
+            </svg>
+            Logout
+          </button>
         </div>
-      </section>
 
-      <section className="rounded-b-xl m-4 mt-0 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
         <form className="mt-4 space-y-4" onSubmit={(event) => void handlePhotoSubmit(event)}>
           <div className="flex flex-col gap-4 md:flex-row md:items-center">
             <div className="shrink-0">
@@ -416,70 +461,168 @@ export function AccountView({
 
           {photoMessage ? <p className="text-sm text-flaque-steel">{photoMessage}</p> : null}
         </form>
-      </section>
 
-      <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
-        <h3 className="font-display text-xl text-flaque-ink">Password</h3>
+        <div className="mt-6 border-t border-flaque-clay/40 pt-5">
+          <h3 className="font-display text-lg text-flaque-ink">Change password</h3>
 
-        <form className="mt-4 grid gap-3 md:grid-cols-2" onSubmit={(event) => void handlePasswordSubmit(event)}>
-          <label className="text-sm text-flaque-steel" htmlFor="account-current-password">
-            Current password
-            <input
-              id="account-current-password"
-              className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-              type="password"
-              value={currentPassword}
-              onChange={(event) => setCurrentPassword(event.target.value)}
-              autoComplete="current-password"
-            />
-          </label>
+          <form className="mt-3 space-y-3" onSubmit={(event) => void handlePasswordSubmit(event)}>
+            <label className="block text-sm text-flaque-steel" htmlFor="account-current-password">
+              Current password
+              <input
+                id="account-current-password"
+                className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
+                type="password"
+                value={currentPassword}
+                onChange={(event) => setCurrentPassword(event.target.value)}
+                autoComplete="current-password"
+              />
+            </label>
 
-          <label className="text-sm text-flaque-steel" htmlFor="account-new-password">
-            New password
-            <input
-              id="account-new-password"
-              className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-              type="password"
-              value={newPassword}
-              onChange={(event) => setNewPassword(event.target.value)}
-              autoComplete="new-password"
-            />
-          </label>
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="text-sm text-flaque-steel" htmlFor="account-new-password">
+                New password
+                <input
+                  id="account-new-password"
+                  className={`mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2 ${
+                    newPasswordTooShort ? "border-red-300" : "border-flaque-clay"
+                  }`}
+                  type="password"
+                  value={newPassword}
+                  onChange={(event) => setNewPassword(event.target.value)}
+                  autoComplete="new-password"
+                  aria-invalid={newPasswordTooShort}
+                  aria-describedby={newPasswordTooShort ? "account-new-password-hint" : undefined}
+                />
+                {newPasswordTooShort ? (
+                  <span id="account-new-password-hint" className="mt-1 block text-xs text-red-600">
+                    Must be at least {PASSWORD_MIN_LENGTH} characters.
+                  </span>
+                ) : null}
+              </label>
 
-          <label className="text-sm text-flaque-steel md:col-span-2" htmlFor="account-confirm-password">
-            Confirm new password
-            <input
-              id="account-confirm-password"
-              className="mt-1 w-full rounded-xl border border-flaque-clay bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2"
-              type="password"
-              value={confirmPassword}
-              onChange={(event) => setConfirmPassword(event.target.value)}
-              autoComplete="new-password"
-            />
-          </label>
+              <label className="text-sm text-flaque-steel" htmlFor="account-confirm-password">
+                Confirm new password
+                <input
+                  id="account-confirm-password"
+                  className={`mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm text-flaque-ink outline-none ring-flaque-sand transition focus:ring-2 ${
+                    passwordMismatch ? "border-red-300" : "border-flaque-clay"
+                  }`}
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(event) => setConfirmPassword(event.target.value)}
+                  autoComplete="new-password"
+                  aria-invalid={passwordMismatch}
+                  aria-describedby={passwordMismatch ? "account-confirm-password-hint" : undefined}
+                />
+                {passwordMismatch ? (
+                  <span id="account-confirm-password-hint" className="mt-1 block text-xs text-red-600">
+                    Passwords don't match.
+                  </span>
+                ) : null}
+              </label>
+            </div>
 
-          <div className="md:col-span-2">
-            <button
-              className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
-              type="submit"
-              disabled={updatingPassword}
+            <div>
+              <button
+                className="rounded-xl border border-flaque-clay bg-white px-4 py-2 text-sm text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+                type="submit"
+                disabled={updatingPassword || !passwordFormValid}
+              >
+                {updatingPassword ? "Saving..." : "Update password"}
+              </button>
+            </div>
+          </form>
+
+          {passwordMessage ? (
+            <p
+              className={`mt-3 rounded-xl px-3 py-2 text-sm ${
+                passwordMessage.isError
+                  ? "border border-red-300 bg-red-50 text-red-700"
+                  : "border border-green-300 bg-green-50 text-green-700"
+              }`}
             >
-              {updatingPassword ? "Saving..." : "Update password"}
-            </button>
-          </div>
-        </form>
+              {passwordMessage.text}
+            </p>
+          ) : null}
+        </div>
 
-        {passwordMessage ? (
-          <p
-            className={`mt-3 rounded-xl px-3 py-2 text-sm ${
-              passwordMessage.isError
-                ? "border border-red-300 bg-red-50 text-red-700"
-                : "border border-green-300 bg-green-50 text-green-700"
-            }`}
-          >
-            {passwordMessage.text}
-          </p>
-        ) : null}
+        <div className="mt-6 border-t border-flaque-clay/40 pt-5">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h3 className="font-display text-lg text-flaque-ink">Sessions</h3>
+
+            <div className="flex items-center gap-2">
+              <button
+                className="rounded-xl border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+                type="button"
+                onClick={() => {
+                  void loadSessions();
+                }}
+                disabled={loadingSessions || revokingSessionId !== null || loggingOutOtherSessions}
+              >
+                Refresh
+              </button>
+
+              <button
+                className="rounded-xl border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+                type="button"
+                onClick={() => {
+                  void handleLogoutOthers();
+                }}
+                disabled={!hasOtherSessions || loadingSessions || revokingSessionId !== null || loggingOutOtherSessions}
+              >
+                {loggingOutOtherSessions ? "Logging out..." : "Logout other devices"}
+              </button>
+            </div>
+          </div>
+
+          {loadingSessions ? <p className="mt-3 text-sm text-flaque-steel">Loading sessions...</p> : null}
+
+          {!loadingSessions && sessions.length === 0 ? <p className="mt-3 text-sm text-flaque-steel">No active session.</p> : null}
+
+          {!loadingSessions && sessions.length > 0 ? (
+            <div className="mt-3 space-y-2">
+              {sessions.map((session) => (
+                <div
+                  key={session.id}
+                  className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-flaque-ink">
+                      {getSessionTitle(session)}
+                      {session.current ? (
+                        <span className="ml-2 rounded-full bg-flaque-ink px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-flaque-cream">
+                          Current
+                        </span>
+                      ) : null}
+                    </p>
+                    <p className="truncate text-xs text-flaque-steel">
+                      Last seen {formatSessionTimestamp(session.lastSeenAt)} - Expires {formatSessionTimestamp(session.expiresAt)}
+                    </p>
+                    {session.ipAddress ? <p className="truncate text-xs text-flaque-steel/90">IP: {session.ipAddress}</p> : null}
+                  </div>
+
+                  <button
+                    className="rounded-lg border border-flaque-clay bg-white px-3 py-1 text-xs text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+                    type="button"
+                    disabled={
+                      session.current ||
+                      loadingSessions ||
+                      loggingOutOtherSessions ||
+                      (revokingSessionId !== null && revokingSessionId !== session.id)
+                    }
+                    onClick={() => {
+                      void handleRevokeSession(session.id);
+                    }}
+                  >
+                    {revokingSessionId === session.id ? "Revoking..." : "Revoke"}
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {sessionsMessage ? <p className="mt-3 text-sm text-flaque-steel">{sessionsMessage}</p> : null}
+        </div>
       </section>
 
       <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
@@ -488,22 +631,58 @@ export function AccountView({
         {loadingStats ? (
           <p className="mt-3 text-sm text-flaque-steel">Loading stats...</p>
         ) : !playStats || playStats.totalPlays === 0 ? (
-          <p className="mt-3 text-sm text-flaque-steel">No listening history yet. Start playing some music!</p>
+          <div className="mt-4 flex flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-flaque-clay/50 bg-flaque-cream/20 px-4 py-8 text-center">
+            <svg
+              className="h-10 w-10 text-flaque-steel/50"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              aria-hidden="true"
+            >
+              <path d="M9 18V5l12-2v13" strokeLinecap="round" strokeLinejoin="round" />
+              <circle cx="6" cy="18" r="3" />
+              <circle cx="18" cy="16" r="3" />
+            </svg>
+            <p className="text-sm text-flaque-steel">No listening history yet.</p>
+            <p className="text-xs text-flaque-steel/70">Start playing some music to fill this in.</p>
+          </div>
         ) : (
-          <div className="mt-3 space-y-4">
-            <div className="flex flex-wrap gap-4">
-              <div className="rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-4 py-3">
-                <p className="font-display text-2xl text-flaque-ink">{playStats.totalPlays}</p>
-                <p className="text-xs text-flaque-steel">Total plays</p>
-              </div>
-              <div className="rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-4 py-3">
-                <p className="font-display text-2xl text-flaque-ink">{playStats.uniqueTracksPlayed}</p>
-                <p className="text-xs text-flaque-steel">Unique tracks</p>
-              </div>
-              <div className="rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-4 py-3">
-                <p className="font-display text-2xl text-flaque-ink">{playStats.topArtists.length}</p>
-                <p className="text-xs text-flaque-steel">Artists</p>
-              </div>
+          <div className="mt-4 space-y-5">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <StatTile
+                value={playStats.totalPlays}
+                label="Total plays"
+                gradient="from-flaque-sand/60 to-flaque-cream/30"
+                icon={
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+                    <path d="M5 4l14 8-14 8V4z" strokeLinejoin="round" />
+                  </svg>
+                }
+              />
+              <StatTile
+                value={playStats.uniqueTracksPlayed}
+                label="Unique tracks"
+                gradient="from-flaque-cream/60 to-flaque-sand/30"
+                icon={
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+                    <path d="M9 18V5l12-2v13" strokeLinecap="round" strokeLinejoin="round" />
+                    <circle cx="6" cy="18" r="3" />
+                    <circle cx="18" cy="16" r="3" />
+                  </svg>
+                }
+              />
+              <StatTile
+                value={playStats.topArtists.length}
+                label="Artists"
+                gradient="from-flaque-clay/30 to-flaque-cream/40"
+                icon={
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+                    <circle cx="12" cy="8" r="4" />
+                    <path d="M4 21a8 8 0 0116 0" strokeLinecap="round" />
+                  </svg>
+                }
+              />
             </div>
 
             {playStats.topArtists.length > 0 ? (
@@ -513,10 +692,15 @@ export function AccountView({
                   {playStats.topArtists.slice(0, 10).map((entry, i) => {
                     const artistLabel = formatArtistString(entry.artist) ?? "Unknown artist";
                     return (
-                      <div key={entry.artist} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-3 py-1.5">
-                        <span className="w-5 shrink-0 text-right text-xs text-flaque-steel/60">{i + 1}</span>
+                      <div
+                        key={entry.artist}
+                        className="flex items-center gap-3 rounded-xl bg-flaque-cream/40 px-3 py-2 transition hover:bg-flaque-cream/70"
+                      >
+                        <RankChip rank={i + 1} />
                         <span className="min-w-0 flex-1 truncate text-sm text-flaque-ink">{artistLabel}</span>
-                        <span className="shrink-0 text-xs text-flaque-steel">{entry.playCount} play{entry.playCount !== 1 ? "s" : ""}</span>
+                        <span className="shrink-0 text-xs text-flaque-steel">
+                          {entry.playCount} play{entry.playCount !== 1 ? "s" : ""}
+                        </span>
                       </div>
                     );
                   })}
@@ -533,12 +717,15 @@ export function AccountView({
                     const title = track ? getTrackDisplayTitle(track) : "Unknown Track";
                     const artist = (track ? getTrackDisplayArtist(track) : undefined) ?? "Unknown artist";
                     return (
-                      <div key={entry.trackId} className="flex items-center gap-2 rounded-lg bg-flaque-cream/40 px-2 py-1.5">
-                        <span className="w-5 shrink-0 text-right text-xs text-flaque-steel/60">{i + 1}</span>
+                      <div
+                        key={entry.trackId}
+                        className="flex items-center gap-3 rounded-xl bg-flaque-cream/40 px-3 py-2 transition hover:bg-flaque-cream/70"
+                      >
+                        <RankChip rank={i + 1} />
                         <img
                           src={track ? coverUrl(track.id, track.cover) : defaultCoverImage}
                           alt=""
-                          className="h-8 w-8 shrink-0 rounded-md object-cover"
+                          className="h-9 w-9 shrink-0 rounded-md object-cover"
                           loading="lazy"
                           onError={(event) => {
                             event.currentTarget.src = defaultCoverImage;
@@ -559,83 +746,6 @@ export function AccountView({
         )}
       </section>
 
-      <section className="rounded-xl m-4 border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <h3 className="font-display text-xl text-flaque-ink">Sessions</h3>
-
-          <div className="flex items-center gap-2">
-            <button
-              className="rounded-xl border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
-              type="button"
-              onClick={() => {
-                void loadSessions();
-              }}
-              disabled={loadingSessions || revokingSessionId !== null || loggingOutOtherSessions}
-            >
-              Refresh
-            </button>
-
-            <button
-              className="rounded-xl border border-flaque-clay bg-white px-3 py-1.5 text-xs text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
-              type="button"
-              onClick={() => {
-                void handleLogoutOthers();
-              }}
-              disabled={!hasOtherSessions || loadingSessions || revokingSessionId !== null || loggingOutOtherSessions}
-            >
-              {loggingOutOtherSessions ? "Logging out..." : "Logout other devices"}
-            </button>
-          </div>
-        </div>
-
-        {loadingSessions ? <p className="mt-3 text-sm text-flaque-steel">Loading sessions...</p> : null}
-
-        {!loadingSessions && sessions.length === 0 ? <p className="mt-3 text-sm text-flaque-steel">No active session.</p> : null}
-
-        {!loadingSessions && sessions.length > 0 ? (
-          <div className="mt-3 space-y-2">
-            {sessions.map((session) => (
-              <div
-                key={session.id}
-                className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-flaque-clay/50 bg-flaque-cream/35 px-3 py-2"
-              >
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-medium text-flaque-ink">
-                    {getSessionTitle(session)}
-                    {session.current ? (
-                      <span className="ml-2 rounded-full bg-flaque-ink px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-flaque-cream">
-                        Current
-                      </span>
-                    ) : null}
-                  </p>
-                  <p className="truncate text-xs text-flaque-steel">
-                    Last seen {formatSessionTimestamp(session.lastSeenAt)} - Expires {formatSessionTimestamp(session.expiresAt)}
-                  </p>
-                  {session.ipAddress ? <p className="truncate text-xs text-flaque-steel/90">IP: {session.ipAddress}</p> : null}
-                </div>
-
-                <button
-                  className="rounded-lg border border-flaque-clay bg-white px-3 py-1 text-xs text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
-                  type="button"
-                  disabled={
-                    session.current ||
-                    loadingSessions ||
-                    loggingOutOtherSessions ||
-                    (revokingSessionId !== null && revokingSessionId !== session.id)
-                  }
-                  onClick={() => {
-                    void handleRevokeSession(session.id);
-                  }}
-                >
-                  {revokingSessionId === session.id ? "Revoking..." : "Revoke"}
-                </button>
-              </div>
-            ))}
-          </div>
-        ) : null}
-
-        {sessionsMessage ? <p className="mt-3 text-sm text-flaque-steel">{sessionsMessage}</p> : null}
-      </section>
     </div>
   );
 }


### PR DESCRIPTION
First task from \`docs/roadmap-next.md\` (P0). Cleans up the account page into two clear panels — *account infos* and *account stats* — and reworks the password change UX.

## Summary
- **Remove dead control:** drop the no-op "Edit profile" button.
- **Single account panel:** merge Account, Password, and Sessions into one card so the page is just two panels (infos + stats). Each subsection is separated by a thin top border.
- **Password change form:**
  - Row 1 = current password (full width).
  - Row 2 = new password + confirm new password (side-by-side on md+, stacked on mobile).
  - Inline red hints: "Must be at least 8 characters" and "Passwords don't match".
  - Submit disabled until current is filled, new ≥ 8 chars, and confirm matches new.
- **Listening Stats polish:**
  - Hero tiles → gradient backgrounds, icon in soft tile, larger numerals, uppercase label.
  - Top Tracks / Top Artists rows → round numbered rank chip, hover state, slightly larger covers.
  - Empty state → dashed card with a music-notes icon and a two-line friendlier message.
- **Logout button:** added a door-arrow icon.

Backend min password length (\`PASSWORD_MIN_LENGTH = 8\` in \`backend/src/utils/validation.ts\`) is mirrored client-side.

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [x] \`npx vitest run\` — 193 tests pass
- [x] Manual: password form happy path + invalid states (empty current, short new, mismatched confirm)
- [x] Manual: listening stats empty + populated states render correctly on mobile and desktop
- [x] Manual: session list still loads, revoke + logout-other-devices still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)