### PR TITLE
feat(home): P2/PR 3 — empty-state quick-action chips

### DIFF
--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -517,6 +517,14 @@ export function AuthenticatedApp({
             clearSelectedArtist();
             clearSelectedArtistAlbum();
             clearSelectedAlbum();
+          },
+          onNavigateToPlaylists: () => {
+            navigateTo("library", "playlists");
+            setActiveLibrarySection("playlists");
+            setPlaylistDetailId(null);
+            clearSelectedArtist();
+            clearSelectedArtistAlbum();
+            clearSelectedAlbum();
           }
         },
         musicProps: {

--- a/frontend/src/components/HomePanels.test.tsx
+++ b/frontend/src/components/HomePanels.test.tsx
@@ -1,0 +1,76 @@
+/* @vitest-environment happy-dom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { HomePanels } from "./HomePanels";
+
+vi.mock("../api", () => ({
+  coverUrl: (trackId: string, coverPath?: string) => coverPath ?? `/mock-covers/${trackId}`,
+  coverPathUrl: (path: string) => `/mock-covers/${path}`
+}));
+
+function renderEmptyHome(overrides: {
+  onStartRadioPlayback?: () => void;
+  onNavigateToLibrary?: () => void;
+  onNavigateToPlaylists?: () => void;
+} = {}): void {
+  render(
+    <HomePanels
+      recentTracks={[]}
+      onRecentTrackReplay={vi.fn()}
+      recentlyUploadedItems={[]}
+      recentlyUploadedLoading={false}
+      recentlyUploadedPeriod="7d"
+      onRecentlyUploadedPeriodChange={vi.fn()}
+      onRecentlyUploadedTrackSelect={vi.fn()}
+      onRecentlyUploadedAlbumPlay={vi.fn()}
+      onRecentlyUploadedAlbumOpen={vi.fn()}
+      onStartRadioPlayback={overrides.onStartRadioPlayback}
+      onNavigateToLibrary={overrides.onNavigateToLibrary}
+      onNavigateToPlaylists={overrides.onNavigateToPlaylists}
+    />
+  );
+}
+
+describe("HomePanels empty state", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the three quick-action chips when all callbacks are provided", () => {
+    renderEmptyHome({
+      onStartRadioPlayback: vi.fn(),
+      onNavigateToLibrary: vi.fn(),
+      onNavigateToPlaylists: vi.fn()
+    });
+
+    expect(screen.getByText("Oh flaque !")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /tune in to flaque fm/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /browse library/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /view playlists/i })).toBeTruthy();
+  });
+
+  it("invokes the corresponding callback when each chip is clicked", () => {
+    const onStartRadioPlayback = vi.fn();
+    const onNavigateToLibrary = vi.fn();
+    const onNavigateToPlaylists = vi.fn();
+    renderEmptyHome({ onStartRadioPlayback, onNavigateToLibrary, onNavigateToPlaylists });
+
+    fireEvent.click(screen.getByRole("button", { name: /tune in to flaque fm/i }));
+    fireEvent.click(screen.getByRole("button", { name: /browse library/i }));
+    fireEvent.click(screen.getByRole("button", { name: /view playlists/i }));
+
+    expect(onStartRadioPlayback).toHaveBeenCalledTimes(1);
+    expect(onNavigateToLibrary).toHaveBeenCalledTimes(1);
+    expect(onNavigateToPlaylists).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides individual chips when their callback is missing", () => {
+    renderEmptyHome({ onNavigateToLibrary: vi.fn() });
+
+    expect(screen.queryByRole("button", { name: /tune in to flaque fm/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /browse library/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /view playlists/i })).toBeNull();
+  });
+});

--- a/frontend/src/components/HomePanels.tsx
+++ b/frontend/src/components/HomePanels.tsx
@@ -33,6 +33,7 @@ export type HomePanelsProps = {
   onDismissResume?: () => void;
   forYouPlaylists?: ForYouPlaylistSummary[];
   onSelectForYouPlaylist?: (playlistId: string) => void;
+  onNavigateToPlaylists?: () => void;
 };
 
 /**
@@ -60,7 +61,8 @@ export function HomePanels({
   onResume,
   onDismissResume,
   forYouPlaylists = [],
-  onSelectForYouPlaylist
+  onSelectForYouPlaylist,
+  onNavigateToPlaylists
 }: HomePanelsProps): JSX.Element | null {
   const hasRecent = recentTracks.length > 0;
   const hasUploaded = recentlyUploadedItems.length > 0 || recentlyUploadedLoading;
@@ -153,20 +155,56 @@ export function HomePanels({
       ) : null}
 
       {!hasRecent && !hasUploaded && !resumeState && !hasForYou ? (
-        <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-flaque-clay/60 bg-white/80 p-8 text-center">
+        <div className="flex flex-col items-center justify-center gap-5 rounded-2xl border border-flaque-clay/60 bg-white/80 p-8 text-center">
           <div className="text-sm text-flaque-steel">
             <p className="font-bold text-flaque-ink">Oh flaque !</p>
-            <p className="mt-1">Nothing to play here at the moment, maybe you should browse your library ?</p>
+            <p className="mt-1">Nothing to play here at the moment. Where would you like to start ?</p>
           </div>
-          {onNavigateToLibrary ? (
-            <button
-              className="rounded-xl border border-flaque-clay/60 bg-flaque-cream/80 px-4 py-2 text-sm font-medium text-flaque-ink transition hover:bg-flaque-cream"
-              type="button"
-              onClick={onNavigateToLibrary}
-            >
-              Browse library
-            </button>
-          ) : null}
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            {onStartRadioPlayback ? (
+              <button
+                className="inline-flex items-center gap-1.5 rounded-xl border border-flaque-clay/60 bg-flaque-cream/80 px-3 py-2 text-sm font-medium text-flaque-ink transition hover:bg-flaque-cream disabled:cursor-not-allowed disabled:opacity-60"
+                type="button"
+                disabled={!canStartRadio}
+                onClick={() => onStartRadioPlayback?.()}
+              >
+                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M8 6v12l10-6-10-6z" />
+                </svg>
+                Tune in to FLAQUE FM
+              </button>
+            ) : null}
+            {onNavigateToLibrary ? (
+              <button
+                className="inline-flex items-center gap-1.5 rounded-xl border border-flaque-clay/60 bg-flaque-cream/80 px-3 py-2 text-sm font-medium text-flaque-ink transition hover:bg-flaque-cream"
+                type="button"
+                onClick={onNavigateToLibrary}
+              >
+                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M4 19.5A2.5 2.5 0 016.5 17H20" />
+                  <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" />
+                </svg>
+                Browse library
+              </button>
+            ) : null}
+            {onNavigateToPlaylists ? (
+              <button
+                className="inline-flex items-center gap-1.5 rounded-xl border border-flaque-clay/60 bg-flaque-cream/80 px-3 py-2 text-sm font-medium text-flaque-ink transition hover:bg-flaque-cream"
+                type="button"
+                onClick={onNavigateToPlaylists}
+              >
+                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <line x1="8" y1="6" x2="21" y2="6" />
+                  <line x1="8" y1="12" x2="21" y2="12" />
+                  <line x1="8" y1="18" x2="21" y2="18" />
+                  <line x1="3" y1="6" x2="3.01" y2="6" />
+                  <line x1="3" y1="12" x2="3.01" y2="12" />
+                  <line x1="3" y1="18" x2="3.01" y2="18" />
+                </svg>
+                View playlists
+              </button>
+            ) : null}
+          </div>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
Final PR of three implementing Option A from \`docs/home-view-redesign.md\`. Polishes the Home empty state for first-time visitors.

## Summary
- The empty state (shown only when there's no Resume, no For-You, no Played Recently, and no Recently Uploaded) now offers three quick-action chips instead of a single "Browse library" button.
- The chips chosen match the user's answers from the discovery doc's open questions: **Tune in to FLAQUE FM**, **Browse library**, **View playlists**.
- Copy tweak: "Where would you like to start ?" replaces the slightly defeatist "maybe you should browse your library ?". "Oh flaque !" preserved.
- Each chip has a small inline icon and is rendered only when its callback is provided, so the empty state degrades gracefully on screens that don't wire one.

## Files
- \`frontend/src/components/HomePanels.tsx\` — empty-state markup, new \`onNavigateToPlaylists\` prop.
- \`frontend/src/AuthenticatedApp.tsx\` — wires \`onNavigateToPlaylists\` to the same routing pattern used elsewhere for the Playlists tab.
- \`frontend/src/components/HomePanels.test.tsx\` (new) — 3 tests covering chips rendered, click handlers, and graceful degradation when callbacks are missing.

## Note on naming
"Launch radio" would collide in tests with the existing radio play button's aria-label at the top of Home. Renamed to **"Tune in to FLAQUE FM"** — distinct, on-brand, and clearer about what happens.

## Test plan
- [x] \`frontend\` — \`npx tsc --noEmit\` clean, \`npx vitest run\` 220 tests pass (3 new)
- [ ] Manual: with a fresh account (no plays, no uploads), the Home empty state shows the three chips and "Oh flaque !"
- [ ] Manual: each chip routes correctly
- [ ] Manual: returning users with any content (Resume, For-You, Recent, Uploaded) do NOT see the empty state

## Option A — feature complete
With this merged, the home redesign Option A is shipped end-to-end:
- PR 1 (#181): cross-device Resume row
- PR 2 (#182): inline For-You row with best-fit ordering
- PR 3 (this): empty-state quick-action chips

Per the discovery doc, the next decision is whether to keep iterating on Home (Option B / C) or move to a different roadmap item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)