### PR TITLE
feat(home): P2/PR 2 — inline For-You row, best-fit ordering

### DIFF
--- a/backend/src/api/playlist/forYou.ts
+++ b/backend/src/api/playlist/forYou.ts
@@ -65,7 +65,8 @@ export function createForYouPlaylistRouter(indexStore: IndexStore): Router {
           seedArtist: p.seedArtist,
           seedArtistPhoto: await resolveSeedArtistPhoto(indexStore, p.seedArtist, p.trackIds, photoCache),
           trackCount: p.trackCount,
-          generatedAt: p.generatedAt
+          generatedAt: p.generatedAt,
+          score: p.score
         }))
       );
 

--- a/backend/src/services/playlists/forYou/generate.ts
+++ b/backend/src/services/playlists/forYou/generate.ts
@@ -548,6 +548,7 @@ type BuildResult =
 
 async function buildForYouPlaylist(
   seedArtist: string,
+  seedScore: number,
   indexStore: IndexStore,
   allTracks: Track[],
   signals: SignalMaps,
@@ -685,7 +686,8 @@ async function buildForYouPlaylist(
       seedArtist,
       trackIds: sequenced.map((c) => c.track.id),
       trackCount: sequenced.length,
-      generatedAt: new Date().toISOString()
+      generatedAt: new Date().toISOString(),
+      score: seedScore
     },
     trace: baseTrace
   };
@@ -754,7 +756,7 @@ export async function generateForYouPlaylistsWithTrace(
     }
     attemptedSeeds++;
 
-    const result = await buildForYouPlaylist(candidate.artist, indexStore, allTracks, signals, userId);
+    const result = await buildForYouPlaylist(candidate.artist, candidate.score, indexStore, allTracks, signals, userId);
 
     if (result.playlist) {
       playlists.push(result.playlist);

--- a/backend/src/services/playlists/forYou/store.ts
+++ b/backend/src/services/playlists/forYou/store.ts
@@ -16,6 +16,12 @@ export type ForYouPlaylist = {
   trackIds: string[];
   trackCount: number;
   generatedAt: string;
+  /**
+   * Seed-artist score used to rank playlists "best-fit first" on Home.
+   * Missing on playlists generated before this field was introduced — those
+   * sink to the bottom on read.
+   */
+  score?: number;
 };
 
 type ForYouMeta = {
@@ -62,7 +68,12 @@ export async function loadForYouPlaylists(userId: string): Promise<ForYouPlaylis
     }
   }
 
