### PR TITLE
feat(albums): P1 — sortable albums view with section separators

### DIFF
--- a/frontend/src/components/LibraryAlbumsSection.test.tsx
+++ b/frontend/src/components/LibraryAlbumsSection.test.tsx
@@ -11,12 +11,14 @@ function createAlbum(input: {
   name: string;
   artist: string;
   trackCount: number;
+  year?: number;
 }): AlbumEntry {
   return {
     id: input.id,
     name: input.name,
     artist: input.artist,
-    trackCount: input.trackCount
+    trackCount: input.trackCount,
+    year: input.year
   };
 }
 
@@ -251,5 +253,48 @@ describe("LibraryAlbumsSection", () => {
     const backButton = screen.getByRole("button", { name: "Back" });
     fireEvent.click(backButton);
     expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("groups albums by first letter by default and re-groups by year on sort change", () => {
+    const albums = [
+      createAlbum({ id: "1", name: "Alpha", artist: "X", trackCount: 1, year: 2020 }),
+      createAlbum({ id: "2", name: "Bravo", artist: "Y", trackCount: 1, year: 1999 }),
+      createAlbum({ id: "3", name: "Charlie", artist: "Z", trackCount: 1 })
+    ];
+
+    try {
+      window.localStorage.removeItem("flaque.albums.sort");
+    } catch {
+      // ignore
+    }
+
+    render(
+      <LibraryAlbumsSection
+        libraryMetadataError={null}
+        loadingAlbums={false}
+        albums={albums}
+        selectedAlbum={null}
+        selectedAlbumTracks={[]}
+        loadingSelectedAlbumTracks={false}
+        selectedAlbumTracksError={null}
+        ownerNameById={{}}
+        onAlbumSelect={vi.fn()}
+        onPlayAlbum={vi.fn()}
+        onBack={vi.fn()}
+        onTrackSelect={vi.fn()}
+      />
+    );
+
+    // Default = album-asc: section headers A, B, C
+    expect(screen.getByText("A")).toBeTruthy();
+    expect(screen.getByText("B")).toBeTruthy();
+    expect(screen.getByText("C")).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Sort albums"), { target: { value: "year-desc" } });
+
+    // Now grouped by year: 2020, 1999, Unknown — labels also appear in cards so use getAllByText
+    expect(screen.getAllByText("2020").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("1999").length).toBeGreaterThan(0);
+    expect(screen.getByText("Unknown")).toBeTruthy();
   });
 });

--- a/frontend/src/components/LibraryAlbumsSection.tsx
+++ b/frontend/src/components/LibraryAlbumsSection.tsx
@@ -1,10 +1,40 @@
 import type { AlbumEntry, Playlist, Track } from "../types";
 import { defaultCoverImage, getAlbumCoverSrc } from "../utils/covers";
 import { formatDurationHuman } from "../utils/format";
-import { useRef, useState } from "react";
+import {
+  type AlbumSortMode,
+  DEFAULT_ALBUM_SORT_MODE,
+  isAlbumSortMode,
+  sortAlbums,
+  sortAndGroupAlbums
+} from "../utils/albumSort";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { AlbumList } from "./AlbumList";
 import { Coverflow } from "./Coverflow";
+import { SectionLabel } from "./SectionLabel";
 import { TrackList } from "./TrackList";
