### PR TITLE
feat(home): P2/PR 1 — cross-device Resume row

### DIFF
--- a/backend/src/api/playCountRoutes.ts
+++ b/backend/src/api/playCountRoutes.ts
@@ -3,6 +3,11 @@ import { Router } from "express";
 import { requireAuth } from "../auth/middleware";
 import type { IndexStore } from "../services/indexer/indexStore";
 import { incrementPlayCount, getUserPlayStats } from "../services/activity/playCountStore";
+import {
+  clearPlaybackState,
+  getPlaybackState,
+  setPlaybackState
+} from "../services/activity/playbackStateStore";
 import { recordSkip } from "../services/activity/skipStore";
 import { AppError } from "../utils/AppError";
 import { createLogger } from "../utils/logger";
@@ -69,6 +74,75 @@ export function createPlayCountRouter(indexStore: IndexStore): Router {
 
       const stats = await getUserPlayStats(userId, indexStore);
       res.json(stats);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/me/playback-state", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        return next(new AppError("Authentication required", 401));
+      }
+
+      const state = await getPlaybackState(userId);
+      if (!state) {
+        return res.json({ state: null });
+      }
+
+      // Drop stale state for tracks that no longer exist in the index.
+      if (!indexStore.hasTrack(state.trackId)) {
+        await clearPlaybackState(userId);
+        return res.json({ state: null });
+      }
+
+      res.json({ state });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.put("/me/playback-state", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        return next(new AppError("Authentication required", 401));
+      }
+
+      const body = req.body as { trackId?: unknown; positionSec?: unknown } | undefined;
+      const trackId = typeof body?.trackId === "string" ? body.trackId.trim() : "";
+      const positionSec =
+        typeof body?.positionSec === "number" && Number.isFinite(body.positionSec)
+          ? body.positionSec
+          : null;
+
+      if (!trackId) {
+        return next(new AppError("trackId is required", 400));
+      }
+      if (positionSec === null) {
+        return next(new AppError("positionSec must be a finite number", 400));
+      }
+      if (!indexStore.hasTrack(trackId)) {
+        return next(new AppError("Track not found", 404));
+      }
+
+      const state = await setPlaybackState(userId, { trackId, positionSec });
+      res.json({ state });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.delete("/me/playback-state", requireAuth, async (req, res, next) => {
+    try {
+      const userId = req.authUser?.id;
+      if (!userId) {
+        return next(new AppError("Authentication required", 401));
+      }
+
+      await clearPlaybackState(userId);
+      res.status(204).end();
     } catch (error) {
       next(error);
     }

--- a/backend/src/services/activity/playbackStateStore.test.ts
+++ b/backend/src/services/activity/playbackStateStore.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let tmpDir: string;
+
+vi.mock("../../utils/paths", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../utils/paths")>();
+  return {
+    ...original,
+    get usersStorageRoot() {
+      return tmpDir;
+    }
+  };
+});
+
+import {
+  clearPlaybackState,
+  getPlaybackState,
+  setPlaybackState
+} from "./playbackStateStore";
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "playback-state-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("playbackStateStore", () => {
+  it("returns null when nothing has been stored", async () => {
+    expect(await getPlaybackState("user-1")).toBeNull();
+  });
+
+  it("stores and retrieves a playback state with an updatedAt timestamp", async () => {
+    const result = await setPlaybackState("user-1", { trackId: "track-a", positionSec: 12.5 });
+
+    expect(result.trackId).toBe("track-a");
+    expect(result.positionSec).toBe(12.5);
+    expect(result.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const fetched = await getPlaybackState("user-1");
+    expect(fetched).toEqual(result);
+  });
+
+  it("clamps negative positions to zero", async () => {
+    const result = await setPlaybackState("user-1", { trackId: "track-a", positionSec: -7 });
+    expect(result.positionSec).toBe(0);
+  });
+
+  it("falls back to zero when given a non-finite position", async () => {
+    const result = await setPlaybackState("user-1", {
+      trackId: "track-a",
+      positionSec: Number.NaN
+    });
+    expect(result.positionSec).toBe(0);
+  });
+
+  it("overwrites previous state with the latest write", async () => {
+    await setPlaybackState("user-1", { trackId: "track-a", positionSec: 10 });
+    await setPlaybackState("user-1", { trackId: "track-b", positionSec: 30 });
+
+    const fetched = await getPlaybackState("user-1");
+    expect(fetched?.trackId).toBe("track-b");
+    expect(fetched?.positionSec).toBe(30);
+  });
+
+  it("isolates state per user", async () => {
+    await setPlaybackState("user-1", { trackId: "track-a", positionSec: 10 });
+    await setPlaybackState("user-2", { trackId: "track-b", positionSec: 20 });
+
+    expect((await getPlaybackState("user-1"))?.trackId).toBe("track-a");
+    expect((await getPlaybackState("user-2"))?.trackId).toBe("track-b");
+  });
+
+  it("clearPlaybackState removes the stored state", async () => {
+    await setPlaybackState("user-1", { trackId: "track-a", positionSec: 10 });
+    await clearPlaybackState("user-1");
+
+    expect(await getPlaybackState("user-1")).toBeNull();
+  });
+});