-  return playlists.sort((a, b) => a.name.localeCompare(b.name));
+  return playlists.sort((a, b) => {
+    const scoreA = typeof a.score === "number" ? a.score : -Infinity;
+    const scoreB = typeof b.score === "number" ? b.score : -Infinity;
+    if (scoreA !== scoreB) return scoreB - scoreA;
+    return a.name.localeCompare(b.name);
+  });
 }
 
 export async function getForYouPlaylistById(

--- a/backend/src/services/playlists/forYouPlaylistService.test.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.test.ts
@@ -230,6 +230,46 @@ describe("forYouPlaylistService", () => {
     expect(loaded[0]!.trackIds).toEqual(["t1", "t2", "t3"]);
   });
 
+  it("sorts loaded for-you playlists by score desc, with missing scores last", async () => {
+    const { saveForYouPlaylists, loadForYouPlaylists } = await import("./forYouPlaylistService");
+
+    await saveForYouPlaylists("user-1", [
+      {
+        id: "for-you:low",
+        name: "Around Low",
+        seedArtist: "Low",
+        trackIds: ["t1"],
+        trackCount: 1,
+        generatedAt: "2026-04-01T00:00:00Z",
+        score: 1.0
+      },
+      {
+        id: "for-you:high",
+        name: "Around High",
+        seedArtist: "High",
+        trackIds: ["t2"],
+        trackCount: 1,
+        generatedAt: "2026-04-01T00:00:00Z",
+        score: 5.0
+      },
+      {
+        id: "for-you:legacy",
+        name: "Around Legacy",
+        seedArtist: "Legacy",
+        trackIds: ["t3"],
+        trackCount: 1,
+        generatedAt: "2026-04-01T00:00:00Z"
+      }
+    ]);
+
+    const loaded = await loadForYouPlaylists("user-1");
+    expect(loaded.map((p) => p.id)).toEqual([
+      "for-you:high",
+      "for-you:low",
+      "for-you:legacy"
+    ]);
+  });
+
   it("enforces the per-peer-artist cap inside a playlist", async () => {
     const { generateForYouPlaylists } = await import("./forYouPlaylistService");
     const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -508,6 +508,15 @@ export function AuthenticatedApp({
           },
           onDismissResume: () => {
             void dismissResume();
+          },
+          forYouPlaylists,
+          onSelectForYouPlaylist: (playlistId: string) => {
+            navigateTo("library", "playlists");
+            setActiveLibrarySection("playlists");
+            setPlaylistDetailId(playlistId);
+            clearSelectedArtist();
+            clearSelectedArtistAlbum();
+            clearSelectedAlbum();
           }
         },
         musicProps: {

--- a/frontend/src/components/HomeForYouRow.test.tsx
+++ b/frontend/src/components/HomeForYouRow.test.tsx
@@ -1,0 +1,96 @@
+/* @vitest-environment happy-dom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ForYouPlaylistSummary } from "../types";
+import { HomeForYouRow } from "./HomeForYouRow";
+
+vi.mock("../api", () => ({
+  coverPathUrl: (path: string) => `/mock-covers/${path}`
+}));
+
+function summary(input: Partial<ForYouPlaylistSummary> & { id: string; name: string }): ForYouPlaylistSummary {
+  return {
+    id: input.id,
+    name: input.name,
+    seedArtist: input.seedArtist ?? "Pink Floyd",
+    seedArtistPhoto: input.seedArtistPhoto,
+    trackCount: input.trackCount ?? 12,
+    generatedAt: input.generatedAt ?? "2026-05-01T00:00:00.000Z"
+  };
+}
+
+describe("HomeForYouRow", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing when there are no playlists", () => {
+    const { container } = render(<HomeForYouRow playlists={[]} onSelect={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders one card per playlist with name and track count", () => {
+    render(
+      <HomeForYouRow
+        playlists={[
+          summary({ id: "for-you:pink-floyd", name: "Because you listen to Pink Floyd", trackCount: 14 }),
+          summary({ id: "for-you:tame-impala", name: "Around Tame Impala", trackCount: 9 })
+        ]}
+        onSelect={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Because you listen to Pink Floyd")).toBeTruthy();
+    expect(screen.getByText("Around Tame Impala")).toBeTruthy();
+    expect(screen.getByText("14 tracks")).toBeTruthy();
+    expect(screen.getByText("9 tracks")).toBeTruthy();
+  });
+
+  it("invokes onSelect with the playlist id when a card is clicked", () => {
+    const onSelect = vi.fn();
+    render(
+      <HomeForYouRow
+        playlists={[summary({ id: "for-you:pink-floyd", name: "Because you listen to Pink Floyd" })]}
+        onSelect={onSelect}
+      />
+    );
+
+    fireEvent.click(screen.getByTitle("Because you listen to Pink Floyd"));
+
+    expect(onSelect).toHaveBeenCalledWith("for-you:pink-floyd");
+  });
+
+  it("renders a gradient fallback with the first letter when no seedArtistPhoto", () => {
+    render(
+      <HomeForYouRow
+        playlists={[
+          summary({ id: "for-you:radiohead", name: "Around Radiohead", seedArtist: "Radiohead" })
+        ]}
+        onSelect={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("R")).toBeTruthy();
+  });
+
+  it("renders an image when seedArtistPhoto is set", () => {
+    render(
+      <HomeForYouRow
+        playlists={[
+          summary({
+            id: "for-you:tame-impala",
+            name: "Around Tame Impala",
+            seedArtist: "Tame Impala",
+            seedArtistPhoto: "artists/tame-impala/photo.jpg"
+          })
+        ]}
+        onSelect={vi.fn()}
+      />
+    );
+
+    const img = screen.getByAltText("Tame Impala") as HTMLImageElement;
+    expect(img.src).toContain("/mock-covers/artists/tame-impala/photo.jpg");
+  });
+});

--- a/frontend/src/components/HomeForYouRow.tsx
+++ b/frontend/src/components/HomeForYouRow.tsx
@@ -1,0 +1,73 @@
+import { coverPathUrl } from "../api";
+import type { ForYouPlaylistSummary } from "../types";
+
+type HomeForYouRowProps = {
+  playlists: ForYouPlaylistSummary[];
+  onSelect: (playlistId: string) => void;
+};
+
+/**
+ * Home view row of For-You playlists. Horizontally scrollable on overflow.
+ * Renders the seed-artist photo when available, falling back to a gradient
+ * tile with the first letter (matching the Playlists tab pattern). The
+ * caller decides ordering — by default the API returns alphabetically.
+ */
+export function HomeForYouRow({ playlists, onSelect }: HomeForYouRowProps): JSX.Element | null {
+  if (playlists.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+      <h2 className="font-display text-xl text-flaque-ink">Made for you</h2>
+      <div
+        className="mt-3 flex gap-3 overflow-x-auto pb-1 [scrollbar-width:thin]"
+        role="list"
+      >
+        {playlists.map((playlist) => {
+          const photoUrl = playlist.seedArtistPhoto ? coverPathUrl(playlist.seedArtistPhoto) : null;
+          return (
+            <button
+              key={playlist.id}
+              type="button"
+              role="listitem"
+              className="group flex w-32 shrink-0 cursor-pointer flex-col overflow-hidden rounded-2xl bg-white/85 text-left shadow-sm transition hover:shadow-md sm:w-36"
+              onClick={() => onSelect(playlist.id)}
+              title={playlist.name}
+            >
+              <div className="relative aspect-square w-full overflow-hidden">
+                {photoUrl ? (
+                  <img
+                    src={photoUrl}
+                    alt={playlist.seedArtist}
+                    className="h-full w-full object-cover"
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-flaque-cream to-flaque-clay/60 text-flaque-steel">
+                    <span className="font-display text-3xl">
+                      {playlist.seedArtist.charAt(0).toUpperCase()}
+                    </span>
+                  </div>
+                )}
+                <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition group-hover:bg-black/30 group-hover:opacity-100">
+                  <svg className="h-8 w-8 drop-shadow-md" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
+                    <path d="M8 6v12l10-6-10-6z" />
+                  </svg>
+                </div>
+              </div>
+              <div className="px-2 py-1.5">
+                <p className="line-clamp-2 min-h-[2rem] text-[11px] font-semibold text-flaque-ink">
+                  {playlist.name}
+                </p>
+                <p className="mt-0.5 text-[10px] text-flaque-steel">
+                  {playlist.trackCount} track{playlist.trackCount !== 1 ? "s" : ""}
+                </p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/HomePanels.tsx
+++ b/frontend/src/components/HomePanels.tsx
@@ -1,6 +1,7 @@
-import type { RadioTrack, Track } from "../types";
+import type { ForYouPlaylistSummary, RadioTrack, Track } from "../types";
 import type { RecentUploadAlbum, RecentUploadItem } from "../api";
 import type { UploadPeriod } from "../hooks/useRecentlyUploaded";
+import { HomeForYouRow } from "./HomeForYouRow";
 import { RecentTracksPanel } from "./RecentTracksPanel";
 import { RecentlyUploadedPanel } from "./RecentlyUploadedPanel";
 import { ResumeRow } from "./ResumeRow";
@@ -30,6 +31,8 @@ export type HomePanelsProps = {
   resumeState?: ResumeRowState | null;
   onResume?: (track: Track, positionSec: number) => void;
   onDismissResume?: () => void;
+  forYouPlaylists?: ForYouPlaylistSummary[];
+  onSelectForYouPlaylist?: (playlistId: string) => void;
 };
 
 /**
@@ -55,10 +58,13 @@ export function HomePanels({
   onStartRadioPlayback,
   resumeState = null,
   onResume,
-  onDismissResume
+  onDismissResume,
+  forYouPlaylists = [],
+  onSelectForYouPlaylist
 }: HomePanelsProps): JSX.Element | null {
   const hasRecent = recentTracks.length > 0;
   const hasUploaded = recentlyUploadedItems.length > 0 || recentlyUploadedLoading;
+  const hasForYou = forYouPlaylists.length > 0 && Boolean(onSelectForYouPlaylist);
   const canStartRadio = Boolean(onStartRadioPlayback && !radioLoading);
 
   const cardGridClass = "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4";
@@ -119,6 +125,13 @@ export function HomePanels({
         />
       ) : null}
 
+      {hasForYou && onSelectForYouPlaylist ? (
+        <HomeForYouRow
+          playlists={forYouPlaylists}
+          onSelect={onSelectForYouPlaylist}
+        />
+      ) : null}
+
       {hasRecent ? (
         <RecentTracksPanel
           tracks={recentTracks}
@@ -139,7 +152,7 @@ export function HomePanels({
         />
       ) : null}
 
-      {!hasRecent && !hasUploaded && !resumeState ? (
+      {!hasRecent && !hasUploaded && !resumeState && !hasForYou ? (
         <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-flaque-clay/60 bg-white/80 p-8 text-center">
           <div className="text-sm text-flaque-steel">
             <p className="font-bold text-flaque-ink">Oh flaque !</p>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -157,6 +157,8 @@ export type ForYouPlaylistSummary = {
   seedArtistPhoto?: string;
   trackCount: number;
   generatedAt: string;
+  /** Seed-artist score; higher = better fit. Missing on pre-2026-05 playlists. */
+  score?: number;
 };
 
 export type ForYouPlaylistDetail = ForYouPlaylistSummary & {


### PR DESCRIPTION
Second of three PRs implementing Option A from \`docs/home-view-redesign.md\`. Surfaces the For-You playlists on Home without removing them from the Playlists tab.

## Summary

### Frontend
- New \`HomeForYouRow.tsx\` — horizontally scrollable row of for-you cards, with seed-artist photo + gradient fallback, hover-play overlay, and a click that routes to the existing \`ForYouPlaylistDetailView\`.
- 5 unit tests covering empty state, content, click handler, photo + fallback rendering.
- \`HomePanels.tsx\` — renders the row between Resume and Played Recently. Empty-state condition extended so the page isn't considered empty when For-You is the only thing present.
- \`AuthenticatedApp.tsx\` — passes the existing \`forYouPlaylists\` from \`useForYouPlaylists\` and a navigation handler that mirrors the Playlists-tab routing pattern (\`navigateTo("library", "playlists")\` + \`setPlaylistDetailId\`).

### Backend (small tweak to honor the discovery doc's "best-fit first" decision)
- \`ForYouPlaylist.score\` is now persisted at generation time from the seed-artist score.
- \`loadForYouPlaylists\` sorts by \`score\` desc, with \`name\` fallback for ties.
- Legacy playlists generated before this field are missing \`score\` and sink to the bottom on read — they pick up an order once the user regenerates (max ~14 days via the existing cadence).
- API summary exposes \`score?\` so the frontend type can reflect it.
- 1 new unit test verifying score-desc + missing-score-last sort.

## Decisions captured (from the discovery doc)
- **Best-fit first ordering** — chosen by the user in the open-questions answers. Implemented end-to-end (backend score persistence + sort).

## Test plan
- [x] \`backend\` — \`npx tsc --noEmit\` clean, \`npx vitest run\` 512 tests pass (1 new)
- [x] \`frontend\` — \`npx tsc --noEmit\` clean, \`npx vitest run\` 217 tests pass (5 new)
- [ ] Manual: For-You row appears on Home for a user with generated playlists
- [ ] Manual: clicking a card opens the correct detail view
- [ ] Manual: regenerate For-You playlists → leftmost cards correspond to highest-scoring seeds
- [ ] Manual: Playlists tab still shows the same For-You section unchanged
- [ ] Manual: empty For-You (no plays / fresh account) → row is hidden

## Next
- PR 3: empty-state polish (Launch Radio / Browse library / View Playlists chips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)