+
+const ALBUM_SORT_STORAGE_KEY = "flaque.albums.sort";
+
+const ALBUM_SORT_OPTIONS: ReadonlyArray<{ value: AlbumSortMode; label: string }> = [
+  { value: "album-asc", label: "Album A → Z" },
+  { value: "album-desc", label: "Album Z → A" },
+  { value: "artist-asc", label: "Artist A → Z" },
+  { value: "artist-desc", label: "Artist Z → A" },
+  { value: "year-desc", label: "Year (newest)" },
+  { value: "year-asc", label: "Year (oldest)" }
+];
+
+function loadInitialSortMode(): AlbumSortMode {
+  if (typeof window === "undefined") return DEFAULT_ALBUM_SORT_MODE;
+  try {
+    const stored = window.localStorage.getItem(ALBUM_SORT_STORAGE_KEY);
+    if (isAlbumSortMode(stored)) return stored;
+  } catch {
+    // localStorage may be unavailable (private mode, etc.)
+  }
+  return DEFAULT_ALBUM_SORT_MODE;
+}
 
 export type LibraryAlbumsSectionProps = {
   libraryMetadataError: string | null;
@@ -48,11 +78,21 @@ export function LibraryAlbumsSection({
 }: LibraryAlbumsSectionProps): JSX.Element {
   const [viewMode, setViewMode] = useState<AlbumViewMode>("list");
   const [searchQuery, setSearchQuery] = useState("");
+  const [sortMode, setSortMode] = useState<AlbumSortMode>(loadInitialSortMode);
   const isAlbumSelected = selectedAlbum !== null;
   const lastSelectedAlbumRef = useRef<AlbumEntry | null>(null);
   if (selectedAlbum && viewMode === "coverflow") {
     lastSelectedAlbumRef.current = selectedAlbum;
   }
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(ALBUM_SORT_STORAGE_KEY, sortMode);
+    } catch {
+      // ignore
+    }
+  }, [sortMode]);
 
   const normalizedQuery = searchQuery.trim().toLowerCase();
   const filteredAlbums = normalizedQuery