--- a/backend/src/services/activity/playbackStateStore.ts
+++ b/backend/src/services/activity/playbackStateStore.ts
@@ -1,0 +1,66 @@
+import path from "node:path";
+
+import { readJsonFile, updateJsonFile } from "../../utils/fs";
+import { usersStorageRoot } from "../../utils/paths";
+
+export type PlaybackState = {
+  trackId: string;
+  positionSec: number;
+  updatedAt: string;
+};
+
+type PlaybackStateFile = {
+  state: PlaybackState | null;
+};
+
+function playbackStatePath(userId: string): string {
+  return path.join(usersStorageRoot, userId, "playback-state.json");
+}
+
+function isValidState(value: unknown): value is PlaybackState {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.trackId === "string" &&
+    typeof record.positionSec === "number" &&
+    Number.isFinite(record.positionSec) &&
+    typeof record.updatedAt === "string"
+  );
+}
+
+export async function getPlaybackState(userId: string): Promise<PlaybackState | null> {
+  const data = await readJsonFile<PlaybackStateFile>(playbackStatePath(userId), { state: null });
+  if (!data || !isValidState(data.state)) {
+    return null;
+  }
+  return data.state;
+}
+
+export async function setPlaybackState(
+  userId: string,
+  input: { trackId: string; positionSec: number }
+): Promise<PlaybackState> {
+  const trackId = input.trackId.trim();
+  const positionSec = Math.max(0, Number.isFinite(input.positionSec) ? input.positionSec : 0);
+  const next: PlaybackState = {
+    trackId,
+    positionSec,
+    updatedAt: new Date().toISOString()
+  };
+
+  await updateJsonFile<PlaybackStateFile>(
+    playbackStatePath(userId),
+    { state: null },
+    () => ({ state: next })
+  );
+
+  return next;
+}
+
+export async function clearPlaybackState(userId: string): Promise<void> {
+  await updateJsonFile<PlaybackStateFile>(
+    playbackStatePath(userId),
+    { state: null },
+    () => ({ state: null })
+  );
+}

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -20,6 +20,7 @@ import { useAutoPlaylists } from "./hooks/useAutoPlaylists";
 import { useForYouPlaylists } from "./hooks/useForYouPlaylists";
 import { usePersonalPlaylists } from "./hooks/usePersonalPlaylists";
 import { useRadioStation } from "./hooks/useRadioStation";
+import { useResumeState } from "./hooks/useResumeState";
 
 type AuthenticatedAppProps = {
   user: User;
@@ -112,6 +113,16 @@ export function AuthenticatedApp({
     recordTrackPlayed, recordTrackSkipped, removeTrackFromPlayback,
     setSelectedTrack, resetAfterLogout
   } = usePlaybackState({ user, allTracksById, allTracks: allTracksLibrary.tracks, loadingAllTracks });
+
+  const { resumeState: resumeStateData, dismiss: dismissResume } = useResumeState(user?.id);
+
+  const resumeState = useMemo(() => {
+    if (!resumeStateData) return null;
+    if (selectedTrackRefreshed?.id === resumeStateData.trackId) return null;
+    const track = allTracksById.get(resumeStateData.trackId);
+    if (!track) return null;
+    return { track, positionSec: resumeStateData.positionSec };
+  }, [resumeStateData, allTracksById, selectedTrackRefreshed?.id]);
 
   const handlePlayRadioTrack = useCallback((track: Track, startOffsetSec: number): void => {
     requestTrackPlayback(track, [track], { startOffsetSec });
@@ -489,6 +500,14 @@ export function AuthenticatedApp({
             clearSelectedArtist();
             clearSelectedArtistAlbum();
             clearSelectedAlbum();
+          },
+          resumeState,
+          onResume: (track, positionSec) => {
+            setPlayerStatusMessage(null);
+            requestTrackPlayback(track, [track], { startOffsetSec: positionSec });
+          },
+          onDismissResume: () => {
+            void dismissResume();
           }
         },
         musicProps: {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -21,9 +21,12 @@ export {
   patchUserAccount,
   deleteUserAccount,
   resetUserPassword,
-  getMyPlayStats
+  getMyPlayStats,
+  getMyPlaybackState,
+  setMyPlaybackState,
+  clearMyPlaybackState
 } from "./users";
-export type { PlayStatsResponse } from "./users";
+export type { PlayStatsResponse, PlaybackState } from "./users";
 
 export {
   getLibrary,

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -117,3 +117,33 @@ export type PlayStatsResponse = {
 export async function getMyPlayStats(): Promise<PlayStatsResponse> {
   return requestJson<PlayStatsResponse>("/api/me/play-stats");
 }
+
+export type PlaybackState = {
+  trackId: string;
+  positionSec: number;
+  updatedAt: string;
+};
+
+export async function getMyPlaybackState(): Promise<PlaybackState | null> {
+  const { state } = await requestJson<{ state: PlaybackState | null }>("/api/me/playback-state");
+  return state;
+}
+
+export async function setMyPlaybackState(input: {
+  trackId: string;
+  positionSec: number;
+}): Promise<PlaybackState> {
+  const { state } = await requestJson<{ state: PlaybackState }>("/api/me/playback-state", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input)
+  });
+  return state;
+}
+
+export async function clearMyPlaybackState(): Promise<void> {
+  await requestJson<void>("/api/me/playback-state", {
+    method: "DELETE",
+    skipJson: true
+  });
+}

--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { useAudioPlayback, type RepeatMode, type TranscodeMode } from "../hooks/useAudioPlayback";
+import { usePlaybackPositionPersistence } from "../hooks/usePlaybackPositionPersistence";
 import type { Playlist, Track } from "../types";
 import { formatDuration } from "../utils/format";
 import {
@@ -117,6 +118,8 @@ export function AudioPlayer({
     shuffleEnabled, onShuffleEnabledChange,
     playRequestNonce, playRequestOffsetSec, onNext, onPrevious, onTrackPlayed, onTrackSkipped
   });
+
+  usePlaybackPositionPersistence({ track, currentTime, isPlaying });
 
   const [showPlaylistPicker, setShowPlaylistPicker] = useState(false);
   const [showQueuePanel, setShowQueuePanel] = useState(false);

--- a/frontend/src/components/HomePanels.tsx
+++ b/frontend/src/components/HomePanels.tsx
@@ -3,6 +3,12 @@ import type { RecentUploadAlbum, RecentUploadItem } from "../api";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
 import { RecentTracksPanel } from "./RecentTracksPanel";
 import { RecentlyUploadedPanel } from "./RecentlyUploadedPanel";
+import { ResumeRow } from "./ResumeRow";
+
+export type ResumeRowState = {
+  track: Track;
+  positionSec: number;
+};
 
 export type HomePanelsProps = {
   recentTracks: Track[];
@@ -21,6 +27,9 @@ export type HomePanelsProps = {
   radioCurrentTrack?: RadioTrack | null;
   radioNextTrack?: RadioTrack | null;
   onStartRadioPlayback?: () => void;
+  resumeState?: ResumeRowState | null;
+  onResume?: (track: Track, positionSec: number) => void;
+  onDismissResume?: () => void;
 };
 
 /**
@@ -43,7 +52,10 @@ export function HomePanels({
   radioStationId = null,
   radioCurrentTrack = null,
   radioNextTrack = null,
-  onStartRadioPlayback
+  onStartRadioPlayback,
+  resumeState = null,
+  onResume,
+  onDismissResume
 }: HomePanelsProps): JSX.Element | null {
   const hasRecent = recentTracks.length > 0;
   const hasUploaded = recentlyUploadedItems.length > 0 || recentlyUploadedLoading;
@@ -98,6 +110,15 @@ export function HomePanels({
         </div>
       </section>
 
+      {resumeState && onResume && onDismissResume ? (
+        <ResumeRow
+          track={resumeState.track}
+          positionSec={resumeState.positionSec}
+          onResume={onResume}
+          onDismiss={onDismissResume}
+        />
+      ) : null}
+
       {hasRecent ? (
         <RecentTracksPanel
           tracks={recentTracks}
@@ -118,7 +139,7 @@ export function HomePanels({
         />
       ) : null}
 
-      {!hasRecent && !hasUploaded ? (
+      {!hasRecent && !hasUploaded && !resumeState ? (
         <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-flaque-clay/60 bg-white/80 p-8 text-center">
           <div className="text-sm text-flaque-steel">
             <p className="font-bold text-flaque-ink">Oh flaque !</p>

--- a/frontend/src/components/ResumeRow.test.tsx
+++ b/frontend/src/components/ResumeRow.test.tsx
@@ -1,0 +1,91 @@
+/* @vitest-environment happy-dom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Track } from "../types";
+import { ResumeRow } from "./ResumeRow";
+
+vi.mock("../api", () => ({
+  coverUrl: (trackId: string, coverPath?: string) => coverPath ?? `/mock-covers/${trackId}`
+}));
+
+function createTrack(): Track {
+  return {
+    id: "track-1",
+    owner: "user-1",
+    path: "/music/track-1.flac",
+    duration: 240,
+    mimeType: "audio/flac",
+    codec: "flac",
+    tags: {
+      title: "Animals",
+      artist: "Pink Floyd",
+      album: "Animals",
+      trackNumber: 1
+    }
+  };
+}
+
+describe("ResumeRow", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the title, artist, and a clamped position label", () => {
+    render(
+      <ResumeRow
+        track={createTrack()}
+        positionSec={120}
+        onResume={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Animals")).toBeTruthy();
+    expect(screen.getByText("Pink Floyd")).toBeTruthy();
+    // Format: 2:00 / 4:00
+    expect(screen.getByText("2:00 / 4:00")).toBeTruthy();
+  });
+
+  it("invokes onResume with the track and clamped position when Resume is clicked", () => {
+    const onResume = vi.fn();
+    const track = createTrack();
+    render(
+      <ResumeRow track={track} positionSec={60} onResume={onResume} onDismiss={vi.fn()} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /resume/i }));
+
+    expect(onResume).toHaveBeenCalledTimes(1);
+    expect(onResume).toHaveBeenCalledWith(track, 60);
+  });
+
+  it("invokes onDismiss when Dismiss is clicked", () => {
+    const onDismiss = vi.fn();
+    render(
+      <ResumeRow
+        track={createTrack()}
+        positionSec={30}
+        onResume={vi.fn()}
+        onDismiss={onDismiss}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("clamps a position past the track duration to the duration", () => {
+    const onResume = vi.fn();
+    const track = createTrack();
+    render(
+      <ResumeRow track={track} positionSec={9999} onResume={onResume} onDismiss={vi.fn()} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /resume/i }));
+
+    expect(onResume).toHaveBeenCalledWith(track, 240);
+  });
+});

--- a/frontend/src/components/ResumeRow.tsx
+++ b/frontend/src/components/ResumeRow.tsx
@@ -1,0 +1,79 @@
+import { coverUrl } from "../api";
+import defaultCoverImage from "../assets/default-cover.png";
+import type { Track } from "../types";
+import { formatDuration } from "../utils/format";
+import { getTrackDisplayArtist, getTrackDisplayTitle } from "../utils/tracks";
+
+type ResumeRowProps = {
+  track: Track;
+  positionSec: number;
+  onResume: (track: Track, positionSec: number) => void;
+  onDismiss: () => void;
+};
+
+/**
+ * Home view affordance for picking up the last-played track where it was
+ * paused, with a one-click resume and a dismiss button.
+ */
+export function ResumeRow({ track, positionSec, onResume, onDismiss }: ResumeRowProps): JSX.Element {
+  const title = getTrackDisplayTitle(track);
+  const artist = getTrackDisplayArtist(track) ?? "Unknown artist";
+  const duration = track.duration || 0;
+  const clampedPosition = Math.max(0, Math.min(positionSec, duration > 0 ? duration : positionSec));
+  const progressPercent = duration > 0 ? Math.min(100, (clampedPosition / duration) * 100) : 0;
+
+  return (
+    <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-4 shadow-panel backdrop-blur-sm">
+      <div className="flex items-center gap-4">
+        <img
+          className="h-16 w-16 shrink-0 rounded-md object-cover"
+          src={coverUrl(track.id, track.cover)}
+          alt=""
+          onError={(event) => {
+            event.currentTarget.src = defaultCoverImage;
+          }}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-flaque-steel">
+            Resume
+          </p>
+          <p className="mt-0.5 truncate text-sm font-semibold text-flaque-ink" title={title}>
+            {title}
+          </p>
+          <p className="truncate text-xs text-flaque-steel">{artist}</p>
+          <div className="mt-2 flex items-center gap-2">
+            <div className="h-1 flex-1 overflow-hidden rounded-full bg-flaque-clay/40">
+              <div
+                className="h-full rounded-full bg-flaque-ink/70"
+                style={{ width: `${progressPercent}%` }}
+              />
+            </div>
+            <span className="shrink-0 text-[10px] tabular-nums text-flaque-steel">
+              {formatDuration(clampedPosition)}
+              {duration > 0 ? ` / ${formatDuration(duration)}` : ""}
+            </span>
+          </div>
+        </div>
+        <div className="flex shrink-0 flex-col items-stretch gap-1.5">
+          <button
+            type="button"
+            className="inline-flex items-center justify-center gap-1.5 rounded-xl bg-flaque-ink px-3 py-1.5 text-xs font-medium uppercase tracking-[0.12em] text-flaque-cream transition hover:bg-flaque-ink/90"
+            onClick={() => onResume(track, clampedPosition)}
+          >
+            <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M8 6v12l10-6-10-6z" />
+            </svg>
+            Resume
+          </button>
+          <button
+            type="button"
+            className="rounded-xl border border-flaque-clay/60 bg-white px-3 py-1 text-[11px] text-flaque-steel transition hover:bg-flaque-cream hover:text-flaque-ink"
+            onClick={onDismiss}
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/hooks/usePlaybackPositionPersistence.ts
+++ b/frontend/src/hooks/usePlaybackPositionPersistence.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from "react";
+
+import { setMyPlaybackState } from "../api";
+import type { Track } from "../types";
+
+const PERSIST_INTERVAL_MS = 15_000;
+
+type UsePlaybackPositionPersistenceInput = {
+  track: Track | null;
+  currentTime: number;
+  isPlaying: boolean;
+};
+
+/**
+ * Periodically persists the user's current track + position to the backend so
+ * the Home view can offer a cross-device "Resume" affordance. Skips radio
+ * tracks (owner === "radio") since they aren't resumable.
+ */
+export function usePlaybackPositionPersistence({
+  track,
+  currentTime,
+  isPlaying
+}: UsePlaybackPositionPersistenceInput): void {
+  const lastPersistedTrackIdRef = useRef<string | null>(null);
+  const lastPersistedAtRef = useRef(0);
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    if (!track || track.owner === "radio") {
+      return;
+    }
+
+    const persist = (positionSec: number): void => {
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      lastPersistedAtRef.current = Date.now();
+      lastPersistedTrackIdRef.current = track.id;
+
+      setMyPlaybackState({ trackId: track.id, positionSec })
+        .catch(() => {
+          // ignore: persistence is best-effort
+        })
+        .finally(() => {
+          inFlightRef.current = false;
+        });
+    };
+
+    // On a fresh track, write the starting position right away so a resume on
+    // another device knows what's loaded even if the user immediately closes.
+    if (lastPersistedTrackIdRef.current !== track.id) {
+      persist(Math.max(0, currentTime));
+      return;
+    }
+
+    if (!isPlaying) {
+      return;
+    }
+
+    const elapsedSinceLast = Date.now() - lastPersistedAtRef.current;
+    if (elapsedSinceLast < PERSIST_INTERVAL_MS) {
+      return;
+    }
+
+    persist(Math.max(0, currentTime));
+  }, [track, isPlaying, currentTime]);
+}

--- a/frontend/src/hooks/useResumeState.ts
+++ b/frontend/src/hooks/useResumeState.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { clearMyPlaybackState, getMyPlaybackState, type PlaybackState } from "../api";
+
+type UseResumeStateResult = {
+  resumeState: PlaybackState | null;
+  loading: boolean;
+  dismiss: () => Promise<void>;
+  refresh: () => Promise<void>;
+};
+
+/**
+ * Loads the user's last-played track + position once on mount. Exposes a
+ * `dismiss` helper that clears the server state (used by the Home view's
+ * Resume row when the user closes it).
+ */
+export function useResumeState(userId: string | undefined): UseResumeStateResult {
+  const [resumeState, setResumeState] = useState<PlaybackState | null>(null);
+  const [loading, setLoading] = useState<boolean>(Boolean(userId));
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (!userId) {
+      setResumeState(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const state = await getMyPlaybackState();
+      setResumeState(state);
+    } catch {
+      setResumeState(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const dismiss = useCallback(async (): Promise<void> => {
+    setResumeState(null);
+    if (!userId) return;
+    try {
+      await clearMyPlaybackState();
+    } catch {
+      // ignore: dismissal is best-effort
+    }
+  }, [userId]);
+
+  return { resumeState, loading, dismiss, refresh };
+}


### PR DESCRIPTION
First PR of three implementing Option A from \`docs/home-view-redesign.md\` (the P2 deliverable).

## Summary
Adds a Resume affordance at the top of the Home view that picks up the last-played track where the user paused, persisted server-side so it survives across devices (per the user's choice on the discovery doc's open question).

### Backend
- New \`backend/src/services/activity/playbackStateStore.ts\` — per-user JSON file at \`data/storage/users/{userId}/playback-state.json\` storing \`{ trackId, positionSec, updatedAt }\`. Negative / NaN positions clamp to 0.
- Three new endpoints on the existing play-count router:
  - \`GET /api/me/playback-state\` — returns \`{ state: PlaybackState | null }\`. Self-heals by clearing stale state when the track no longer exists in the index.
  - \`PUT /api/me/playback-state\` — accepts \`{ trackId, positionSec }\`, validates both, returns the persisted state.
  - \`DELETE /api/me/playback-state\` — clears state (used by the Dismiss button).
- 7 new store tests.

### Frontend
- \`usePlaybackPositionPersistence\` (new hook) — wired into \`AudioPlayer\`. Writes the current position every 15s while playing, immediately on track change. Skips radio tracks (\`track.owner === "radio"\`).
- \`useResumeState\` (new hook) — fetches state once on mount, exposes \`dismiss\` that clears it server-side.
- \`ResumeRow.tsx\` (new) — cover + title + artist + progress bar + Resume / Dismiss. Uses the existing display helpers, falls back to defaultCoverImage on load error. 4 unit tests.
- \`HomePanels.tsx\` — renders ResumeRow above Played Recently when state exists. Empty-state condition updated so the page isn't considered empty just because Resume is present.
- \`AuthenticatedApp.tsx\` — wires \`useResumeState\`, suppresses the row when the currently selected track is the same as the resumed one, calls \`requestTrackPlayback(track, [track], { startOffsetSec })\` on click.

## Decisions captured (from the doc's open questions)
- **Cross-device persistence** (not localStorage) — confirmed by user.
- Persistence interval = 15s (compromise between disk writes and accuracy).
- Radio tracks excluded — they aren't resumable.

## Test plan
- [x] \`backend\` — \`npx tsc --noEmit\` clean, \`npx vitest run\` 511 tests pass (7 new)
- [x] \`frontend\` — \`npx tsc --noEmit\` clean, \`npx vitest run\` 212 tests pass (4 new)
- [x] Manual: play a track, pause mid-way, refresh the Home view → Resume row shows with correct cover/title/position
- [x] Manual: click Resume → playback restarts at the saved offset
- [x] Manual: click Dismiss → row disappears and stays gone after refresh
- [x] Manual: play another device → resume on this device starts where the other left off (cross-device)
- [x] Manual: play a radio track → no resume state gets written

## Next
- PR 2: inline For-You row on Home
- PR 3: empty-state polish (Launch Radio / Browse library / View Playlists chips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)