@@ -62,6 +102,9 @@ export function LibraryAlbumsSection({
           (album.artist && album.artist.toLowerCase().includes(normalizedQuery))
       )
     : albums;
+
+  const sortedAlbums = useMemo(() => sortAlbums(filteredAlbums, sortMode), [filteredAlbums, sortMode]);
+  const groupedAlbums = useMemo(() => sortAndGroupAlbums(filteredAlbums, sortMode), [filteredAlbums, sortMode]);
 
   const albumCoverSrc = selectedAlbum ? getAlbumCoverSrc(selectedAlbum) : defaultCoverImage;
 
@@ -108,7 +151,7 @@ export function LibraryAlbumsSection({
         ) : (
           <>
             <h2 className="font-display text-xl text-flaque-ink">Albums</h2>
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-3">
               <input
                 className="rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-3 py-1.5 text-sm text-flaque-ink placeholder:text-flaque-steel/60 focus:border-flaque-ink/40 focus:outline-none"
                 type="text"
@@ -116,6 +159,20 @@ export function LibraryAlbumsSection({
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
               />
+              <label className="sr-only" htmlFor="album-sort">Sort albums</label>
+              <select
+                id="album-sort"
+                className="rounded-lg border border-flaque-clay/70 bg-flaque-cream/40 px-3 py-1.5 text-sm text-flaque-ink focus:border-flaque-ink/40 focus:outline-none"
+                value={sortMode}
+                onChange={(e) => setSortMode(e.target.value as AlbumSortMode)}
+                aria-label="Sort albums"
+              >
+                {ALBUM_SORT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
               <div className="inline-flex rounded-xl border border-flaque-clay/70 bg-flaque-cream/50 p-1">
                 <button
                   className={`rounded-lg px-3 py-1.5 text-sm transition ${
@@ -154,18 +211,26 @@ export function LibraryAlbumsSection({
           {!isAlbumSelected && viewMode === "coverflow" ? (
             <div className="flex flex-1 items-center">
               <Coverflow
-                albums={filteredAlbums}
+                albums={sortedAlbums}
                 selectedAlbum={lastSelectedAlbumRef.current}
                 onAlbumSelect={onAlbumSelect}
               />
             </div>
           ) : !isAlbumSelected && viewMode === "list" ? (
-            <AlbumList
-              albums={filteredAlbums}
-              selectedAlbum={selectedAlbum}
-              onAlbumSelect={onAlbumSelect}
-              onPlayAlbum={onPlayAlbum}
-            />
+            <div className="mt-3">
+              {groupedAlbums.map((group, idx) => (
+                <div key={group.key}>
+                  <SectionLabel label={group.label} />
+                  <AlbumList
+                    albums={group.albums}
+                    selectedAlbum={selectedAlbum}
+                    onAlbumSelect={onAlbumSelect}
+                    onPlayAlbum={onPlayAlbum}
+                  />
+                  {idx < groupedAlbums.length - 1 && <div className="mb-4" />}
+                </div>
+              ))}
+            </div>
           ) : null}
 
           {isAlbumSelected ? (

--- a/frontend/src/components/LibraryArtistsSection.tsx
+++ b/frontend/src/components/LibraryArtistsSection.tsx
@@ -6,6 +6,7 @@ import { formatDurationHuman } from "../utils/format";
 import { getArtistSortKey } from "../utils/tracks";
 import { AlbumList } from "./AlbumList";
 import { ArtistCard } from "./ArtistCard";
+import { SectionLabel } from "./SectionLabel";
 import { TrackList } from "./TrackList";
 
 export type LibraryArtistsSectionProps = {
@@ -209,10 +210,7 @@ export function LibraryArtistsSection({
 
             return sortedKeys.map((letter, idx) => (
               <div key={letter}>
-                <div className="flex items-center gap-3">
-                  <span className="text-sm font-semibold text-flaque-steel">{letter}</span>
-                  <div className="flex-1 h-[2px] border-t-[2px] border-flaque-clay/40" style={{ maskImage: "linear-gradient(to right, black 50%, transparent)", WebkitMaskImage: "linear-gradient(to right, black 50%, transparent)" }} />
-                </div>
+                <SectionLabel label={letter} />
                 <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
                   {grouped.get(letter)!.map((artist) => (
                     <ArtistCard

--- a/frontend/src/components/SectionLabel.tsx
+++ b/frontend/src/components/SectionLabel.tsx
@@ -1,0 +1,18 @@
+/**
+ * Inline section header used to group library content (artists by letter,
+ * albums by letter or year). Renders the label next to a fading divider.
+ */
+export function SectionLabel({ label }: { label: string }): JSX.Element {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm font-semibold text-flaque-steel">{label}</span>
+      <div
+        className="flex-1 h-[2px] border-t-[2px] border-flaque-clay/40"
+        style={{
+          maskImage: "linear-gradient(to right, black 50%, transparent)",
+          WebkitMaskImage: "linear-gradient(to right, black 50%, transparent)"
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/utils/albumSort.test.ts
+++ b/frontend/src/utils/albumSort.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import type { AlbumEntry } from "../types";
+import {
+  DEFAULT_ALBUM_SORT_MODE,
+  isAlbumSortMode,
+  sortAlbums,
+  sortAndGroupAlbums
+} from "./albumSort";
+
+function album(input: Partial<AlbumEntry> & { name: string }): AlbumEntry {
+  return {
+    name: input.name,
+    artist: input.artist,
+    trackCount: input.trackCount ?? 1,
+    year: input.year,
+    cover: input.cover,
+    totalDuration: input.totalDuration,
+    id: input.id,
+    artists: input.artists,
+    previewTrackId: input.previewTrackId
+  };
+}
+
+describe("isAlbumSortMode", () => {
+  it("accepts known modes", () => {
+    expect(isAlbumSortMode("album-asc")).toBe(true);
+    expect(isAlbumSortMode("year-desc")).toBe(true);
+  });
+
+  it("rejects unknown values", () => {
+    expect(isAlbumSortMode("foo")).toBe(false);
+    expect(isAlbumSortMode(null)).toBe(false);
+    expect(isAlbumSortMode(undefined)).toBe(false);
+    expect(isAlbumSortMode(42)).toBe(false);
+  });
+});
+
+describe("sortAlbums — album name", () => {
+  it("sorts ascending by album name", () => {
+    const sorted = sortAlbums(
+      [album({ name: "Charlie" }), album({ name: "Alpha" }), album({ name: "Bravo" })],
+      "album-asc"
+    );
+    expect(sorted.map((a) => a.name)).toEqual(["Alpha", "Bravo", "Charlie"]);
+  });
+
+  it("sorts descending by album name", () => {
+    const sorted = sortAlbums(
+      [album({ name: "Alpha" }), album({ name: "Charlie" }), album({ name: "Bravo" })],
+      "album-desc"
+    );
+    expect(sorted.map((a) => a.name)).toEqual(["Charlie", "Bravo", "Alpha"]);
+  });
+
+  it("places non-alphabetical names in the # bucket at the end (asc and desc)", () => {
+    const items = [album({ name: "Alpha" }), album({ name: "1999" }), album({ name: "Bravo" })];
+
+    const asc = sortAlbums(items, "album-asc");
+    expect(asc.map((a) => a.name)).toEqual(["Alpha", "Bravo", "1999"]);
+
+    const desc = sortAlbums(items, "album-desc");
+    expect(desc.map((a) => a.name)).toEqual(["Bravo", "Alpha", "1999"]);
+  });
+});
+
+describe("sortAlbums — artist", () => {
+  it("sorts by artist with leading 'The' ignored", () => {
+    const sorted = sortAlbums(
+      [
+        album({ name: "A1", artist: "The Beatles" }),
+        album({ name: "A2", artist: "Arctic Monkeys" }),
+        album({ name: "A3", artist: "Coldplay" })
+      ],
+      "artist-asc"
+    );
+    expect(sorted.map((a) => a.artist)).toEqual(["Arctic Monkeys", "The Beatles", "Coldplay"]);
+  });
+
+  it("falls back to album-name order within the same artist", () => {
+    const sorted = sortAlbums(
+      [
+        album({ name: "Zebra", artist: "Pink Floyd" }),
+        album({ name: "Animals", artist: "Pink Floyd" })
+      ],
+      "artist-asc"
+    );
+    expect(sorted.map((a) => a.name)).toEqual(["Animals", "Zebra"]);
+  });
+});
+
+describe("sortAlbums — year", () => {
+  it("sorts year ascending and pushes unknown to the end", () => {
+    const sorted = sortAlbums(
+      [
+        album({ name: "B", year: 2020 }),
+        album({ name: "A", year: 1999 }),
+        album({ name: "C" }),
+        album({ name: "D", year: 2010 })
+      ],
+      "year-asc"
+    );
+    expect(sorted.map((a) => a.name)).toEqual(["A", "D", "B", "C"]);
+  });
+
+  it("sorts year descending and pushes unknown to the end", () => {
+    const sorted = sortAlbums(
+      [
+        album({ name: "B", year: 2020 }),
+        album({ name: "A", year: 1999 }),
+        album({ name: "C" }),
+        album({ name: "D", year: 2010 })
+      ],
+      "year-desc"
+    );
+    expect(sorted.map((a) => a.name)).toEqual(["B", "D", "A", "C"]);
+  });
+});
+
+describe("sortAndGroupAlbums", () => {
+  it("groups alphabetical sort by first letter with # bucket last", () => {
+    const groups = sortAndGroupAlbums(
+      [
+        album({ name: "Alpha" }),
+        album({ name: "Bravo" }),
+        album({ name: "1999" }),
+        album({ name: "Apple" })
+      ],
+      "album-asc"
+    );
+    expect(groups.map((g) => g.label)).toEqual(["A", "B", "#"]);
+    expect(groups[0].albums.map((a) => a.name)).toEqual(["Alpha", "Apple"]);
+    expect(groups[2].albums.map((a) => a.name)).toEqual(["1999"]);
+  });
+
+  it("groups artist sort by artist first letter (ignoring leading The)", () => {
+    const groups = sortAndGroupAlbums(
+      [
+        album({ name: "A1", artist: "The Beatles" }),
+        album({ name: "A2", artist: "Arctic Monkeys" })
+      ],
+      "artist-asc"
+    );
+    // "Arctic Monkeys" → A, "The Beatles" → B (after stripping "The")
+    expect(groups.map((g) => g.label)).toEqual(["A", "B"]);
+  });
+
+  it("groups year sort by year with Unknown bucket last", () => {
+    const groups = sortAndGroupAlbums(
+      [
+        album({ name: "A", year: 2020 }),
+        album({ name: "B", year: 2020 }),
+        album({ name: "C", year: 1999 }),
+        album({ name: "D" })
+      ],
+      "year-desc"
+    );
+    expect(groups.map((g) => g.label)).toEqual(["2020", "1999", "Unknown"]);
+    expect(groups[0].albums.map((a) => a.name)).toEqual(["A", "B"]);
+    expect(groups[2].albums).toHaveLength(1);
+  });
+
+  it("returns an empty list for empty input", () => {
+    expect(sortAndGroupAlbums([], "album-asc")).toEqual([]);
+  });
+});
+
+describe("DEFAULT_ALBUM_SORT_MODE", () => {
+  it("is album-asc", () => {
+    expect(DEFAULT_ALBUM_SORT_MODE).toBe("album-asc");
+  });
+});

--- a/frontend/src/utils/albumSort.ts
+++ b/frontend/src/utils/albumSort.ts
@@ -1,0 +1,160 @@
+import type { AlbumEntry } from "../types";
+import { getArtistSortKey } from "./tracks";
+
+export type AlbumSortMode =
+  | "album-asc"
+  | "album-desc"
+  | "artist-asc"
+  | "artist-desc"
+  | "year-desc"
+  | "year-asc";
+
+export const DEFAULT_ALBUM_SORT_MODE: AlbumSortMode = "album-asc";
+
+const ALBUM_SORT_MODES: ReadonlyArray<AlbumSortMode> = [
+  "album-asc",
+  "album-desc",
+  "artist-asc",
+  "artist-desc",
+  "year-desc",
+  "year-asc"
+];
+
+export function isAlbumSortMode(value: unknown): value is AlbumSortMode {
+  return typeof value === "string" && (ALBUM_SORT_MODES as readonly string[]).includes(value);
+}
+
+export type AlbumGroup = {
+  key: string;
+  label: string;
+  albums: AlbumEntry[];
+};
+
+const UNKNOWN_YEAR_KEY = "unknown-year";
+const NON_ALPHA_KEY = "#";
+
+function firstLetterBucket(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return NON_ALPHA_KEY;
+  const first = trimmed[0]?.toUpperCase() ?? NON_ALPHA_KEY;
+  return /[A-Z]/.test(first) ? first : NON_ALPHA_KEY;
+}
+
+function albumNameKey(album: AlbumEntry): string {
+  return album.name;
+}
+
+function albumArtistKey(album: AlbumEntry): string {
+  return getArtistSortKey(album.artist ?? "");
+}
+
+function compareLetterBuckets(a: string, b: string, descending: boolean): number {
+  if (a === NON_ALPHA_KEY && b !== NON_ALPHA_KEY) return 1;
+  if (a !== NON_ALPHA_KEY && b === NON_ALPHA_KEY) return -1;
+  const cmp = a.localeCompare(b);
+  return descending ? -cmp : cmp;
+}
+
+function compareStrings(a: string, b: string, descending: boolean): number {
+  const cmp = a.trim().toLowerCase().localeCompare(b.trim().toLowerCase());
+  return descending ? -cmp : cmp;
+}
+
+function hasYear(album: AlbumEntry): album is AlbumEntry & { year: number } {
+  return typeof album.year === "number" && Number.isFinite(album.year);
+}
+
+export function sortAlbums(albums: readonly AlbumEntry[], mode: AlbumSortMode): AlbumEntry[] {
+  switch (mode) {
+    case "album-asc":
+    case "album-desc": {
+      const descending = mode === "album-desc";
+      return [...albums].sort((a, b) => {
+        const bucketCmp = compareLetterBuckets(
+          firstLetterBucket(albumNameKey(a)),
+          firstLetterBucket(albumNameKey(b)),
+          descending
+        );
+        if (bucketCmp !== 0) return bucketCmp;
+        return compareStrings(albumNameKey(a), albumNameKey(b), descending);
+      });
+    }
+    case "artist-asc":
+    case "artist-desc": {
+      const descending = mode === "artist-desc";
+      return [...albums].sort((a, b) => {
+        const bucketCmp = compareLetterBuckets(
+          firstLetterBucket(albumArtistKey(a)),
+          firstLetterBucket(albumArtistKey(b)),
+          descending
+        );
+        if (bucketCmp !== 0) return bucketCmp;
+        const artistCmp = compareStrings(albumArtistKey(a), albumArtistKey(b), descending);
+        if (artistCmp !== 0) return artistCmp;
+        // Stable secondary order: album name ascending regardless of direction
+        return compareStrings(albumNameKey(a), albumNameKey(b), false);
+      });
+    }
+    case "year-desc":
+    case "year-asc": {
+      const descending = mode === "year-desc";
+      return [...albums].sort((a, b) => {
+        const aHas = hasYear(a);
+        const bHas = hasYear(b);
+        if (!aHas && !bHas) return compareStrings(albumNameKey(a), albumNameKey(b), false);
+        if (!aHas) return 1;
+        if (!bHas) return -1;
+        const cmp = a.year - b.year;
+        if (cmp !== 0) return descending ? -cmp : cmp;
+        return compareStrings(albumNameKey(a), albumNameKey(b), false);
+      });
+    }
+  }
+}
+
+export function groupSortedAlbums(
+  sortedAlbums: readonly AlbumEntry[],
+  mode: AlbumSortMode
+): AlbumGroup[] {
+  const groups: AlbumGroup[] = [];
+  let current: AlbumGroup | null = null;
+
+  const bucketFor = (album: AlbumEntry): { key: string; label: string } => {
+    switch (mode) {
+      case "album-asc":
+      case "album-desc": {
+        const bucket = firstLetterBucket(albumNameKey(album));
+        return { key: bucket, label: bucket };
+      }
+      case "artist-asc":
+      case "artist-desc": {
+        const bucket = firstLetterBucket(albumArtistKey(album));
+        return { key: bucket, label: bucket };
+      }
+      case "year-desc":
+      case "year-asc": {
+        if (!hasYear(album)) return { key: UNKNOWN_YEAR_KEY, label: "Unknown" };
+        const year = String(Math.trunc(album.year));
+        return { key: year, label: year };
+      }
+    }
+  };
+
+  for (const album of sortedAlbums) {
+    const { key, label } = bucketFor(album);
+    if (!current || current.key !== key) {
+      current = { key, label, albums: [] };
+      groups.push(current);
+    }
+    current.albums.push(album);
+  }
+
+  return groups;
+}
+
+export function sortAndGroupAlbums(
+  albums: readonly AlbumEntry[],
+  mode: AlbumSortMode
+): AlbumGroup[] {
+  return groupSortedAlbums(sortAlbums(albums, mode), mode);
+}


### PR DESCRIPTION
Second task from \`docs/roadmap-next.md\` (P1).

## Summary
- New \`Sort\` dropdown in the Albums view toolbar with six modes: album A→Z (default) / Z→A, artist A→Z / Z→A, year newest / oldest.
- List mode renders one \`AlbumList\` per group, each preceded by a \`SectionLabel\` (the letter-and-fading-line pattern from the Artists view, now extracted into a shared component).
- Alphabetical sorts bucket non-alpha first letters under \`#\` (always last). Year sorts bucket missing-year albums under \`Unknown\` (always last). Artist sort uses \`getArtistSortKey\` so "The Beatles" lives under B, matching the Artists view.
- Coverflow mode applies the sort order but skips separators (the horizontal scroll doesn't have room for them).
- Preference persists in \`localStorage\` under \`flaque.albums.sort\` and survives reloads.

## Files
- \`frontend/src/utils/albumSort.ts\` (new) — pure sort + group helpers
- \`frontend/src/utils/albumSort.test.ts\` (new) — 14 unit tests
- \`frontend/src/components/SectionLabel.tsx\` (new) — shared inline header
- \`frontend/src/components/LibraryArtistsSection.tsx\` — adopts \`SectionLabel\` (mechanical refactor, no visual change)
- \`frontend/src/components/LibraryAlbumsSection.tsx\` — sort dropdown, persistence, grouped list rendering
- \`frontend/src/components/LibraryAlbumsSection.test.tsx\` — +1 integration test

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [x] \`npx vitest run\` — 208 tests pass (14 new util + 1 new component integration)
- [x] Manual: cycle through all 6 sort modes, confirm section headers + order
- [x] Manual: switch to Coverflow → sort still applied, no separators
- [x] Manual: reload page → sort preference persists
- [x] Manual: search filter + sort interact correctly (filter, then sort)
- [x] Manual: Artists view section headers still look identical after \`SectionLabel\` extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)