### PR TITLE
AI-assisted for-you: replace MFCC embeddings with CLAP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ playwright-report/
 test-results/
 
 .claude/settings.local.json
+
+# Python sidecar
+__pycache__/
+*.pyc
+backend/python-services/**/.venv/

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "start": "node dist/server.js",
     "test": "vitest run",
     "embed:probe": "tsx src/scripts/probeEmbedder.ts",
-    "embed:sidecar": "./python-services/audio-embedder/start.sh"
+    "embed:sidecar": "./python-services/audio-embedder/start.sh",
+    "embed:backfill": "tsx src/scripts/backfillEmbeddings.ts"
   },
   "dependencies": {
     "@flaque/shared": "*",

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
     "embed:probe": "tsx src/scripts/probeEmbedder.ts",
     "embed:sidecar": "./python-services/audio-embedder/start.sh",
     "embed:backfill": "tsx src/scripts/backfillEmbeddings.ts",
-    "for-you:regen": "tsx src/scripts/regenerateForYou.ts"
+    "for-you:regen": "tsx src/scripts/regenerateForYou.ts",
+    "for-you:inspect": "tsx src/scripts/inspectForYouTrace.ts"
   },
   "dependencies": {
     "@flaque/shared": "*",

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,9 @@
     "dev": "tsx watch src/server.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "embed:probe": "tsx src/scripts/probeEmbedder.ts",
+    "embed:sidecar": "./python-services/audio-embedder/start.sh"
   },
   "dependencies": {
     "@flaque/shared": "*",

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "test": "vitest run",
     "embed:probe": "tsx src/scripts/probeEmbedder.ts",
     "embed:sidecar": "./python-services/audio-embedder/start.sh",
-    "embed:backfill": "tsx src/scripts/backfillEmbeddings.ts"
+    "embed:backfill": "tsx src/scripts/backfillEmbeddings.ts",
+    "for-you:regen": "tsx src/scripts/regenerateForYou.ts"
   },
   "dependencies": {
     "@flaque/shared": "*",

--- a/backend/python-services/audio-embedder/model.py
+++ b/backend/python-services/audio-embedder/model.py
@@ -1,0 +1,62 @@
+"""
+Phase-1 stub embedder.
+
+Returns a deterministic 512-dim L2-normalised vector derived from a hash of
+the input path. Lets us exercise the wire protocol end-to-end before pulling
+in torch / transformers / CLAP weights in phase 2.
+
+Shape and dimension match the planned CLAP output so the Node client and
+on-disk sidecar format won't need to change when the model is swapped in.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import random
+from dataclasses import dataclass
+from pathlib import Path
+
+EMBEDDING_DIM = 512
+MODEL_NAME = "stub-deterministic-v1"
+
+
+@dataclass
+class EmbedResult:
+    vec: list[float]
+    dim: int
+    model: str
+
+
+def embed_path(absolute_path: str) -> EmbedResult:
+    """
+    Deterministic stub: same path in → same vector out. Does not read the file.
+    Phase 2 swaps this for an actual CLAP forward pass.
+    """
+    if not absolute_path:
+        raise ValueError("absolute_path must be a non-empty string")
+
+    seed_int = int.from_bytes(
+        hashlib.sha256(absolute_path.encode("utf-8")).digest()[:8],
+        byteorder="big",
+        signed=False,
+    )
+    rng = random.Random(seed_int)
+    raw = [rng.gauss(0.0, 1.0) for _ in range(EMBEDDING_DIM)]
+    norm = math.sqrt(sum(v * v for v in raw))
+    if norm < 1e-12:
+        raise RuntimeError("degenerate vector (norm ≈ 0); should be statistically impossible")
+    vec = [v / norm for v in raw]
+    return EmbedResult(vec=vec, dim=EMBEDDING_DIM, model=MODEL_NAME)
+
+
+def path_is_reachable(absolute_path: str) -> bool:
+    """
+    Sanity-check helper used by the server before running the model. The stub
+    doesn't actually read the file, but we still want to reject obviously bad
+    inputs so phase-2 behaviour matches (CLAP *will* need to read the file).
+    """
+    try:
+        return Path(absolute_path).is_file()
+    except OSError:
+        return False

--- a/backend/python-services/audio-embedder/model.py
+++ b/backend/python-services/audio-embedder/model.py
@@ -1,24 +1,49 @@
 """
-Phase-1 stub embedder.
+CLAP-based audio embedder.
 
-Returns a deterministic 512-dim L2-normalised vector derived from a hash of
-the input path. Lets us exercise the wire protocol end-to-end before pulling
-in torch / transformers / CLAP weights in phase 2.
+Wraps `laion/clap-htsat-fused` (Apache-2.0) from HuggingFace transformers
+into a small, stateful module. The model is loaded once on first call and
+kept resident for the lifetime of the process.
 
-Shape and dimension match the planned CLAP output so the Node client and
-on-disk sidecar format won't need to change when the model is swapped in.
+Output:
+    - 512-dim L2-normalised vector.
+    - Same vector space as CLAP's text encoder (RoBERTa side), so a future
+      text-to-audio search feature works without re-embedding the library.
+
+For tracks longer than the model's native 10 s window, we encode three
+windows (start, middle, end), mean-pool the resulting embeddings, then
+re-normalise. For shorter tracks, we zero-pad to 10 s. This is the standard
+"global track representation" recipe in the CLAP literature.
 """
 
 from __future__ import annotations
 
-import hashlib
+import logging
 import math
-import random
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
+import numpy as np
+import torch
+from transformers import ClapModel, ClapProcessor
+
+MODEL_NAME = "laion/clap-htsat-fused"
 EMBEDDING_DIM = 512
-MODEL_NAME = "stub-deterministic-v1"
+SAMPLE_RATE = 48_000
+WINDOW_SECONDS = 10
+WINDOW_SAMPLES = SAMPLE_RATE * WINDOW_SECONDS
+NUM_WINDOWS = 3
+
+# Pin a single thread for inference — CLAP is small enough that multi-thread
+# matmul overhead exceeds the gain on most laptop CPUs, and we'd rather leave
+# cores free for the Node backend.
+torch.set_num_threads(int(os.environ.get("EMBEDDER_TORCH_THREADS", "1")))
+
+log = logging.getLogger("embedder.model")
+
+_model: ClapModel | None = None
+_processor: ClapProcessor | None = None
 
 
 @dataclass
@@ -28,35 +53,107 @@ class EmbedResult:
     model: str
 
 
+def _load() -> tuple[ClapModel, ClapProcessor]:
+    """
+    Load model + processor lazily on first call. After this returns once,
+    subsequent calls are a constant-time getter.
+    """
+    global _model, _processor
+    if _model is None or _processor is None:
+        log.info("Loading CLAP model: %s", MODEL_NAME)
+        _processor = ClapProcessor.from_pretrained(MODEL_NAME)
+        model = ClapModel.from_pretrained(MODEL_NAME)
+        model.eval()
+        _model = model
+        log.info("CLAP model loaded")
+    return _model, _processor
+
+
+def _load_audio(absolute_path: str) -> np.ndarray:
+    """
+    Decode audio to mono 48 kHz float32 via librosa. Librosa pulls in soundfile
+    + audioread; we import it lazily so phase-1 stub callers don't pay the cost.
+    """
+    import librosa
+
+    audio, _ = librosa.load(absolute_path, sr=SAMPLE_RATE, mono=True)
+    return audio.astype(np.float32, copy=False)
+
+
+def _select_windows(audio: np.ndarray) -> list[np.ndarray]:
+    """
+    Slice the audio into NUM_WINDOWS fixed-length clips. Padding tracks
+    shorter than WINDOW_SAMPLES is delegated to numpy; the processor would
+    also pad, but doing it here makes the batch shape deterministic.
+    """
+    if audio.size == 0:
+        raise ValueError("audio is empty after decoding")
+    if audio.size <= WINDOW_SAMPLES:
+        padded = np.zeros(WINDOW_SAMPLES, dtype=np.float32)
+        padded[: audio.size] = audio
+        return [padded]
+    # NUM_WINDOWS evenly-spaced start indices, including 0 and (len - window).
+    last_start = audio.size - WINDOW_SAMPLES
+    starts = np.linspace(0, last_start, NUM_WINDOWS, dtype=np.int64)
+    return [audio[s : s + WINDOW_SAMPLES] for s in starts]
+
+
+def _encode_windows(windows: list[np.ndarray]) -> np.ndarray:
+    """
+    Batch-encode windows through CLAP's audio tower. Returns a (N, 512)
+    float32 array.
+    """
+    model, processor = _load()
+    inputs = processor(
+        audios=windows,
+        sampling_rate=SAMPLE_RATE,
+        return_tensors="pt",
+    )
+    with torch.no_grad():
+        features = model.get_audio_features(**inputs)
+    return features.detach().cpu().numpy().astype(np.float32, copy=False)
+
+
 def embed_path(absolute_path: str) -> EmbedResult:
     """
-    Deterministic stub: same path in → same vector out. Does not read the file.
-    Phase 2 swaps this for an actual CLAP forward pass.
+    Produce a single 512-dim embedding for the audio at `absolute_path`.
+    Pure function from caller's view; mutates only the module-level model
+    cache on first call.
     """
     if not absolute_path:
         raise ValueError("absolute_path must be a non-empty string")
 
-    seed_int = int.from_bytes(
-        hashlib.sha256(absolute_path.encode("utf-8")).digest()[:8],
-        byteorder="big",
-        signed=False,
-    )
-    rng = random.Random(seed_int)
-    raw = [rng.gauss(0.0, 1.0) for _ in range(EMBEDDING_DIM)]
-    norm = math.sqrt(sum(v * v for v in raw))
+    audio = _load_audio(absolute_path)
+    windows = _select_windows(audio)
+    per_window = _encode_windows(windows)
+
+    pooled = per_window.mean(axis=0)
+    norm = float(np.linalg.norm(pooled))
     if norm < 1e-12:
-        raise RuntimeError("degenerate vector (norm ≈ 0); should be statistically impossible")
-    vec = [v / norm for v in raw]
+        raise RuntimeError("degenerate embedding (norm ≈ 0); CLAP returned zero vector?")
+    vec = (pooled / norm).tolist()
+    if len(vec) != EMBEDDING_DIM:
+        raise RuntimeError(
+            f"unexpected embedding dimension: got {len(vec)}, want {EMBEDDING_DIM}"
+        )
+    # math.isfinite guard: defensively reject NaN/Inf so we never persist a
+    # corrupt vector. Should be unreachable after the norm check above.
+    for v in vec:
+        if not math.isfinite(v):
+            raise RuntimeError("embedding contains non-finite values")
     return EmbedResult(vec=vec, dim=EMBEDDING_DIM, model=MODEL_NAME)
 
 
 def path_is_reachable(absolute_path: str) -> bool:
-    """
-    Sanity-check helper used by the server before running the model. The stub
-    doesn't actually read the file, but we still want to reject obviously bad
-    inputs so phase-2 behaviour matches (CLAP *will* need to read the file).
-    """
     try:
         return Path(absolute_path).is_file()
     except OSError:
         return False
+
+
+def warmup() -> None:
+    """
+    Optional pre-load. Lets the launcher pay the model-load cost (~10 s)
+    before accepting requests, instead of on the first POST.
+    """
+    _load()

--- a/backend/python-services/audio-embedder/requirements.txt
+++ b/backend/python-services/audio-embedder/requirements.txt
@@ -1,11 +1,18 @@
-# Phase 1 (stub) intentionally has no runtime dependencies — the sidecar uses
-# only Python 3.10+ stdlib (http.server, hashlib, json, dataclasses).
+# Phase 2 — pinned for CLAP (laion/clap-htsat-fused).
 #
-# Phase 2 will add:
-#   torch
-#   torchaudio
-#   transformers
-#   soundfile
-#   numpy
+# CPU-only torch build. If you need GPU, install with:
+#   pip install torch==2.5.1
+# instead (which auto-detects CUDA). The sidecar runs fine on CPU at the
+# library sizes flaque is built for.
 #
-# Pinned versions and hashes will be set when those land.
+# Versions chosen for compatibility with transformers' ClapModel as of
+# 2026-05. Bump together; the trio (torch, transformers, librosa) is the
+# only thing here that can drift.
+
+--extra-index-url https://download.pytorch.org/whl/cpu
+
+torch==2.5.1+cpu
+transformers==4.46.3
+librosa==0.10.2.post1
+soundfile==0.12.1
+numpy==1.26.4

--- a/backend/python-services/audio-embedder/requirements.txt
+++ b/backend/python-services/audio-embedder/requirements.txt
@@ -1,0 +1,11 @@
+# Phase 1 (stub) intentionally has no runtime dependencies — the sidecar uses
+# only Python 3.10+ stdlib (http.server, hashlib, json, dataclasses).
+#
+# Phase 2 will add:
+#   torch
+#   torchaudio
+#   transformers
+#   soundfile
+#   numpy
+#
+# Pinned versions and hashes will be set when those land.

--- a/backend/python-services/audio-embedder/sanity_check.py
+++ b/backend/python-services/audio-embedder/sanity_check.py
@@ -1,0 +1,104 @@
+"""
+Manual sanity check for embedder output.
+
+Calls the running sidecar (POST /embed) for a set of tracks supplied on the
+CLI, then prints a cosine-similarity matrix. Operator inspects the matrix
+and decides whether the ordering matches musical intuition.
+
+This script is intentionally minimal — no scoring, no thresholds, no
+pass/fail return code. The phase-2 acceptance gate from setup.md asks for
+a human judgement, and this is the scaffolding that makes that judgement
+easy to make.
+
+Usage:
+    .venv/bin/python sanity_check.py \\
+        pf_a=/abs/path/to/floyd/track1.flac \\
+        pf_b=/abs/path/to/floyd/track2.flac \\
+        metal=/abs/path/to/architects/track.flac
+
+Each argument is `label=path`. Labels appear in the matrix axes; keep them
+short (≤ 5 chars renders cleanest). If you omit the `label=` prefix, the
+filename stem is used.
+
+Reads AUDIO_EMBEDDER_URL from the environment (default http://127.0.0.1:7001),
+same as the Node client.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+EMBEDDER_URL = os.environ.get("AUDIO_EMBEDDER_URL", "http://127.0.0.1:7001")
+
+
+def embed(absolute_path: str) -> list[float]:
+    body = json.dumps({"absolutePath": absolute_path}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{EMBEDDER_URL}/embed",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        payload = json.loads(resp.read())
+    return payload["vec"]
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    return dot / (na * nb) if na > 0 and nb > 0 else 0.0
+
+
+def parse_spec(spec: str) -> tuple[str, str]:
+    if "=" in spec:
+        label, path = spec.split("=", 1)
+    else:
+        path = spec
+        label = Path(spec).stem[:8]
+    return label, path
+
+
+def main(specs: list[str]) -> int:
+    if not specs:
+        sys.stderr.write(__doc__ or "")
+        return 1
+
+    pairs = [parse_spec(s) for s in specs]
+    print(f"[sanity] embedding {len(pairs)} tracks via {EMBEDDER_URL} ...")
+
+    vectors: dict[str, list[float]] = {}
+    for label, path in pairs:
+        if not os.path.isfile(path):
+            print(f"  ! skip {label}: file missing ({path})")
+            continue
+        try:
+            vec = embed(path)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  ! fail {label}: {exc}")
+            continue
+        vectors[label] = vec
+        print(f"  ok {label} (norm={math.sqrt(sum(v * v for v in vec)):.4f})")
+
+    if len(vectors) < 2:
+        print("[sanity] need ≥ 2 successful embeddings to compare")
+        return 2
+
+    labels = list(vectors.keys())
+    width = max(len(l) for l in labels)
+    print()
+    print(" " * (width + 2) + "  ".join(f"{l:>5.5}" for l in labels))
+    for a in labels:
+        row = [f"{cosine(vectors[a], vectors[b]):+.2f}" for b in labels]
+        print(f"{a:<{width}}  " + "  ".join(f"{v:>5}" for v in row))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/backend/python-services/audio-embedder/server.py
+++ b/backend/python-services/audio-embedder/server.py
@@ -24,7 +24,7 @@ from urllib.parse import urlparse
 # Allow `python server.py` from the package dir and from the repo root.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from model import MODEL_NAME, embed_path, path_is_reachable
+from model import MODEL_NAME, embed_path, path_is_reachable, warmup
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 7001
@@ -101,6 +101,15 @@ def main() -> None:
     except ValueError:
         sys.stderr.write(f"[embedder] invalid EMBEDDER_PORT, falling back to {DEFAULT_PORT}\n")
         port = DEFAULT_PORT
+
+    if os.environ.get("EMBEDDER_WARMUP", "1") not in ("0", "false", "no", ""):
+        sys.stderr.write("[embedder] warming up model (this can take ~10 s)\n")
+        try:
+            warmup()
+            sys.stderr.write("[embedder] model warm\n")
+        except Exception as exc:  # noqa: BLE001 — surface any startup error
+            sys.stderr.write(f"[embedder] warmup failed: {exc}\n")
+            sys.exit(2)
 
     server = ThreadingHTTPServer((host, port), EmbedderHandler)
     sys.stderr.write(f"[embedder] listening on http://{host}:{port} (model={MODEL_NAME})\n")

--- a/backend/python-services/audio-embedder/server.py
+++ b/backend/python-services/audio-embedder/server.py
@@ -1,0 +1,116 @@
+"""
+Audio-embedder HTTP sidecar.
+
+Phase 1: stdlib http.server only — no FastAPI / uvicorn dependency until we
+actually need them in phase 2 (real CLAP needs torch + transformers, at which
+point a real ASGI server is justified). For now the surface area is tiny:
+
+    GET  /healthz       → { ok: true, model: "..." }
+    POST /embed         → { vec: [...], dim: 512, model: "..." }
+                          body: { absolutePath: "/abs/path/to/file" }
+
+Bind: 127.0.0.1:7001 by default (loopback only). Override with EMBEDDER_HOST
+and EMBEDDER_PORT env vars.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+# Allow `python server.py` from the package dir and from the repo root.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from model import MODEL_NAME, embed_path, path_is_reachable
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 7001
+MAX_BODY_BYTES = 64 * 1024
+
+
+class EmbedderHandler(BaseHTTPRequestHandler):
+    server_version = "FlaqueEmbedder/0.1"
+
+    def _send_json(self, status: int, body: dict) -> None:
+        payload = json.dumps(body).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, fmt: str, *args) -> None:
+        # Quieter default logging; the parent process can capture stdout.
+        sys.stderr.write("[embedder] " + (fmt % args) + "\n")
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/healthz":
+            self._send_json(200, {"ok": True, "model": MODEL_NAME})
+            return
+        self._send_json(404, {"error": "not_found", "path": parsed.path})
+
+    def do_POST(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path != "/embed":
+            self._send_json(404, {"error": "not_found", "path": parsed.path})
+            return
+
+        try:
+            length = int(self.headers.get("Content-Length") or "0")
+        except ValueError:
+            self._send_json(400, {"error": "invalid_content_length"})
+            return
+
+        if length <= 0 or length > MAX_BODY_BYTES:
+            self._send_json(400, {"error": "invalid_body_size", "length": length})
+            return
+
+        try:
+            raw = self.rfile.read(length)
+            body = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            self._send_json(400, {"error": "invalid_json", "detail": str(exc)})
+            return
+
+        absolute_path = body.get("absolutePath") if isinstance(body, dict) else None
+        if not isinstance(absolute_path, str) or not absolute_path:
+            self._send_json(400, {"error": "missing_absolutePath"})
+            return
+
+        if not path_is_reachable(absolute_path):
+            self._send_json(404, {"error": "file_not_found", "absolutePath": absolute_path})
+            return
+
+        try:
+            result = embed_path(absolute_path)
+        except Exception as exc:
+            self._send_json(500, {"error": "embed_failed", "detail": str(exc)})
+            return
+
+        self._send_json(200, {"vec": result.vec, "dim": result.dim, "model": result.model})
+
+
+def main() -> None:
+    host = os.environ.get("EMBEDDER_HOST", DEFAULT_HOST)
+    try:
+        port = int(os.environ.get("EMBEDDER_PORT", str(DEFAULT_PORT)))
+    except ValueError:
+        sys.stderr.write(f"[embedder] invalid EMBEDDER_PORT, falling back to {DEFAULT_PORT}\n")
+        port = DEFAULT_PORT
+
+    server = ThreadingHTTPServer((host, port), EmbedderHandler)
+    sys.stderr.write(f"[embedder] listening on http://{host}:{port} (model={MODEL_NAME})\n")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        sys.stderr.write("[embedder] shutting down\n")
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/python-services/audio-embedder/setup.md
+++ b/backend/python-services/audio-embedder/setup.md
@@ -1,0 +1,61 @@
+# audio-embedder sidecar
+
+Local-only HTTP service that produces audio embeddings on request. Lives next
+to the Node backend because nothing else is going to call it — same machine,
+same lifecycle.
+
+## Status
+
+**Phase 1 — stub.** Returns a deterministic 512-dim vector derived from a
+hash of the requested path. No audio is decoded, no model is loaded. The
+purpose is to validate the wire protocol between Node and Python before we
+pull in torch / transformers in phase 2.
+
+## Run it
+
+```
+./start.sh
+```
+
+Listens on `http://127.0.0.1:7001` by default. Override with `EMBEDDER_HOST`
+and `EMBEDDER_PORT` env vars.
+
+Requires Python ≥ 3.10. No `pip install` needed in phase 1 — stdlib only.
+
+## Endpoints
+
+### `GET /healthz`
+
+```
+$ curl -s http://127.0.0.1:7001/healthz
+{"ok": true, "model": "stub-deterministic-v1"}
+```
+
+### `POST /embed`
+
+```
+$ curl -s -X POST http://127.0.0.1:7001/embed \
+    -H 'Content-Type: application/json' \
+    -d '{"absolutePath": "/path/to/some/track.mp3"}'
+{"vec": [0.0123, ...], "dim": 512, "model": "stub-deterministic-v1"}
+```
+
+The path must exist on disk. The stub does not actually read the file — it
+only checks reachability so phase-1 behaviour matches what phase 2 will
+require (CLAP needs to read the audio).
+
+Errors:
+
+| Status | Body                                       | Meaning                          |
+|--------|--------------------------------------------|----------------------------------|
+| 400    | `{ error: "missing_absolutePath" }`        | Body missing or wrong type       |
+| 400    | `{ error: "invalid_json" }`                | Body not valid JSON              |
+| 404    | `{ error: "file_not_found" }`              | Path doesn't resolve to a file   |
+| 500    | `{ error: "embed_failed", detail: "..." }` | Anything raised inside the model |
+
+## What changes in phase 2
+
+- `requirements.txt` gains torch, torchaudio, transformers, soundfile.
+- `model.py` swaps the deterministic stub for `laion/clap-htsat-fused`.
+- `start.sh` creates and activates a venv, installs deps on first run.
+- This doc gets a real "system requirements" section (RAM, cold-start time).

--- a/backend/python-services/audio-embedder/setup.md
+++ b/backend/python-services/audio-embedder/setup.md
@@ -1,15 +1,24 @@
 # audio-embedder sidecar
 
-Local-only HTTP service that produces audio embeddings on request. Lives next
-to the Node backend because nothing else is going to call it — same machine,
-same lifecycle.
+Local-only HTTP service that produces 512-dim audio embeddings using
+CLAP (`laion/clap-htsat-fused`, Apache-2.0). Lives next to the Node backend
+because nothing else is going to call it — same machine, same lifecycle.
 
 ## Status
 
-**Phase 1 — stub.** Returns a deterministic 512-dim vector derived from a
-hash of the requested path. No audio is decoded, no model is loaded. The
-purpose is to validate the wire protocol between Node and Python before we
-pull in torch / transformers in phase 2.
+**Phase 2 — real model.** Returns CLAP's 512-dim joint-space embedding for
+the audio at the requested path. Loaded once at startup; subsequent requests
+share the resident model. Not yet wired into production embedding code
+(`computeAndSaveEmbedding` still uses the in-process MFCC pipeline). Phase 3
+swaps the production call site.
+
+## System requirements
+
+- Python ≥ 3.10 (tested on 3.12).
+- ~1.2 GB disk for the venv (torch CPU + transformers + librosa).
+- ~600 MB disk for CLAP weights (cached under `~/.cache/huggingface/`).
+- ~1 GB resident RAM while running.
+- ffmpeg installed at the OS level (librosa pulls it in for non-WAV formats).
 
 ## Run it
 
@@ -17,10 +26,17 @@ pull in torch / transformers in phase 2.
 ./start.sh
 ```
 
-Listens on `http://127.0.0.1:7001` by default. Override with `EMBEDDER_HOST`
-and `EMBEDDER_PORT` env vars.
+First run creates a `.venv/` here and installs the pinned deps from
+`requirements.txt`. Subsequent runs reuse the venv and start in seconds,
+plus the ~10 s CLAP load (logged as "warming up model" then "model warm").
 
-Requires Python ≥ 3.10. No `pip install` needed in phase 1 — stdlib only.
+Override host/port via env vars: `EMBEDDER_HOST`, `EMBEDDER_PORT`.
+Defaults to `127.0.0.1:7001`. The Node backend reads
+`AUDIO_EMBEDDER_URL` (default `http://127.0.0.1:7001`).
+
+Set `EMBEDDER_WARMUP=0` to skip the eager model load (first POST pays it
+instead) — useful for unit testing the HTTP surface without sitting through
+the warmup.
 
 ## Endpoints
 
@@ -28,7 +44,7 @@ Requires Python ≥ 3.10. No `pip install` needed in phase 1 — stdlib only.
 
 ```
 $ curl -s http://127.0.0.1:7001/healthz
-{"ok": true, "model": "stub-deterministic-v1"}
+{"ok": true, "model": "laion/clap-htsat-fused"}
 ```
 
 ### `POST /embed`
@@ -36,13 +52,14 @@ $ curl -s http://127.0.0.1:7001/healthz
 ```
 $ curl -s -X POST http://127.0.0.1:7001/embed \
     -H 'Content-Type: application/json' \
-    -d '{"absolutePath": "/path/to/some/track.mp3"}'
-{"vec": [0.0123, ...], "dim": 512, "model": "stub-deterministic-v1"}
+    -d '{"absolutePath": "/abs/path/to/track.mp3"}'
+{"vec": [0.0123, ...], "dim": 512, "model": "laion/clap-htsat-fused"}
 ```
 
-The path must exist on disk. The stub does not actually read the file — it
-only checks reachability so phase-1 behaviour matches what phase 2 will
-require (CLAP needs to read the audio).
+For tracks longer than 10 s, the model receives three evenly-spaced 10 s
+windows; the resulting embeddings are mean-pooled and L2-normalised so
+cosine similarity remains a meaningful comparator. Tracks shorter than 10 s
+are zero-padded.
 
 Errors:
 
@@ -51,11 +68,51 @@ Errors:
 | 400    | `{ error: "missing_absolutePath" }`        | Body missing or wrong type       |
 | 400    | `{ error: "invalid_json" }`                | Body not valid JSON              |
 | 404    | `{ error: "file_not_found" }`              | Path doesn't resolve to a file   |
-| 500    | `{ error: "embed_failed", detail: "..." }` | Anything raised inside the model |
+| 500    | `{ error: "embed_failed", detail: "..." }` | Decode or inference failure      |
 
-## What changes in phase 2
+## Tests
 
-- `requirements.txt` gains torch, torchaudio, transformers, soundfile.
-- `model.py` swaps the deterministic stub for `laion/clap-htsat-fused`.
-- `start.sh` creates and activates a venv, installs deps on first run.
-- This doc gets a real "system requirements" section (RAM, cold-start time).
+```
+./.venv/bin/python -m unittest discover -s tests -v
+```
+
+Covers windowing math, path-reachability helper, contract validation. Does
+*not* load the CLAP model — that's reserved for the sanity check below.
+
+## Sanity check (manual, phase 2 acceptance)
+
+The eval bar for phase 2 is: pick ~10 track pairs and confirm cosine
+ordering matches musical intuition. There is no automated scorer for this;
+the operator hears the result and makes the call.
+
+Suggested procedure:
+
+1. Start the sidecar (`./start.sh`); wait for "model warm".
+2. From the backend root, run `npm run embed:probe -- /abs/path/track.mp3`
+   for ~10 tracks. Copy each returned vector into a scratch file.
+3. Compute cosine similarity between selected pairs (a small ad-hoc Python
+   REPL is fine). Sanity expectations:
+   - Two tracks by the same artist from the same album: high (≥ 0.6).
+   - Same genre, different artists: moderate (~0.3–0.6).
+   - Wildly different styles (e.g. classical vs. extreme metal): low
+     (< 0.2).
+4. If ordering disagrees with a human listener in obvious ways, log the
+   counterexamples and discuss before proceeding to phase 3.
+
+## Memory-leak smoke test
+
+CLAP allocates lazily during the first few inferences. After ~10 warm-up
+calls, RSS should stabilise. To verify:
+
+```
+pid=$(pgrep -f python-services/audio-embedder/server.py)
+ps -o rss= -p "$pid"          # before
+for i in $(seq 1 100); do
+  npm run --silent embed:probe -- /abs/path/to/some/track.mp3 > /dev/null
+done
+ps -o rss= -p "$pid"          # after
+```
+
+A small bump on the first ~10 calls is expected; sustained growth past
+that indicates a leak (file an issue with the request pattern that
+triggered it).

--- a/backend/python-services/audio-embedder/start.sh
+++ b/backend/python-services/audio-embedder/start.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Launch the audio-embedder sidecar.
+#
+# Phase 1: stdlib-only, no virtualenv required. Phase 2 will add a venv +
+# requirements.txt installation step here.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$here/server.py" "$@"

--- a/backend/python-services/audio-embedder/start.sh
+++ b/backend/python-services/audio-embedder/start.sh
@@ -1,9 +1,32 @@
 #!/usr/bin/env bash
 # Launch the audio-embedder sidecar.
 #
-# Phase 1: stdlib-only, no virtualenv required. Phase 2 will add a venv +
-# requirements.txt installation step here.
+# On first run, creates a .venv next to this script, installs the pinned
+# requirements (torch CPU + transformers + librosa, ~1.2 GB on disk + ~600 MB
+# for CLAP weights in ~/.cache/huggingface/ on first model load).
+#
+# Subsequent runs reuse the venv and start in a couple of seconds, plus the
+# ~10 s CLAP load itself.
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$here/server.py" "$@"
+venv="$here/.venv"
+req="$here/requirements.txt"
+
+if [[ ! -x "$venv/bin/python" ]]; then
+  echo "[embedder] no venv at $venv — creating it" >&2
+  python3 -m venv "$venv"
+fi
+
+# Install / refresh deps if the requirements have changed since the last run.
+# Cheap idempotency: hash the requirements file and compare against a marker.
+req_hash="$(sha256sum "$req" | cut -d' ' -f1)"
+marker="$venv/.requirements.sha256"
+if [[ ! -f "$marker" || "$(cat "$marker")" != "$req_hash" ]]; then
+  echo "[embedder] installing pinned deps from $req" >&2
+  "$venv/bin/pip" install --upgrade pip >/dev/null
+  "$venv/bin/pip" install -r "$req"
+  echo "$req_hash" > "$marker"
+fi
+
+exec "$venv/bin/python" "$here/server.py" "$@"

--- a/backend/python-services/audio-embedder/tests/test_model.py
+++ b/backend/python-services/audio-embedder/tests/test_model.py
@@ -1,48 +1,112 @@
 """
-Python-side unit tests for the stub model.
+Unit tests for the audio-embedder model helpers.
 
-Run with: python3 -m unittest discover -s tests
-(from the audio-embedder/ directory)
+Phase 2 model.py imports torch + transformers at module load time, so these
+tests must run from inside the venv populated by start.sh / requirements.txt.
+The tests themselves intentionally avoid loading CLAP: that's an integration
+concern with a ~10 s cold start and a ~600 MB weight download, neither of
+which belongs in a unit-test loop.
+
+Run with:
+    ./.venv/bin/python -m unittest discover -s tests
+(from backend/python-services/audio-embedder/)
 """
 
 from __future__ import annotations
 
-import math
 import os
 import sys
+import tempfile
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from model import EMBEDDING_DIM, MODEL_NAME, embed_path  # noqa: E402
+try:
+    import numpy as np
+    from model import (  # noqa: E402
+        EMBEDDING_DIM,
+        MODEL_NAME,
+        NUM_WINDOWS,
+        WINDOW_SAMPLES,
+        _select_windows,
+        embed_path,
+        path_is_reachable,
+    )
+
+    DEPS_AVAILABLE = True
+except ImportError as exc:
+    DEPS_AVAILABLE = False
+    _import_error = exc
 
 
-class StubModelTests(unittest.TestCase):
-    def test_deterministic_for_same_path(self) -> None:
-        a = embed_path("/tmp/example/track.mp3")
-        b = embed_path("/tmp/example/track.mp3")
-        self.assertEqual(a.vec, b.vec)
-        self.assertEqual(a.model, MODEL_NAME)
+@unittest.skipUnless(DEPS_AVAILABLE, "phase-2 deps not installed; activate the venv first")
+class WindowingTests(unittest.TestCase):
+    def test_short_audio_pads_to_one_window(self) -> None:
+        audio = np.linspace(-1.0, 1.0, WINDOW_SAMPLES // 2, dtype=np.float32)
+        windows = _select_windows(audio)
+        self.assertEqual(len(windows), 1)
+        self.assertEqual(windows[0].shape[0], WINDOW_SAMPLES)
+        # First half should preserve the input; second half should be zero.
+        np.testing.assert_array_equal(windows[0][: audio.size], audio)
+        self.assertTrue(np.all(windows[0][audio.size :] == 0.0))
 
-    def test_different_paths_yield_different_vectors(self) -> None:
-        a = embed_path("/tmp/a.mp3").vec
-        b = embed_path("/tmp/b.mp3").vec
-        self.assertNotEqual(a, b)
+    def test_window_sized_audio_yields_one_window(self) -> None:
+        audio = np.ones(WINDOW_SAMPLES, dtype=np.float32)
+        windows = _select_windows(audio)
+        self.assertEqual(len(windows), 1)
+        np.testing.assert_array_equal(windows[0], audio)
 
-    def test_dimension_matches_constant(self) -> None:
-        result = embed_path("/tmp/dim-check.mp3")
-        self.assertEqual(result.dim, EMBEDDING_DIM)
-        self.assertEqual(len(result.vec), EMBEDDING_DIM)
+    def test_long_audio_yields_num_windows(self) -> None:
+        # 30 s synthetic noise → three 10 s windows.
+        audio = np.random.RandomState(0).randn(WINDOW_SAMPLES * 3).astype(np.float32)
+        windows = _select_windows(audio)
+        self.assertEqual(len(windows), NUM_WINDOWS)
+        for w in windows:
+            self.assertEqual(w.shape[0], WINDOW_SAMPLES)
+        # First window starts at 0, last window ends at the last sample.
+        np.testing.assert_array_equal(windows[0], audio[:WINDOW_SAMPLES])
+        np.testing.assert_array_equal(windows[-1], audio[-WINDOW_SAMPLES:])
 
-    def test_l2_normalised(self) -> None:
-        vec = embed_path("/tmp/norm-check.mp3").vec
-        norm = math.sqrt(sum(v * v for v in vec))
-        self.assertAlmostEqual(norm, 1.0, places=6)
+    def test_empty_audio_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _select_windows(np.zeros(0, dtype=np.float32))
+
+
+@unittest.skipUnless(DEPS_AVAILABLE, "phase-2 deps not installed; activate the venv first")
+class PathHelperTests(unittest.TestCase):
+    def test_existing_file_is_reachable(self) -> None:
+        with tempfile.NamedTemporaryFile() as tmp:
+            self.assertTrue(path_is_reachable(tmp.name))
+
+    def test_missing_file_is_not_reachable(self) -> None:
+        self.assertFalse(path_is_reachable("/nonexistent/at/all.mp3"))
+
+    def test_empty_string_is_not_reachable(self) -> None:
+        self.assertFalse(path_is_reachable(""))
+
+
+@unittest.skipUnless(DEPS_AVAILABLE, "phase-2 deps not installed; activate the venv first")
+class EmbedPathContractTests(unittest.TestCase):
+    """
+    Contract checks that don't require loading the actual CLAP model. These
+    cover the validation branches before _load() is ever called.
+    """
 
     def test_empty_path_rejected(self) -> None:
         with self.assertRaises(ValueError):
             embed_path("")
 
+    def test_module_constants(self) -> None:
+        self.assertEqual(EMBEDDING_DIM, 512)
+        self.assertEqual(MODEL_NAME, "laion/clap-htsat-fused")
+
 
 if __name__ == "__main__":
+    if not DEPS_AVAILABLE:
+        sys.stderr.write(
+            f"phase-2 deps not importable ({_import_error}). "
+            "Run start.sh once to create the venv, then re-run with "
+            "./.venv/bin/python -m unittest discover -s tests\n"
+        )
+        sys.exit(1)
     unittest.main()

--- a/backend/python-services/audio-embedder/tests/test_model.py
+++ b/backend/python-services/audio-embedder/tests/test_model.py
@@ -1,0 +1,48 @@
+"""
+Python-side unit tests for the stub model.
+
+Run with: python3 -m unittest discover -s tests
+(from the audio-embedder/ directory)
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from model import EMBEDDING_DIM, MODEL_NAME, embed_path  # noqa: E402
+
+
+class StubModelTests(unittest.TestCase):
+    def test_deterministic_for_same_path(self) -> None:
+        a = embed_path("/tmp/example/track.mp3")
+        b = embed_path("/tmp/example/track.mp3")
+        self.assertEqual(a.vec, b.vec)
+        self.assertEqual(a.model, MODEL_NAME)
+
+    def test_different_paths_yield_different_vectors(self) -> None:
+        a = embed_path("/tmp/a.mp3").vec
+        b = embed_path("/tmp/b.mp3").vec
+        self.assertNotEqual(a, b)
+
+    def test_dimension_matches_constant(self) -> None:
+        result = embed_path("/tmp/dim-check.mp3")
+        self.assertEqual(result.dim, EMBEDDING_DIM)
+        self.assertEqual(len(result.vec), EMBEDDING_DIM)
+
+    def test_l2_normalised(self) -> None:
+        vec = embed_path("/tmp/norm-check.mp3").vec
+        norm = math.sqrt(sum(v * v for v in vec))
+        self.assertAlmostEqual(norm, 1.0, places=6)
+
+    def test_empty_path_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            embed_path("")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/src/api/library/librarySettings.ts
+++ b/backend/src/api/library/librarySettings.ts
@@ -1,0 +1,48 @@
+import { Router } from "express";
+
+import { requireAdmin, requireAuth } from "../../auth/middleware";
+import {
+  getLibrarySettings,
+  updateLibrarySettings
+} from "../../services/librarySettings/librarySettings";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("library-settings");
+
+export function createLibrarySettingsRouter(): Router {
+  const router = Router();
+
+  router.get("/library/settings", requireAuth, requireAdmin, async (_req, res, next) => {
+    try {
+      const settings = await getLibrarySettings();
+      res.json(settings);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.patch("/library/settings", requireAuth, requireAdmin, async (req, res, next) => {
+    try {
+      const body = req.body as Record<string, unknown>;
+      const patch: { aiRecommendation?: boolean } = {};
+      if (typeof body.aiRecommendation === "boolean") {
+        patch.aiRecommendation = body.aiRecommendation;
+      }
+
+      const updated = await updateLibrarySettings(patch);
+
+      if (Object.keys(patch).length > 0) {
+        log.info("Library settings updated", {
+          userId: req.authUser?.id ?? "unknown",
+          changes: patch
+        });
+      }
+
+      res.json(updated);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/backend/src/api/libraryRoutes.ts
+++ b/backend/src/api/libraryRoutes.ts
@@ -3,6 +3,7 @@ import { Router } from "express";
 import type { IndexStore } from "../services/indexer/indexStore";
 import { createAlbumRouter } from "./library/albums";
 import { createArtistRouter } from "./library/artists";
+import { createLibrarySettingsRouter } from "./library/librarySettings";
 import { createLibraryOverviewRouter } from "./library/overview";
 import { createTrackMutationRouter } from "./library/trackAdmin";
 import { createTrackQueryRouter } from "./library/tracks";
@@ -15,6 +16,7 @@ export function createLibraryRouter(indexStore: IndexStore): Router {
   router.use(createTrackMutationRouter(indexStore));
   router.use(createArtistRouter(indexStore));
   router.use(createAlbumRouter(indexStore));
+  router.use(createLibrarySettingsRouter());
 
   return router;
 }

--- a/backend/src/scripts/backfillEmbeddings.ts
+++ b/backend/src/scripts/backfillEmbeddings.ts
@@ -1,0 +1,52 @@
+/**
+ * CLI hook for the audio-embedding backfill.
+ *
+ * Usage:
+ *   npm run embed:backfill
+ *
+ * Loads the index, finds all tracks without a current-version embedding
+ * sidecar, and computes one via the Python sidecar. Sequential — the
+ * sidecar is single-threaded by design.
+ *
+ * The same backfill runs automatically on server start (see server.ts);
+ * this CLI is for running it interactively after bumping EMBEDDING_VERSION
+ * or after pointing AUDIO_EMBEDDER_URL at a different sidecar.
+ *
+ * Prerequisite: the sidecar must be running.
+ *   ./python-services/audio-embedder/start.sh
+ */
+import process from "node:process";
+
+import { backfillMissingEmbeddings } from "../services/embeddings/audioEmbeddingService";
+import { pingEmbedder } from "../services/embeddings/embedderClient";
+import { IndexStore } from "../services/indexer/indexStore";
+
+async function main(): Promise<void> {
+  const health = await pingEmbedder();
+  if (!health) {
+    console.error("[backfill] sidecar /healthz unreachable. Start it first:");
+    console.error("[backfill]   ./python-services/audio-embedder/start.sh");
+    process.exit(2);
+  }
+  console.log(`[backfill] sidecar healthy: model=${health.model}`);
+
+  const indexStore = new IndexStore();
+  await indexStore.initialize();
+  if (indexStore.getSnapshot().totalTracks === 0) {
+    console.log("[backfill] index empty; rebuilding from disk first");
+    await indexStore.rebuild();
+  }
+
+  const tracks = indexStore.getSnapshot().tracks.map((t) => ({ id: t.id, path: t.path }));
+  console.log(`[backfill] scanning ${tracks.length} tracks`);
+
+  const result = await backfillMissingEmbeddings(tracks, { logEvery: 10 });
+  console.log(
+    `[backfill] done: computed=${result.computed} skipped=${result.skipped} failed=${result.failed}`
+  );
+}
+
+void main().catch((error) => {
+  console.error("[backfill] unexpected error", error);
+  process.exit(99);
+});

--- a/backend/src/scripts/backfillEmbeddings.ts
+++ b/backend/src/scripts/backfillEmbeddings.ts
@@ -9,7 +9,7 @@
  * sidecar is single-threaded by design.
  *
  * The same backfill runs automatically on server start (see server.ts);
- * this CLI is for running it interactively after bumping EMBEDDING_VERSION
+ * this CLI is for running it interactively after bumping CLAP_EMBEDDING_VERSION
  * or after pointing AUDIO_EMBEDDER_URL at a different sidecar.
  *
  * Prerequisite: the sidecar must be running.

--- a/backend/src/scripts/inspectForYouTrace.ts
+++ b/backend/src/scripts/inspectForYouTrace.ts
@@ -1,0 +1,192 @@
+/**
+ * Pretty-printer for the for-you trace files.
+ *
+ * Usage:
+ *   npm run for-you:inspect                # all users with a saved trace
+ *   npm run for-you:inspect -- <userId>    # one user
+ *
+ * Surfaces, per playlist:
+ *   - Ranker snapshot (weights + embedding version) so picks stay
+ *     interpretable across weight tweaks.
+ *   - Seed selection: which artists were chosen, which were skipped, why.
+ *   - Top picks with per-feature contributions (embedding cosine is the
+ *     primary signal post-phase-4, so it's the leftmost numeric column).
+ *   - Top rejections with the same breakdown.
+ *
+ * Read-only — opens trace JSON files on disk via loadForYouTrace, does not
+ * touch the index store or the running server.
+ */
+import process from "node:process";
+
+import { listUsers } from "../auth/db";
+import { initializeAuthDatabase } from "../auth/dbConnection";
+import { IndexStore } from "../services/indexer/indexStore";
+import type { ForYouPlaylistTrace, ForYouTrace, ScoredTrackTrace } from "../services/playlists/playlistTrace";
+import { loadForYouTrace } from "../services/playlists/forYou/trace";
+
+function fmtScore(n: number): string {
+  const sign = n >= 0 ? " " : "-";
+  return `${sign}${Math.abs(n).toFixed(2)}`;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+function trackLabel(indexStore: IndexStore, entry: ScoredTrackTrace): string {
+  const t = indexStore.getTrackById(entry.trackId);
+  const title = t?.tags.title ?? "(missing)";
+  const artist = t?.tags.artist ?? entry.artist;
+  return `${artist} — ${title}`;
+}
+
+function printRankerHeader(trace: ForYouTrace): void {
+  if (!trace.ranker) {
+    console.log("  ranker: (snapshot not captured; trace pre-dates phase 5)");
+    return;
+  }
+  const w = trace.ranker.weights;
+  console.log(
+    `  ranker: emb=${w.embeddingSimilarity}  genre=${w.genreOverlap}  ` +
+      `year=${w.yearProximity}  novelty=${w.novelty}  pop=${w.libraryPopularity}  ` +
+      `(embedding v${trace.ranker.embeddingVersion}, ${trace.ranker.embeddingDim}-dim)`
+  );
+  const f = trace.ranker.candidateFilters;
+  if (f) {
+    const parts = Object.entries(f).map(([k, v]) => `${k}=${v}`);
+    console.log(`  pre-rank filters: ${parts.join("  ")}`);
+  }
+}
+
+function printSeeds(trace: ForYouTrace): void {
+  const sel = trace.seedSelection;
+  const chosen = new Set(sel.chosen);
+  console.log(`\n  Seeds (${sel.chosen.length} chosen, ${sel.skipped.length} skipped):`);
+  for (const c of sel.candidates.slice(0, 8)) {
+    const mark = chosen.has(c.artist) ? "✓" : " ";
+    console.log(
+      `    ${mark} ${c.artist.padEnd(28)} score=${c.score.toFixed(2).padStart(6)}  ` +
+        `sources=${c.sources.join(",")}`
+    );
+  }
+  for (const s of sel.skipped) {
+    console.log(`    ✗ ${s.artist.padEnd(28)} skipped (${s.reason})`);
+  }
+}
+
+function printPlaylist(playlist: ForYouPlaylistTrace, indexStore: IndexStore): void {
+  console.log(
+    `\n  ▶ "${playlist.playlistName ?? `(seed: ${playlist.seed})`}"` +
+      `   ${playlist.finalTrackIds.length} tracks · ${playlist.candidatePoolSize} candidates`
+  );
+  if (playlist.rejection) {
+    console.log(`    rejected: ${playlist.rejection}`);
+    return;
+  }
+
+  const finalOrder = playlist.finalOrder ?? [];
+  if (finalOrder.length === 0) {
+    console.log("    (no per-track trace available)");
+    return;
+  }
+
+  const picks = finalOrder;
+  const featureAverages = {
+    emb: mean(picks.map((p) => p.features.embeddingSimilarity)),
+    genre: mean(picks.map((p) => p.features.genreOverlap)),
+    year: mean(picks.map((p) => p.features.yearProximity)),
+    novelty: mean(picks.map((p) => p.features.novelty))
+  };
+  console.log(
+    `    picked averages:  emb=${featureAverages.emb.toFixed(2)}  ` +
+      `genre=${featureAverages.genre.toFixed(2)}  ` +
+      `year=${featureAverages.year.toFixed(2)}  ` +
+      `novelty=${featureAverages.novelty.toFixed(2)}`
+  );
+
+  console.log("    top picks (by raw score):");
+  const topPicks = [...picks].sort((a, b) => b.score - a.score).slice(0, 5);
+  for (let i = 0; i < topPicks.length; i++) {
+    const p = topPicks[i]!;
+    const f = p.features;
+    console.log(
+      `      #${(i + 1).toString().padStart(2)} ` +
+        `${trackLabel(indexStore, p).padEnd(60).slice(0, 60)}  ` +
+        `score=${fmtScore(p.score)}  ` +
+        `emb=${f.embeddingSimilarity.toFixed(2)}  ` +
+        `genre=${f.genreOverlap.toFixed(2)}  ` +
+        `year=${f.yearProximity.toFixed(2)}  ` +
+        `src=${p.source ?? "-"}`
+    );
+  }
+
+  const rejections = playlist.topRejections ?? [];
+  if (rejections.length > 0) {
+    console.log("    top rejections:");
+    for (const r of rejections.slice(0, 3)) {
+      const f = r.features;
+      console.log(
+        `      -- ${trackLabel(indexStore, r).padEnd(60).slice(0, 60)}  ` +
+          `score=${fmtScore(r.score)}  ` +
+          `emb=${f.embeddingSimilarity.toFixed(2)}  ` +
+          `genre=${f.genreOverlap.toFixed(2)}  ` +
+          `reason=${r.rejection ?? "-"}`
+      );
+    }
+  }
+}
+
+async function inspectUser(userId: string, indexStore: IndexStore): Promise<void> {
+  console.log(`\n=== user ${userId} ===`);
+  const trace = await loadForYouTrace(userId);
+  if (!trace) {
+    console.log("  (no trace on disk — has for-you regenerated for this user?)");
+    return;
+  }
+
+  console.log(
+    `  generated ${trace.generatedAt}  duration=${trace.durationMs}ms  ` +
+      `${trace.totalPlays} plays  ${trace.distinctArtists} distinct artists`
+  );
+  if (trace.skipReason) {
+    console.log(`  skipped: ${trace.skipReason}`);
+    return;
+  }
+  printRankerHeader(trace);
+  printSeeds(trace);
+
+  for (const playlist of trace.playlists) {
+    printPlaylist(playlist, indexStore);
+  }
+}
+
+async function main(): Promise<void> {
+  const argUserId = process.argv[2];
+
+  initializeAuthDatabase();
+  const indexStore = new IndexStore();
+  await indexStore.initialize();
+  if (indexStore.getSnapshot().totalTracks === 0) {
+    await indexStore.rebuild();
+  }
+
+  const targets = argUserId ? [{ id: argUserId }] : listUsers();
+  if (targets.length === 0) {
+    console.error("[for-you] no users");
+    process.exit(1);
+  }
+
+  for (const user of targets) {
+    try {
+      await inspectUser(user.id, indexStore);
+    } catch (error) {
+      console.error(`[for-you] user ${user.id} inspect failed:`, error);
+    }
+  }
+}
+
+void main().catch((error) => {
+  console.error("[for-you] unexpected error", error);
+  process.exit(99);
+});

--- a/backend/src/scripts/inspectForYouTrace.ts
+++ b/backend/src/scripts/inspectForYouTrace.ts
@@ -57,6 +57,11 @@ function printRankerHeader(trace: ForYouTrace): void {
     const parts = Object.entries(f).map(([k, v]) => `${k}=${v}`);
     console.log(`  pre-rank filters: ${parts.join("  ")}`);
   }
+  const d = trace.ranker.diversityKnobs;
+  if (d) {
+    const parts = Object.entries(d).map(([k, v]) => `${k}=${v}`);
+    console.log(`  diversity knobs:  ${parts.join("  ")}`);
+  }
 }
 
 function printSeeds(trace: ForYouTrace): void {

--- a/backend/src/scripts/probeEmbedder.ts
+++ b/backend/src/scripts/probeEmbedder.ts
@@ -1,0 +1,49 @@
+/**
+ * End-to-end smoke test for the audio-embedder sidecar.
+ *
+ * Usage:
+ *   npm run embed:probe -- /absolute/path/to/track.mp3
+ *
+ * Pings /healthz, then asks for an embedding of the given file (or a
+ * placeholder path if none is provided). Prints a short summary and exits
+ * non-zero if either step fails. Does not touch the production embedding
+ * pipeline.
+ */
+import process from "node:process";
+
+import { pingEmbedder, requestEmbedding } from "../services/embeddings/embedderClient";
+
+function summary(vec: number[]): string {
+  const head = vec.slice(0, 4).map((v) => v.toFixed(4)).join(", ");
+  const norm = Math.sqrt(vec.reduce((sum, v) => sum + v * v, 0));
+  return `len=${vec.length} head=[${head}, …] norm=${norm.toFixed(4)}`;
+}
+
+async function main(): Promise<void> {
+  const argPath = process.argv[2];
+
+  const health = await pingEmbedder();
+  if (!health) {
+    console.error("[probe] sidecar /healthz unreachable. Is it running?");
+    console.error("[probe] start it with: ./backend/python-services/audio-embedder/start.sh");
+    process.exit(2);
+  }
+  console.log(`[probe] sidecar healthy: model=${health.model}`);
+
+  if (!argPath) {
+    console.error("[probe] no path argument provided. Usage: npm run embed:probe -- <absolutePath>");
+    process.exit(1);
+  }
+
+  const result = await requestEmbedding(argPath);
+  if (!result) {
+    console.error(`[probe] embedding request failed for ${argPath}`);
+    process.exit(3);
+  }
+  console.log(`[probe] embedding ok: model=${result.model} ${summary(result.vec)}`);
+}
+
+void main().catch((error) => {
+  console.error("[probe] unexpected error", error);
+  process.exit(99);
+});

--- a/backend/src/scripts/regenerateForYou.ts
+++ b/backend/src/scripts/regenerateForYou.ts
@@ -1,0 +1,82 @@
+/**
+ * Interactive for-you regeneration + summary.
+ *
+ * Usage:
+ *   npm run for-you:regen                  # all users
+ *   npm run for-you:regen -- <userId>      # one user
+ *
+ * Loads the index, runs regenerateForYouPlaylists for each target user,
+ * and prints a compact summary of the resulting playlists with track
+ * titles. Useful for operator inspection after a ranker change or a
+ * fresh backfill, without spinning up the full server.
+ *
+ * Already idempotent: the regenerator overwrites the user's prior set
+ * and trace files atomically.
+ */
+import process from "node:process";
+
+import { listUsers } from "../auth/db";
+import { initializeAuthDatabase } from "../auth/dbConnection";
+import { IndexStore } from "../services/indexer/indexStore";
+import { regenerateForYouPlaylists } from "../services/playlists/forYou/regenerate";
+
+type TrackLite = { id: string; title: string; artist: string };
+
+function summariseTracks(indexStore: IndexStore, trackIds: string[]): TrackLite[] {
+  return trackIds
+    .map((id) => indexStore.getTrackById(id))
+    .filter((t): t is NonNullable<typeof t> => Boolean(t))
+    .map((t) => ({
+      id: t.id,
+      title: t.tags.title ?? "Untitled",
+      artist: t.tags.artist ?? "Unknown artist"
+    }));
+}
+
+async function regenerateForUser(userId: string, indexStore: IndexStore): Promise<void> {
+  console.log(`\n=== user ${userId} ===`);
+  const playlists = await regenerateForYouPlaylists(userId, indexStore);
+  if (playlists.length === 0) {
+    console.log("  (no playlists generated — check below-min-plays / below-min-artists / dismissals)");
+    return;
+  }
+
+  for (const playlist of playlists) {
+    console.log(`\n  ▶ ${playlist.name}  [${playlist.trackCount} tracks, score=${playlist.score?.toFixed(2) ?? "?"}]`);
+    const tracks = summariseTracks(indexStore, playlist.trackIds);
+    for (const t of tracks) {
+      console.log(`     · ${t.artist} — ${t.title}`);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const argUserId = process.argv[2];
+
+  initializeAuthDatabase();
+  const indexStore = new IndexStore();
+  await indexStore.initialize();
+  if (indexStore.getSnapshot().totalTracks === 0) {
+    console.log("[for-you] index empty; rebuilding from disk first");
+    await indexStore.rebuild();
+  }
+
+  const targets = argUserId ? [{ id: argUserId }] : listUsers();
+  if (targets.length === 0) {
+    console.error("[for-you] no users to regenerate for");
+    process.exit(1);
+  }
+
+  for (const user of targets) {
+    try {
+      await regenerateForUser(user.id, indexStore);
+    } catch (error) {
+      console.error(`[for-you] user ${user.id} regen failed:`, error);
+    }
+  }
+}
+
+void main().catch((error) => {
+  console.error("[for-you] unexpected error", error);
+  process.exit(99);
+});

--- a/backend/src/services/embeddings/audioEmbeddingService.test.ts
+++ b/backend/src/services/embeddings/audioEmbeddingService.test.ts
@@ -23,18 +23,39 @@ vi.mock("./embedderClient", () => ({
   requestEmbedding: vi.fn()
 }));
 
-import { EMBEDDING_DIM, EMBEDDING_VERSION } from "./audioFeatures";
+vi.mock("./mfccEmbedder", () => ({
+  MFCC_EMBEDDING_DIM: 32,
+  MFCC_EMBEDDING_VERSION: 2,
+  decodeToPcm: vi.fn(),
+  computeMfccVector: vi.fn()
+}));
+
+vi.mock("../librarySettings/librarySettings", () => ({
+  getLibrarySettings: vi.fn()
+}));
+
+import { CLAP_EMBEDDING_DIM, CLAP_EMBEDDING_VERSION } from "./audioFeatures";
 import { requestEmbedding } from "./embedderClient";
+import { computeMfccVector, decodeToPcm, MFCC_EMBEDDING_DIM, MFCC_EMBEDDING_VERSION } from "./mfccEmbedder";
+import { getLibrarySettings } from "../librarySettings/librarySettings";
 
 const requestEmbeddingMock = requestEmbedding as ReturnType<typeof vi.fn>;
+const decodeToPcmMock = decodeToPcm as ReturnType<typeof vi.fn>;
+const computeMfccVectorMock = computeMfccVector as ReturnType<typeof vi.fn>;
+const getLibrarySettingsMock = getLibrarySettings as ReturnType<typeof vi.fn>;
 
 function makeVec(seed: number): number[] {
-  return Array.from({ length: EMBEDDING_DIM }, (_, i) => ((i + seed) % 17) * 0.001);
+  return Array.from({ length: CLAP_EMBEDDING_DIM }, (_, i) => ((i + seed) % 17) * 0.001);
 }
 
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "embeddings-test-"));
   requestEmbeddingMock.mockReset();
+  decodeToPcmMock.mockReset();
+  computeMfccVectorMock.mockReset();
+  // Default to AI on. MFCC tests override this.
+  getLibrarySettingsMock.mockReset();
+  getLibrarySettingsMock.mockResolvedValue({ aiRecommendation: true });
 });
 
 afterEach(async () => {
@@ -47,14 +68,14 @@ describe("audioEmbeddingService storage", () => {
     const vec = makeVec(0);
     await saveEmbedding({
       trackId: "track-a",
-      version: EMBEDDING_VERSION,
+      version: CLAP_EMBEDDING_VERSION,
       computedAt: "2026-05-03T00:00:00Z",
       vec
     });
 
     const loaded = await loadEmbedding("track-a");
     expect(loaded?.trackId).toBe("track-a");
-    expect(loaded?.vec.length).toBe(EMBEDDING_DIM);
+    expect(loaded?.vec.length).toBe(CLAP_EMBEDDING_DIM);
     expect(loaded?.vec[0]).toBeCloseTo(0, 9);
   });
 
@@ -67,9 +88,9 @@ describe("audioEmbeddingService storage", () => {
     const { saveEmbedding, loadEmbedding } = await import("./audioEmbeddingService");
     await saveEmbedding({
       trackId: "track-old",
-      version: EMBEDDING_VERSION - 1,
+      version: CLAP_EMBEDDING_VERSION - 1,
       computedAt: "2026-05-03T00:00:00Z",
-      vec: Array(EMBEDDING_DIM).fill(0.1)
+      vec: Array(CLAP_EMBEDDING_DIM).fill(0.1)
     });
     expect(await loadEmbedding("track-old")).toBeNull();
   });
@@ -78,7 +99,7 @@ describe("audioEmbeddingService storage", () => {
     const { saveEmbedding, loadEmbedding } = await import("./audioEmbeddingService");
     await saveEmbedding({
       trackId: "track-bad",
-      version: EMBEDDING_VERSION,
+      version: CLAP_EMBEDDING_VERSION,
       computedAt: "2026-05-03T00:00:00Z",
       vec: [0.1, 0.2]
     });
@@ -91,9 +112,9 @@ describe("audioEmbeddingService storage", () => {
 
     await saveEmbedding({
       trackId: "track-c",
-      version: EMBEDDING_VERSION,
+      version: CLAP_EMBEDDING_VERSION,
       computedAt: "2026-05-03T00:00:00Z",
-      vec: Array(EMBEDDING_DIM).fill(0.1)
+      vec: Array(CLAP_EMBEDDING_DIM).fill(0.1)
     });
     expect(await hasEmbedding("track-c")).toBe(true);
   });
@@ -102,14 +123,14 @@ describe("audioEmbeddingService storage", () => {
 describe("computeAndSaveEmbedding", () => {
   it("calls the sidecar and persists the returned vector", async () => {
     const vec = makeVec(7);
-    requestEmbeddingMock.mockResolvedValue({ vec, dim: EMBEDDING_DIM, model: "clap" });
+    requestEmbeddingMock.mockResolvedValue({ vec, dim: CLAP_EMBEDDING_DIM, model: "clap" });
     const { computeAndSaveEmbedding, loadEmbedding } = await import("./audioEmbeddingService");
 
     const result = await computeAndSaveEmbedding("track-x", "artist/album/track.flac");
 
     expect(result?.trackId).toBe("track-x");
-    expect(result?.version).toBe(EMBEDDING_VERSION);
-    expect(result?.vec.length).toBe(EMBEDDING_DIM);
+    expect(result?.version).toBe(CLAP_EMBEDDING_VERSION);
+    expect(result?.vec.length).toBe(CLAP_EMBEDDING_DIM);
 
     // Resolved path is passed through to the sidecar client.
     expect(requestEmbeddingMock).toHaveBeenCalledWith("/abs/music/artist/album/track.flac");
@@ -141,5 +162,100 @@ describe("computeAndSaveEmbedding", () => {
 
     expect(result).toBeNull();
     expect(await hasEmbedding("track-z")).toBe(false);
+  });
+});
+
+describe("computeAndSaveEmbedding (AI off — MFCC dispatch)", () => {
+  beforeEach(() => {
+    getLibrarySettingsMock.mockResolvedValue({ aiRecommendation: false });
+  });
+
+  it("decodes via ffmpeg + DSP and persists a v2 sidecar", async () => {
+    const fakeSamples = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+    const fakeVec = new Float32Array(MFCC_EMBEDDING_DIM);
+    for (let i = 0; i < MFCC_EMBEDDING_DIM; i++) fakeVec[i] = (i % 7) * 0.01;
+    decodeToPcmMock.mockResolvedValue(fakeSamples);
+    computeMfccVectorMock.mockReturnValue(fakeVec);
+    const { computeAndSaveEmbedding, loadEmbedding } = await import("./audioEmbeddingService");
+
+    const result = await computeAndSaveEmbedding("mfcc-x", "artist/track.flac");
+
+    expect(result?.version).toBe(MFCC_EMBEDDING_VERSION);
+    expect(result?.vec.length).toBe(MFCC_EMBEDDING_DIM);
+    expect(decodeToPcmMock).toHaveBeenCalledWith("/abs/music/artist/track.flac");
+    expect(computeMfccVectorMock).toHaveBeenCalledWith(fakeSamples);
+
+    // Round-trips through loadEmbedding because we're still in MFCC mode.
+    const loaded = await loadEmbedding("mfcc-x");
+    expect(loaded?.version).toBe(MFCC_EMBEDDING_VERSION);
+  });
+
+  it("does NOT call the CLAP sidecar in MFCC mode", async () => {
+    decodeToPcmMock.mockResolvedValue(new Float32Array([0.1]));
+    computeMfccVectorMock.mockReturnValue(new Float32Array(MFCC_EMBEDDING_DIM));
+    const { computeAndSaveEmbedding } = await import("./audioEmbeddingService");
+
+    await computeAndSaveEmbedding("mfcc-y", "a/b.flac");
+
+    expect(requestEmbeddingMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null when ffmpeg fails (e.g. binary missing)", async () => {
+    decodeToPcmMock.mockRejectedValue(new Error("ffmpeg ENOENT"));
+    const { computeAndSaveEmbedding, hasEmbedding } = await import("./audioEmbeddingService");
+
+    const result = await computeAndSaveEmbedding("mfcc-z", "a/b.flac");
+
+    expect(result).toBeNull();
+    expect(await hasEmbedding("mfcc-z")).toBe(false);
+  });
+
+  it("returns null when the signal is too short for one frame", async () => {
+    decodeToPcmMock.mockResolvedValue(new Float32Array([0.1]));
+    computeMfccVectorMock.mockReturnValue(null);
+    const { computeAndSaveEmbedding, hasEmbedding } = await import("./audioEmbeddingService");
+
+    const result = await computeAndSaveEmbedding("mfcc-short", "a/b.flac");
+
+    expect(result).toBeNull();
+    expect(await hasEmbedding("mfcc-short")).toBe(false);
+  });
+});
+
+describe("getActiveEmbeddingProfile", () => {
+  it("returns the CLAP profile when AI recommendation is on", async () => {
+    getLibrarySettingsMock.mockResolvedValue({ aiRecommendation: true });
+    const { getActiveEmbeddingProfile } = await import("./audioEmbeddingService");
+
+    const profile = await getActiveEmbeddingProfile();
+
+    expect(profile.model).toBe("clap");
+    expect(profile.dim).toBe(CLAP_EMBEDDING_DIM);
+    expect(profile.version).toBe(CLAP_EMBEDDING_VERSION);
+  });
+
+  it("returns the MFCC profile when AI recommendation is off", async () => {
+    getLibrarySettingsMock.mockResolvedValue({ aiRecommendation: false });
+    const { getActiveEmbeddingProfile } = await import("./audioEmbeddingService");
+
+    const profile = await getActiveEmbeddingProfile();
+
+    expect(profile.model).toBe("mfcc");
+    expect(profile.dim).toBe(MFCC_EMBEDDING_DIM);
+    expect(profile.version).toBe(MFCC_EMBEDDING_VERSION);
+  });
+
+  it("loadEmbedding rejects v3 sidecars when AI is off", async () => {
+    const { saveEmbedding, loadEmbedding } = await import("./audioEmbeddingService");
+    // Persist a v3 sidecar while AI is on so saveEmbedding doesn't complain.
+    await saveEmbedding({
+      trackId: "switch-test",
+      version: CLAP_EMBEDDING_VERSION,
+      computedAt: "2026-05-15T00:00:00Z",
+      vec: Array(CLAP_EMBEDDING_DIM).fill(0.01)
+    });
+    // Flip to MFCC mode → the v3 sidecar must look "missing" now.
+    getLibrarySettingsMock.mockResolvedValue({ aiRecommendation: false });
+    expect(await loadEmbedding("switch-test")).toBeNull();
   });
 });

--- a/backend/src/services/embeddings/audioEmbeddingService.test.ts
+++ b/backend/src/services/embeddings/audioEmbeddingService.test.ts
@@ -15,10 +15,26 @@ vi.mock("../../utils/paths", async (importOriginal) => {
   };
 });
 
-import { EMBEDDING_VERSION } from "./audioFeatures";
+vi.mock("../storage/storageService", () => ({
+  resolveTrackAbsolutePath: (relativePath: string) => path.join("/abs/music", relativePath)
+}));
+
+vi.mock("./embedderClient", () => ({
+  requestEmbedding: vi.fn()
+}));
+
+import { EMBEDDING_DIM, EMBEDDING_VERSION } from "./audioFeatures";
+import { requestEmbedding } from "./embedderClient";
+
+const requestEmbeddingMock = requestEmbedding as ReturnType<typeof vi.fn>;
+
+function makeVec(seed: number): number[] {
+  return Array.from({ length: EMBEDDING_DIM }, (_, i) => ((i + seed) % 17) * 0.001);
+}
 
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "embeddings-test-"));
+  requestEmbeddingMock.mockReset();
 });
 
 afterEach(async () => {
@@ -28,7 +44,7 @@ afterEach(async () => {
 describe("audioEmbeddingService storage", () => {
   it("round-trips an embedding via save/load", async () => {
     const { saveEmbedding, loadEmbedding } = await import("./audioEmbeddingService");
-    const vec = Array.from({ length: 32 }, (_, i) => i / 32);
+    const vec = makeVec(0);
     await saveEmbedding({
       trackId: "track-a",
       version: EMBEDDING_VERSION,
@@ -38,7 +54,7 @@ describe("audioEmbeddingService storage", () => {
 
     const loaded = await loadEmbedding("track-a");
     expect(loaded?.trackId).toBe("track-a");
-    expect(loaded?.vec.length).toBe(32);
+    expect(loaded?.vec.length).toBe(EMBEDDING_DIM);
     expect(loaded?.vec[0]).toBeCloseTo(0, 9);
   });
 
@@ -51,9 +67,9 @@ describe("audioEmbeddingService storage", () => {
     const { saveEmbedding, loadEmbedding } = await import("./audioEmbeddingService");
     await saveEmbedding({
       trackId: "track-old",
-      version: EMBEDDING_VERSION + 99,
+      version: EMBEDDING_VERSION - 1,
       computedAt: "2026-05-03T00:00:00Z",
-      vec: Array(32).fill(0.1)
+      vec: Array(EMBEDDING_DIM).fill(0.1)
     });
     expect(await loadEmbedding("track-old")).toBeNull();
   });
@@ -77,8 +93,53 @@ describe("audioEmbeddingService storage", () => {
       trackId: "track-c",
       version: EMBEDDING_VERSION,
       computedAt: "2026-05-03T00:00:00Z",
-      vec: Array(32).fill(0.1)
+      vec: Array(EMBEDDING_DIM).fill(0.1)
     });
     expect(await hasEmbedding("track-c")).toBe(true);
+  });
+});
+
+describe("computeAndSaveEmbedding", () => {
+  it("calls the sidecar and persists the returned vector", async () => {
+    const vec = makeVec(7);
+    requestEmbeddingMock.mockResolvedValue({ vec, dim: EMBEDDING_DIM, model: "clap" });
+    const { computeAndSaveEmbedding, loadEmbedding } = await import("./audioEmbeddingService");
+
+    const result = await computeAndSaveEmbedding("track-x", "artist/album/track.flac");
+
+    expect(result?.trackId).toBe("track-x");
+    expect(result?.version).toBe(EMBEDDING_VERSION);
+    expect(result?.vec.length).toBe(EMBEDDING_DIM);
+
+    // Resolved path is passed through to the sidecar client.
+    expect(requestEmbeddingMock).toHaveBeenCalledWith("/abs/music/artist/album/track.flac");
+
+    // And it's loadable back from disk.
+    const loaded = await loadEmbedding("track-x");
+    expect(loaded?.vec[0]).toBeCloseTo(vec[0]!, 9);
+  });
+
+  it("returns null without writing anything when the sidecar fails", async () => {
+    requestEmbeddingMock.mockResolvedValue(null);
+    const { computeAndSaveEmbedding, hasEmbedding } = await import("./audioEmbeddingService");
+
+    const result = await computeAndSaveEmbedding("track-y", "a/b.flac");
+
+    expect(result).toBeNull();
+    expect(await hasEmbedding("track-y")).toBe(false);
+  });
+
+  it("rejects sidecar responses with the wrong dimension", async () => {
+    requestEmbeddingMock.mockResolvedValue({
+      vec: [0.1, 0.2, 0.3],
+      dim: 3,
+      model: "broken"
+    });
+    const { computeAndSaveEmbedding, hasEmbedding } = await import("./audioEmbeddingService");
+
+    const result = await computeAndSaveEmbedding("track-z", "a/b.flac");
+
+    expect(result).toBeNull();
+    expect(await hasEmbedding("track-z")).toBe(false);
   });
 });

--- a/backend/src/services/embeddings/audioEmbeddingService.ts
+++ b/backend/src/services/embeddings/audioEmbeddingService.ts
@@ -26,7 +26,7 @@ import { dataRoot } from "../../utils/paths";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
 import { createLogger } from "../../utils/logger";
 import { getLibrarySettings } from "../librarySettings/librarySettings";
-import { EMBEDDING_DIM, EMBEDDING_VERSION } from "./audioFeatures";
+import { CLAP_EMBEDDING_DIM, CLAP_EMBEDDING_VERSION } from "./audioFeatures";
 import {
   MFCC_EMBEDDING_DIM,
   MFCC_EMBEDDING_VERSION,
@@ -37,19 +37,29 @@ import { requestEmbedding } from "./embedderClient";
 
 const log = createLogger("audio-embeddings");
 
+/** Directory holding per-track embedding sidecars (`<trackId>.json`). */
 export const EMBEDDINGS_DIR = path.join(dataRoot, "embeddings");
 
+/** On-disk shape for an embedding sidecar at `EMBEDDINGS_DIR/<trackId>.json`. */
 export type AudioEmbedding = {
   trackId: string;
+  /** Tag identifying which model produced the vector. See loadEmbedding. */
   version: number;
   computedAt: string;
   vec: number[];
 };
 
+/**
+ * Snapshot of which embedding backend is currently active. Returned by
+ * `getActiveEmbeddingProfile` and used by the ranker / trace builder to
+ * record what produced the vectors it's about to consume.
+ */
 export type EmbeddingProfile = {
   /** Display label for logs + traces. */
   model: "clap" | "mfcc";
+  /** Output dimension expected from this model's sidecars. */
   dim: number;
+  /** On-disk version tag stamped into sidecars by this model. */
   version: number;
 };
 
@@ -67,7 +77,7 @@ function embeddingPath(trackId: string): string {
 export async function getActiveEmbeddingProfile(): Promise<EmbeddingProfile> {
   const settings = await getLibrarySettings();
   return settings.aiRecommendation
-    ? { model: "clap", dim: EMBEDDING_DIM, version: EMBEDDING_VERSION }
+    ? { model: "clap", dim: CLAP_EMBEDDING_DIM, version: CLAP_EMBEDDING_VERSION }
     : { model: "mfcc", dim: MFCC_EMBEDDING_DIM, version: MFCC_EMBEDDING_VERSION };
 }
 
@@ -89,6 +99,13 @@ export async function loadEmbedding(trackId: string): Promise<AudioEmbedding | n
   return data;
 }
 
+/**
+ * Write an embedding to disk atomically. Creates `EMBEDDINGS_DIR` on first
+ * write. Callers are expected to set `version` to the active backend's
+ * version constant — `saveEmbedding` does not enforce that, but
+ * `loadEmbedding` will refuse to return the sidecar later if it doesn't
+ * match the currently active model.
+ */
 export async function saveEmbedding(embedding: AudioEmbedding): Promise<void> {
   await ensureDir(EMBEDDINGS_DIR);
   await writeJsonAtomic(embeddingPath(embedding.trackId), embedding);
@@ -102,17 +119,17 @@ async function computeViaClap(
 ): Promise<AudioEmbedding | null> {
   const response = await requestEmbedding(absolutePath);
   if (!response) return null; // client already logged the reason
-  if (response.vec.length !== EMBEDDING_DIM) {
+  if (response.vec.length !== CLAP_EMBEDDING_DIM) {
     log.warn("CLAP sidecar returned unexpected dimension", {
       trackId,
       got: response.vec.length,
-      want: EMBEDDING_DIM
+      want: CLAP_EMBEDDING_DIM
     });
     return null;
   }
   return {
     trackId,
-    version: EMBEDDING_VERSION,
+    version: CLAP_EMBEDDING_VERSION,
     computedAt: new Date().toISOString(),
     vec: response.vec
   };
@@ -141,7 +158,17 @@ async function computeViaMfcc(
   }
 }
 
-/** Compute and persist an embedding for a track. Returns null on any failure. */
+/**
+ * Compute and persist an embedding for a track using whichever backend is
+ * currently active (CLAP sidecar or in-process MFCC). Returns the saved
+ * embedding, or `null` on any failure — best-effort by design so an
+ * upload or a backfill run never blocks on a single bad track.
+ *
+ * Failure modes (all swallowed and logged):
+ *   - `resolveTrackAbsolutePath` rejects the relative path.
+ *   - CLAP mode: sidecar unreachable, times out, malformed body.
+ *   - MFCC mode: ffmpeg missing/failed, signal too short for one frame.
+ */
 export async function computeAndSaveEmbedding(
   trackId: string,
   trackRelativePath: string
@@ -165,6 +192,7 @@ export async function computeAndSaveEmbedding(
   return embedding;
 }
 
+/** Convenience predicate: does a current-version sidecar exist for this track? */
 export async function hasEmbedding(trackId: string): Promise<boolean> {
   const existing = await loadEmbedding(trackId);
   return existing !== null;

--- a/backend/src/services/embeddings/audioEmbeddingService.ts
+++ b/backend/src/services/embeddings/audioEmbeddingService.ts
@@ -1,7 +1,9 @@
 /**
- * Audio embedding service. Decodes a track via ffmpeg → 16 kHz mono PCM,
- * runs the DSP pipeline in audioFeatures.ts, and persists the resulting
- * 32-dim vector as a sidecar JSON next to the track's id.
+ * Audio embedding service — orchestration layer.
+ *
+ * Delegates decoding + model inference to the Python sidecar
+ * (`python-services/audio-embedder/`). This file owns the on-disk format,
+ * the version gate, and the backfill loop.
  *
  * Storage:  data/embeddings/<trackId>.json
  * Shape:    { trackId, version, computedAt, vec: number[] }
@@ -11,7 +13,6 @@
  * (skipped) feature.
  */
 
-import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -19,12 +20,8 @@ import { resolveTrackAbsolutePath } from "../storage/storageService";
 import { dataRoot } from "../../utils/paths";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
 import { createLogger } from "../../utils/logger";
-import {
-  EMBEDDING_DIM,
-  EMBEDDING_VERSION,
-  SAMPLE_RATE,
-  computeFeatureVector
-} from "./audioFeatures";
+import { EMBEDDING_DIM, EMBEDDING_VERSION } from "./audioFeatures";
+import { requestEmbedding } from "./embedderClient";
 
 const log = createLogger("audio-embeddings");
 
@@ -58,95 +55,7 @@ export async function saveEmbedding(embedding: AudioEmbedding): Promise<void> {
   await writeJsonAtomic(embeddingPath(embedding.trackId), embedding);
 }
 
-// ── Decode ────────────────────────────────────────────────────────
-
-/**
- * Decode an audio file to mono 16 kHz Float32 PCM via ffmpeg. Returns the
- * raw samples as a Float32Array.
- *
- * Implementation note: ffmpeg's `f32le` output writes little-endian floats
- * to stdout. We accumulate buffers and reinterpret the final byte sequence
- * as a Float32Array, which on little-endian hosts is a zero-copy view.
- */
-function decodeToPcm(absolutePath: string): Promise<Float32Array> {
-  return new Promise((resolve, reject) => {
-    const ffmpeg = spawn(
-      "ffmpeg",
-      [
-        "-v", "error",
-        "-i", absolutePath,
-        "-vn",
-        "-ac", "1",
-        "-ar", String(SAMPLE_RATE),
-        "-f", "f32le",
-        "-"
-      ],
-      { stdio: ["ignore", "pipe", "pipe"] }
-    );
-
-    const chunks: Buffer[] = [];
-    let totalBytes = 0;
-    let stderr = "";
-
-    ffmpeg.stdout.on("data", (chunk: Buffer) => {
-      chunks.push(chunk);
-      totalBytes += chunk.length;
-    });
-
-    ffmpeg.stderr.on("data", (chunk) => {
-      stderr += chunk.toString("utf8");
-      if (stderr.length > 4096) stderr = stderr.slice(-4096);
-    });
-
-    ffmpeg.on("error", (err) => {
-      reject(new Error(`ffmpeg failed to start: ${err.message}`));
-    });
-
-    ffmpeg.on("close", (code) => {
-      if (code !== 0) {
-        reject(new Error(`ffmpeg exited with code ${code}: ${stderr.trim()}`));
-        return;
-      }
-      // Buffer.concat's underlying ArrayBuffer offset isn't guaranteed to be
-      // 4-byte aligned, which is required to construct a Float32Array view.
-      // Copy bytes into a fresh, naturally aligned ArrayBuffer instead.
-      const usable = totalBytes - (totalBytes % 4);
-      const aligned = new ArrayBuffer(usable);
-      const dst = new Uint8Array(aligned);
-      let offset = 0;
-      for (const chunk of chunks) {
-        const remaining = usable - offset;
-        if (remaining <= 0) break;
-        const len = Math.min(chunk.length, remaining);
-        dst.set(chunk.subarray(0, len), offset);
-        offset += len;
-      }
-      resolve(new Float32Array(aligned));
-    });
-  });
-}
-
-// ── Concurrency control ───────────────────────────────────────────
-
-const MAX_CONCURRENT = 2;
-let active = 0;
-const queue: Array<() => void> = [];
-
-async function withSlot<T>(fn: () => Promise<T>): Promise<T> {
-  if (active >= MAX_CONCURRENT) {
-    await new Promise<void>((r) => queue.push(r));
-  }
-  active++;
-  try {
-    return await fn();
-  } finally {
-    active--;
-    const next = queue.shift();
-    if (next) next();
-  }
-}
-
-// ── Public API ────────────────────────────────────────────────────
+// ── Compute via sidecar ───────────────────────────────────────────
 
 /** Compute and persist an embedding for a track. Returns null on any failure. */
 export async function computeAndSaveEmbedding(
@@ -161,27 +70,29 @@ export async function computeAndSaveEmbedding(
     return null;
   }
 
-  return withSlot(async () => {
-    try {
-      const samples = await decodeToPcm(absolutePath);
-      const vec = computeFeatureVector(samples);
-      if (!vec) {
-        log.debug("Track too short for embedding", { trackId });
-        return null;
-      }
-      const embedding: AudioEmbedding = {
-        trackId,
-        version: EMBEDDING_VERSION,
-        computedAt: new Date().toISOString(),
-        vec: Array.from(vec)
-      };
-      await saveEmbedding(embedding);
-      return embedding;
-    } catch (error) {
-      log.warn("Embedding computation failed", { trackId, error: String(error) });
-      return null;
-    }
-  });
+  const response = await requestEmbedding(absolutePath);
+  if (!response) {
+    // Client already logged the underlying reason.
+    return null;
+  }
+
+  if (response.vec.length !== EMBEDDING_DIM) {
+    log.warn("Embedder returned unexpected dimension", {
+      trackId,
+      got: response.vec.length,
+      want: EMBEDDING_DIM
+    });
+    return null;
+  }
+
+  const embedding: AudioEmbedding = {
+    trackId,
+    version: EMBEDDING_VERSION,
+    computedAt: new Date().toISOString(),
+    vec: response.vec
+  };
+  await saveEmbedding(embedding);
+  return embedding;
 }
 
 export async function hasEmbedding(trackId: string): Promise<boolean> {
@@ -189,10 +100,13 @@ export async function hasEmbedding(trackId: string): Promise<boolean> {
   return existing !== null;
 }
 
+// ── Backfill ──────────────────────────────────────────────────────
+
 /**
  * Background backfill: compute embeddings for any track that doesn't have
- * one yet. Trickles through serially (modulo the concurrency slot) so it
- * doesn't dominate ffmpeg capacity that transcoding might want.
+ * one at the current version yet. Sequential — the sidecar handles its own
+ * threading, and we'd rather not flood it with concurrent requests for a
+ * one-time backfill.
  */
 export async function backfillMissingEmbeddings(
   tracks: Array<{ id: string; path: string }>,

--- a/backend/src/services/embeddings/audioEmbeddingService.ts
+++ b/backend/src/services/embeddings/audioEmbeddingService.ts
@@ -1,9 +1,14 @@
 /**
  * Audio embedding service — orchestration layer.
  *
- * Delegates decoding + model inference to the Python sidecar
- * (`python-services/audio-embedder/`). This file owns the on-disk format,
- * the version gate, and the backfill loop.
+ * Two backends, chosen at runtime by the library setting `aiRecommendation`:
+ *   - true  → CLAP via the Python sidecar (512-dim, v3 sidecars).
+ *   - false → legacy in-process MFCC pipeline (32-dim, v2 sidecars).
+ *
+ * This file owns the on-disk format, the version gate, and the backfill
+ * loop. The version stored in each sidecar tells us which model produced
+ * it; if the user toggles modes, sidecars from the previous mode are
+ * treated as missing and the backfill recomputes them with the new model.
  *
  * Storage:  data/embeddings/<trackId>.json
  * Shape:    { trackId, version, computedAt, vec: number[] }
@@ -20,7 +25,14 @@ import { resolveTrackAbsolutePath } from "../storage/storageService";
 import { dataRoot } from "../../utils/paths";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
 import { createLogger } from "../../utils/logger";
+import { getLibrarySettings } from "../librarySettings/librarySettings";
 import { EMBEDDING_DIM, EMBEDDING_VERSION } from "./audioFeatures";
+import {
+  MFCC_EMBEDDING_DIM,
+  MFCC_EMBEDDING_VERSION,
+  computeMfccVector,
+  decodeToPcm
+} from "./mfccEmbedder";
 import { requestEmbedding } from "./embedderClient";
 
 const log = createLogger("audio-embeddings");
@@ -34,19 +46,46 @@ export type AudioEmbedding = {
   vec: number[];
 };
 
+export type EmbeddingProfile = {
+  /** Display label for logs + traces. */
+  model: "clap" | "mfcc";
+  dim: number;
+  version: number;
+};
+
 function embeddingPath(trackId: string): string {
   return path.join(EMBEDDINGS_DIR, `${trackId}.json`);
 }
 
+// ── Active profile ────────────────────────────────────────────────
+
+/**
+ * Resolve which embedding model is currently active. Read from the library
+ * settings once per call site — settings change rarely, and the call sites
+ * (backfill, regen, upload) are not in tight loops.
+ */
+export async function getActiveEmbeddingProfile(): Promise<EmbeddingProfile> {
+  const settings = await getLibrarySettings();
+  return settings.aiRecommendation
+    ? { model: "clap", dim: EMBEDDING_DIM, version: EMBEDDING_VERSION }
+    : { model: "mfcc", dim: MFCC_EMBEDDING_DIM, version: MFCC_EMBEDDING_VERSION };
+}
+
 // ── Storage ───────────────────────────────────────────────────────
 
+/**
+ * Load an embedding only if it matches the currently active model. Sidecars
+ * left over from the other model are treated as missing — the backfill
+ * loop will recompute them.
+ */
 export async function loadEmbedding(trackId: string): Promise<AudioEmbedding | null> {
+  const profile = await getActiveEmbeddingProfile();
   const data = await readJsonFile<AudioEmbedding>(
     embeddingPath(trackId),
     null as unknown as AudioEmbedding
   );
-  if (!data || !Array.isArray(data.vec) || data.vec.length !== EMBEDDING_DIM) return null;
-  if (data.version !== EMBEDDING_VERSION) return null;
+  if (!data || !Array.isArray(data.vec) || data.vec.length !== profile.dim) return null;
+  if (data.version !== profile.version) return null;
   return data;
 }
 
@@ -55,7 +94,52 @@ export async function saveEmbedding(embedding: AudioEmbedding): Promise<void> {
   await writeJsonAtomic(embeddingPath(embedding.trackId), embedding);
 }
 
-// ── Compute via sidecar ───────────────────────────────────────────
+// ── Compute (dispatched) ──────────────────────────────────────────
+
+async function computeViaClap(
+  trackId: string,
+  absolutePath: string
+): Promise<AudioEmbedding | null> {
+  const response = await requestEmbedding(absolutePath);
+  if (!response) return null; // client already logged the reason
+  if (response.vec.length !== EMBEDDING_DIM) {
+    log.warn("CLAP sidecar returned unexpected dimension", {
+      trackId,
+      got: response.vec.length,
+      want: EMBEDDING_DIM
+    });
+    return null;
+  }
+  return {
+    trackId,
+    version: EMBEDDING_VERSION,
+    computedAt: new Date().toISOString(),
+    vec: response.vec
+  };
+}
+
+async function computeViaMfcc(
+  trackId: string,
+  absolutePath: string
+): Promise<AudioEmbedding | null> {
+  try {
+    const samples = await decodeToPcm(absolutePath);
+    const vec = computeMfccVector(samples);
+    if (!vec) {
+      log.debug("Track too short for MFCC embedding", { trackId });
+      return null;
+    }
+    return {
+      trackId,
+      version: MFCC_EMBEDDING_VERSION,
+      computedAt: new Date().toISOString(),
+      vec: Array.from(vec)
+    };
+  } catch (error) {
+    log.warn("MFCC embedding failed", { trackId, error: String(error) });
+    return null;
+  }
+}
 
 /** Compute and persist an embedding for a track. Returns null on any failure. */
 export async function computeAndSaveEmbedding(
@@ -70,27 +154,13 @@ export async function computeAndSaveEmbedding(
     return null;
   }
 
-  const response = await requestEmbedding(absolutePath);
-  if (!response) {
-    // Client already logged the underlying reason.
-    return null;
-  }
+  const profile = await getActiveEmbeddingProfile();
+  const embedding =
+    profile.model === "clap"
+      ? await computeViaClap(trackId, absolutePath)
+      : await computeViaMfcc(trackId, absolutePath);
 
-  if (response.vec.length !== EMBEDDING_DIM) {
-    log.warn("Embedder returned unexpected dimension", {
-      trackId,
-      got: response.vec.length,
-      want: EMBEDDING_DIM
-    });
-    return null;
-  }
-
-  const embedding: AudioEmbedding = {
-    trackId,
-    version: EMBEDDING_VERSION,
-    computedAt: new Date().toISOString(),
-    vec: response.vec
-  };
+  if (!embedding) return null;
   await saveEmbedding(embedding);
   return embedding;
 }
@@ -104,9 +174,8 @@ export async function hasEmbedding(trackId: string): Promise<boolean> {
 
 /**
  * Background backfill: compute embeddings for any track that doesn't have
- * one at the current version yet. Sequential — the sidecar handles its own
- * threading, and we'd rather not flood it with concurrent requests for a
- * one-time backfill.
+ * one at the current version yet. Sequential — whichever backend is active
+ * (sidecar or local DSP) handles its own internal concurrency.
  */
 export async function backfillMissingEmbeddings(
   tracks: Array<{ id: string; path: string }>,
@@ -117,9 +186,8 @@ export async function backfillMissingEmbeddings(
   let skipped = 0;
   let failed = 0;
 
-  // Build a Set of trackIds that already have a current-version sidecar.
-  // We readdir once (avoiding stat-per-track for tracks that lack a file)
-  // and then read only the existing sidecars to drop stale-version ones.
+  const profile = await getActiveEmbeddingProfile();
+
   await ensureDir(EMBEDDINGS_DIR);
   const validIds = new Set<string>();
   const entries = await fs.readdir(EMBEDDINGS_DIR).catch(() => [] as string[]);
@@ -137,6 +205,11 @@ export async function backfillMissingEmbeddings(
     })());
   }
   await Promise.all(workers);
+
+  log.info(
+    `Embedding backfill starting (model=${profile.model}, v${profile.version}, ` +
+      `${profile.dim}-dim): ${tracks.length} track(s), ${validIds.size} already current`
+  );
 
   for (let i = 0; i < tracks.length; i++) {
     const track = tracks[i]!;

--- a/backend/src/services/embeddings/audioFeatures.test.ts
+++ b/backend/src/services/embeddings/audioFeatures.test.ts
@@ -1,115 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  EMBEDDING_DIM,
-  FRAME_SIZE,
-  HOP_SIZE,
-  SAMPLE_RATE,
-  computeFeatureVector,
-  cosineSimilarity,
-  fft,
-  meanVector
-} from "./audioFeatures";
+import { EMBEDDING_DIM, EMBEDDING_VERSION, cosineSimilarity, meanVector } from "./audioFeatures";
 
-function sineWave(freq: number, durationSec: number, amplitude = 0.7): Float32Array {
-  const n = Math.floor(SAMPLE_RATE * durationSec);
-  const out = new Float32Array(n);
-  for (let i = 0; i < n; i++) {
-    out[i] = amplitude * Math.sin((2 * Math.PI * freq * i) / SAMPLE_RATE);
-  }
-  return out;
-}
-
-function whiteNoise(durationSec: number, amplitude = 0.3, seed = 1): Float32Array {
-  const n = Math.floor(SAMPLE_RATE * durationSec);
-  const out = new Float32Array(n);
-  // Deterministic PRNG so tests are reproducible.
-  let state = seed >>> 0;
-  for (let i = 0; i < n; i++) {
-    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
-    out[i] = ((state / 0xffffffff) * 2 - 1) * amplitude;
-  }
-  return out;
-}
-
-describe("FFT", () => {
-  it("recovers a known frequency bin from a sine wave", () => {
-    // Sine at exactly bin 32 of a 1024-point FFT at 16kHz: 32 * 16000 / 1024 = 500Hz.
-    const freq = 500;
-    const real = new Float32Array(FRAME_SIZE);
-    const imag = new Float32Array(FRAME_SIZE);
-    for (let i = 0; i < FRAME_SIZE; i++) {
-      real[i] = Math.sin((2 * Math.PI * freq * i) / SAMPLE_RATE);
-    }
-    fft(real, imag);
-
-    const half = FRAME_SIZE / 2 + 1;
-    let maxBin = 0;
-    let maxMag = 0;
-    for (let k = 0; k < half; k++) {
-      const m = Math.sqrt(real[k]! * real[k]! + imag[k]! * imag[k]!);
-      if (m > maxMag) {
-        maxMag = m;
-        maxBin = k;
-      }
-    }
-
-    const dominantFreq = (maxBin * SAMPLE_RATE) / FRAME_SIZE;
-    expect(Math.abs(dominantFreq - freq)).toBeLessThan(SAMPLE_RATE / FRAME_SIZE);
-  });
-});
-
-describe("computeFeatureVector", () => {
-  it("returns null on signals shorter than one frame", () => {
-    const tiny = new Float32Array(FRAME_SIZE - 1);
-    expect(computeFeatureVector(tiny)).toBeNull();
-  });
-
-  it("produces a vector of EMBEDDING_DIM that is L2-unit-normalized", () => {
-    const sig = sineWave(1000, 1.0);
-    const vec = computeFeatureVector(sig);
-    expect(vec).not.toBeNull();
-    expect(vec!.length).toBe(EMBEDDING_DIM);
-    let sumSq = 0;
-    for (const v of vec!) sumSq += v * v;
-    expect(sumSq).toBeGreaterThan(0.99);
-    expect(sumSq).toBeLessThan(1.01);
-  });
-
-  it("is deterministic for the same input", () => {
-    const sig = sineWave(1500, 1.0);
-    const a = computeFeatureVector(sig)!;
-    const b = computeFeatureVector(sig)!;
-    for (let i = 0; i < a.length; i++) {
-      expect(Math.abs(a[i]! - b[i]!)).toBeLessThan(1e-9);
-    }
-  });
-
-  it("treats two close pure tones as more similar than tone vs. noise", () => {
-    const tone1 = computeFeatureVector(sineWave(1000, 1.5))!;
-    const tone2 = computeFeatureVector(sineWave(1100, 1.5))!;
-    const noise = computeFeatureVector(whiteNoise(1.5))!;
-
-    const toneToTone = cosineSimilarity(tone1, tone2);
-    const toneToNoise = cosineSimilarity(tone1, noise);
-    expect(toneToTone).toBeGreaterThan(toneToNoise);
-  });
-
-  it("uses HOP_SIZE worth of frames given a known signal length", () => {
-    // Doesn't directly assert frame count, but exercises the boundary —
-    // a signal exactly FRAME_SIZE long gives one frame.
-    const oneFrame = new Float32Array(FRAME_SIZE);
-    for (let i = 0; i < FRAME_SIZE; i++) {
-      oneFrame[i] = Math.sin((2 * Math.PI * 800 * i) / SAMPLE_RATE);
-    }
-    const vec = computeFeatureVector(oneFrame);
-    expect(vec).not.toBeNull();
-    // With one frame, std dimensions should be ~0 (no variance).
-    // MFCC stds are at indices 13..25.
-    for (let i = 13; i < 26; i++) {
-      expect(vec![i]!).toBeCloseTo(0, 5);
-    }
-    void HOP_SIZE; // referenced for clarity; constant is exported.
+describe("EMBEDDING_DIM / EMBEDDING_VERSION", () => {
+  it("are the CLAP-aligned values", () => {
+    expect(EMBEDDING_DIM).toBe(512);
+    expect(EMBEDDING_VERSION).toBe(3);
   });
 });
 
@@ -146,12 +42,32 @@ describe("meanVector", () => {
     let sq = 0;
     for (const v of m) sq += v * v;
     expect(sq).toBeCloseTo(1, 6);
-    // Mean direction is (0.5, 0.5, 0); after normalization, equal nonzero coords.
     expect(m[0]).toBeCloseTo(m[1]!, 6);
     expect(m[2]).toBeCloseTo(0, 6);
   });
 
   it("returns null on an empty list", () => {
     expect(meanVector([])).toBeNull();
+  });
+
+  it("drops vectors of mismatched dimension instead of crashing", () => {
+    const m = meanVector([
+      [1, 0, 0],
+      [0, 1], // wrong dim — skipped
+      [0, 0, 1]
+    ])!;
+    expect(m.length).toBe(3);
+    // Only the two 3-dim vectors contributed; mean ≈ (0.5, 0, 0.5), normalised.
+    let sq = 0;
+    for (const v of m) sq += v * v;
+    expect(sq).toBeCloseTo(1, 6);
+    expect(m[0]).toBeCloseTo(m[2]!, 6);
+    expect(m[1]).toBeCloseTo(0, 6);
+  });
+
+  it("returns null when all inputs are wrong-dim relative to the first", () => {
+    const m = meanVector([[1, 0, 0], [0, 1], [0, 0]]);
+    // First sets dim=3; remaining two are dim=2 → used=1 → still valid.
+    expect(m).not.toBeNull();
   });
 });

--- a/backend/src/services/embeddings/audioFeatures.test.ts
+++ b/backend/src/services/embeddings/audioFeatures.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { EMBEDDING_DIM, EMBEDDING_VERSION, cosineSimilarity, meanVector } from "./audioFeatures";
+import { CLAP_EMBEDDING_DIM, CLAP_EMBEDDING_VERSION, cosineSimilarity, meanVector } from "./audioFeatures";
 
-describe("EMBEDDING_DIM / EMBEDDING_VERSION", () => {
+describe("CLAP_EMBEDDING_DIM / CLAP_EMBEDDING_VERSION", () => {
   it("are the CLAP-aligned values", () => {
-    expect(EMBEDDING_DIM).toBe(512);
-    expect(EMBEDDING_VERSION).toBe(3);
+    expect(CLAP_EMBEDDING_DIM).toBe(512);
+    expect(CLAP_EMBEDDING_VERSION).toBe(3);
   });
 });
 

--- a/backend/src/services/embeddings/audioFeatures.ts
+++ b/backend/src/services/embeddings/audioFeatures.ts
@@ -1,327 +1,24 @@
 /**
- * Lightweight DSP feature extraction for audio embeddings. Pure functions —
- * no I/O, no ffmpeg, just signal-in / vector-out. Kept separate from the
- * orchestration service so the math is unit-testable with synthetic signals.
+ * Embedding constants and vector-math helpers.
  *
- * The pipeline takes a mono Float32Array at a known sample rate and returns
- * a fixed-length feature vector summarizing the track's timbre and dynamics:
+ * Audio decoding + feature extraction live in the Python sidecar
+ * (`python-services/audio-embedder/`). This file is what the Node-side
+ * ranker uses to consume the persisted vectors.
  *
- *   13× MFCC mean
- *   13× MFCC std
- *    1× spectral centroid mean
- *    1× spectral centroid std
- *    1× spectral rolloff mean
- *    1× spectral flatness mean
- *    1× zero-crossing rate mean
- *    1× RMS mean
- *
- * 32-dimensional vector. Each dimension is L2-normalized at the end so that
- * cosine similarity is a meaningful comparator between two embeddings.
+ * Bump EMBEDDING_VERSION whenever the producing model changes — old
+ * sidecars on disk are no longer comparable. `loadEmbedding` self-
+ * invalidates anything that doesn't match.
  */
 
-export const SAMPLE_RATE = 16000;
-export const FRAME_SIZE = 1024;
-export const HOP_SIZE = 512;
-export const NUM_MEL_FILTERS = 40;
-export const NUM_MFCC_COEFFS = 13;
-export const EMBEDDING_DIM = 32;
-export const EMBEDDING_VERSION = 2;
+/** 512-dim vectors from CLAP (`laion/clap-htsat-fused`). */
+export const EMBEDDING_DIM = 512;
 
 /**
- * Per-feature scaling so no single dimension dominates cosine similarity.
- * Without this, raw centroid/rolloff (Hz, ~10²-10³) drown out MFCCs (~10¹)
- * and 0..1 features (flatness/zcr/rms) under the final L2 normalization.
- *
- * Bump EMBEDDING_VERSION whenever these scales change — old embeddings on
- * disk are no longer comparable.
+ * v1: legacy 32-dim hand-crafted MFCC + spectral stats (pre-versioning).
+ * v2: same shape, scale-normalised so cosine actually compared like with like.
+ * v3: CLAP 512-dim audio embedding, produced by the Python sidecar.
  */
-const NYQUIST = SAMPLE_RATE / 2;
-const MFCC_SCALE = 50;
-
-// ── Window ─────────────────────────────────────────────────────────
-
-const HANN = (() => {
-  const w = new Float32Array(FRAME_SIZE);
-  for (let i = 0; i < FRAME_SIZE; i++) {
-    w[i] = 0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (FRAME_SIZE - 1));
-  }
-  return w;
-})();
-
-// ── FFT (Cooley-Tukey, in-place radix-2) ──────────────────────────
-
-export function fft(real: Float32Array, imag: Float32Array): void {
-  const n = real.length;
-  // Bit-reverse permutation.
-  let j = 0;
-  for (let i = 1; i < n; i++) {
-    let bit = n >> 1;
-    while (j & bit) {
-      j ^= bit;
-      bit >>= 1;
-    }
-    j ^= bit;
-    if (i < j) {
-      const tr = real[i]!;
-      const ti = imag[i]!;
-      real[i] = real[j]!;
-      imag[i] = imag[j]!;
-      real[j] = tr;
-      imag[j] = ti;
-    }
-  }
-  // Butterflies.
-  for (let size = 2; size <= n; size <<= 1) {
-    const half = size >> 1;
-    const angleStep = (-2 * Math.PI) / size;
-    for (let block = 0; block < n; block += size) {
-      for (let k = 0; k < half; k++) {
-        const angle = angleStep * k;
-        const wr = Math.cos(angle);
-        const wi = Math.sin(angle);
-        const idx = block + k;
-        const jdx = idx + half;
-        const tre = real[jdx]! * wr - imag[jdx]! * wi;
-        const tim = real[jdx]! * wi + imag[jdx]! * wr;
-        real[jdx] = real[idx]! - tre;
-        imag[jdx] = imag[idx]! - tim;
-        real[idx] = real[idx]! + tre;
-        imag[idx] = imag[idx]! + tim;
-      }
-    }
-  }
-}
-
-// ── Mel filterbank ────────────────────────────────────────────────
-
-function hzToMel(hz: number): number {
-  return 2595 * Math.log10(1 + hz / 700);
-}
-
-function melToHz(mel: number): number {
-  return 700 * (10 ** (mel / 2595) - 1);
-}
-
-function buildMelFilterbank(
-  numFilters: number,
-  fftSize: number,
-  sampleRate: number
-): Float32Array[] {
-  const halfFft = fftSize / 2 + 1;
-  const melMin = hzToMel(0);
-  const melMax = hzToMel(sampleRate / 2);
-  const points: number[] = [];
-  for (let i = 0; i <= numFilters + 1; i++) {
-    points.push(melMin + ((melMax - melMin) * i) / (numFilters + 1));
-  }
-  const bins = points
-    .map(melToHz)
-    .map((hz) => Math.floor(((fftSize + 1) * hz) / sampleRate));
-
-  const filters: Float32Array[] = [];
-  for (let m = 1; m <= numFilters; m++) {
-    const filter = new Float32Array(halfFft);
-    const lo = bins[m - 1]!;
-    const ce = bins[m]!;
-    const hi = bins[m + 1]!;
-    for (let k = lo; k < ce; k++) {
-      filter[k] = ce === lo ? 0 : (k - lo) / (ce - lo);
-    }
-    for (let k = ce; k < hi; k++) {
-      filter[k] = hi === ce ? 0 : (hi - k) / (hi - ce);
-    }
-    filters.push(filter);
-  }
-  return filters;
-}
-
-const MEL_FILTERS = buildMelFilterbank(NUM_MEL_FILTERS, FRAME_SIZE, SAMPLE_RATE);
-
-// ── DCT-II (used to decorrelate the log-mel into MFCC) ────────────
-
-function dctII(input: Float32Array, numCoeffs: number): Float32Array {
-  const N = input.length;
-  const out = new Float32Array(numCoeffs);
-  const factor = Math.PI / N;
-  for (let k = 0; k < numCoeffs; k++) {
-    let sum = 0;
-    for (let n = 0; n < N; n++) {
-      sum += input[n]! * Math.cos(factor * (n + 0.5) * k);
-    }
-    out[k] = sum;
-  }
-  return out;
-}
-
-// ── Per-frame features ────────────────────────────────────────────
-
-type FrameFeatures = {
-  mfcc: Float32Array;
-  centroid: number;
-  rolloff: number;
-  flatness: number;
-  rms: number;
-  zcr: number;
-};
-
-function frameFeatures(
-  frame: Float32Array,
-  real: Float32Array,
-  imag: Float32Array,
-  mag: Float32Array
-): FrameFeatures {
-  const N = frame.length;
-  for (let i = 0; i < N; i++) {
-    real[i] = frame[i]! * HANN[i]!;
-    imag[i] = 0;
-  }
-  fft(real, imag);
-
-  const half = N / 2 + 1;
-  let totalEnergy = 0;
-  for (let k = 0; k < half; k++) {
-    const re = real[k]!;
-    const im = imag[k]!;
-    const m = Math.sqrt(re * re + im * im);
-    mag[k] = m;
-    totalEnergy += m;
-  }
-
-  // Spectral centroid (Hz, weighted by magnitude).
-  let weightedFreq = 0;
-  for (let k = 0; k < half; k++) {
-    weightedFreq += ((k * SAMPLE_RATE) / N) * mag[k]!;
-  }
-  const centroid = totalEnergy > 0 ? weightedFreq / totalEnergy : 0;
-
-  // Spectral rolloff (frequency under which 85% of energy lies).
-  const rolloffThreshold = totalEnergy * 0.85;
-  let cumulative = 0;
-  let rolloff = SAMPLE_RATE / 2;
-  for (let k = 0; k < half; k++) {
-    cumulative += mag[k]!;
-    if (cumulative >= rolloffThreshold) {
-      rolloff = (k * SAMPLE_RATE) / N;
-      break;
-    }
-  }
-
-  // Spectral flatness (geometric mean / arithmetic mean of magnitude spectrum,
-  // skipping DC). Pure tones → ~0, white noise → ~1.
-  let logSum = 0;
-  let arithSum = 0;
-  let valid = 0;
-  for (let k = 1; k < half; k++) {
-    const m = mag[k]!;
-    if (m > 1e-10) {
-      logSum += Math.log(m);
-      arithSum += m;
-      valid++;
-    }
-  }
-  const flatness =
-    valid > 0 && arithSum > 0
-      ? Math.exp(logSum / valid) / (arithSum / valid)
-      : 0;
-
-  // Mel filterbank → log → DCT → MFCC.
-  const melEnergies = new Float32Array(NUM_MEL_FILTERS);
-  for (let m = 0; m < NUM_MEL_FILTERS; m++) {
-    const filter = MEL_FILTERS[m]!;
-    let energy = 0;
-    for (let k = 0; k < half; k++) {
-      energy += mag[k]! * mag[k]! * filter[k]!;
-    }
-    melEnergies[m] = Math.log(energy + 1e-10);
-  }
-  const mfcc = dctII(melEnergies, NUM_MFCC_COEFFS);
-
-  // Time-domain features.
-  let sumSq = 0;
-  let zeroCrossings = 0;
-  for (let i = 0; i < N; i++) {
-    const s = frame[i]!;
-    sumSq += s * s;
-    if (i > 0 && (frame[i - 1]! >= 0) !== (s >= 0)) zeroCrossings++;
-  }
-  const rms = Math.sqrt(sumSq / N);
-  const zcr = zeroCrossings / N;
-
-  return { mfcc, centroid, rolloff, flatness, rms, zcr };
-}
-
-// ── Whole-track aggregation ────────────────────────────────────────
-
-function meanStd(values: number[]): { mean: number; std: number } {
-  if (values.length === 0) return { mean: 0, std: 0 };
-  let sum = 0;
-  for (const v of values) sum += v;
-  const mean = sum / values.length;
-  let sqDiff = 0;
-  for (const v of values) sqDiff += (v - mean) ** 2;
-  const std = Math.sqrt(sqDiff / values.length);
-  return { mean, std };
-}
-
-function l2Normalize(vec: Float32Array): Float32Array {
-  let sumSq = 0;
-  for (let i = 0; i < vec.length; i++) sumSq += vec[i]! * vec[i]!;
-  const norm = Math.sqrt(sumSq);
-  if (norm < 1e-10) return vec;
-  for (let i = 0; i < vec.length; i++) vec[i] = vec[i]! / norm;
-  return vec;
-}
-
-/**
- * Compute the full feature vector from a mono PCM signal at SAMPLE_RATE.
- * Returns a length-EMBEDDING_DIM vector, L2-normalized so cosine similarity
- * works directly. Returns null if the signal is shorter than one frame.
- */
-export function computeFeatureVector(samples: Float32Array): Float32Array | null {
-  if (samples.length < FRAME_SIZE) return null;
-
-  const mfccByCoeff: number[][] = Array.from({ length: NUM_MFCC_COEFFS }, () => []);
-  const centroids: number[] = [];
-  const rolloffs: number[] = [];
-  const flatnesses: number[] = [];
-  const rmsValues: number[] = [];
-  const zcrs: number[] = [];
-
-  // Pre-allocate working buffers once for the whole track.
-  const frame = new Float32Array(FRAME_SIZE);
-  const real = new Float32Array(FRAME_SIZE);
-  const imag = new Float32Array(FRAME_SIZE);
-  const mag = new Float32Array(FRAME_SIZE / 2 + 1);
-  for (let start = 0; start + FRAME_SIZE <= samples.length; start += HOP_SIZE) {
-    for (let i = 0; i < FRAME_SIZE; i++) frame[i] = samples[start + i]!;
-    const f = frameFeatures(frame, real, imag, mag);
-    for (let c = 0; c < NUM_MFCC_COEFFS; c++) mfccByCoeff[c]!.push(f.mfcc[c]!);
-    centroids.push(f.centroid);
-    rolloffs.push(f.rolloff);
-    flatnesses.push(f.flatness);
-    rmsValues.push(f.rms);
-    zcrs.push(f.zcr);
-  }
-
-  if (centroids.length === 0) return null;
-
-  const mfccStats = mfccByCoeff.map(meanStd);
-  const out = new Float32Array(EMBEDDING_DIM);
-  let idx = 0;
-  for (let c = 0; c < NUM_MFCC_COEFFS; c++) out[idx++] = mfccStats[c]!.mean / MFCC_SCALE;
-  for (let c = 0; c < NUM_MFCC_COEFFS; c++) out[idx++] = mfccStats[c]!.std / MFCC_SCALE;
-  const cm = meanStd(centroids);
-  out[idx++] = cm.mean / NYQUIST;
-  out[idx++] = cm.std / NYQUIST;
-  out[idx++] = meanStd(rolloffs).mean / NYQUIST;
-  out[idx++] = meanStd(flatnesses).mean;
-  out[idx++] = meanStd(zcrs).mean;
-  out[idx++] = meanStd(rmsValues).mean;
-
-  return l2Normalize(out);
-}
-
-// ── Cosine similarity ─────────────────────────────────────────────
+export const EMBEDDING_VERSION = 3;
 
 export function cosineSimilarity(a: ArrayLike<number>, b: ArrayLike<number>): number {
   if (a.length !== b.length) return 0;
@@ -339,15 +36,24 @@ export function cosineSimilarity(a: ArrayLike<number>, b: ArrayLike<number>): nu
   return denom > 0 ? dot / denom : 0;
 }
 
-/** Mean of a set of vectors, then L2-normalized. */
+/** Mean of a set of vectors, L2-normalized. Drops vectors of mismatched dim. */
 export function meanVector(vectors: ArrayLike<number>[]): Float32Array | null {
   if (vectors.length === 0) return null;
   const dim = vectors[0]!.length;
   const out = new Float32Array(dim);
+  let used = 0;
   for (const v of vectors) {
     if (v.length !== dim) continue;
     for (let i = 0; i < dim; i++) out[i] = out[i]! + v[i]!;
+    used++;
   }
-  for (let i = 0; i < dim; i++) out[i] = out[i]! / vectors.length;
-  return l2Normalize(out);
+  if (used === 0) return null;
+  for (let i = 0; i < dim; i++) out[i] = out[i]! / used;
+
+  let sumSq = 0;
+  for (let i = 0; i < dim; i++) sumSq += out[i]! * out[i]!;
+  const norm = Math.sqrt(sumSq);
+  if (norm < 1e-10) return out;
+  for (let i = 0; i < dim; i++) out[i] = out[i]! / norm;
+  return out;
 }

--- a/backend/src/services/embeddings/audioFeatures.ts
+++ b/backend/src/services/embeddings/audioFeatures.ts
@@ -1,25 +1,39 @@
 /**
- * Embedding constants and vector-math helpers.
+ * CLAP embedding constants and generic vector-math helpers.
  *
  * Audio decoding + feature extraction live in the Python sidecar
- * (`python-services/audio-embedder/`). This file is what the Node-side
- * ranker uses to consume the persisted vectors.
+ * (`python-services/audio-embedder/`). This file is the Node-side header:
+ * the dimension/version constants that describe what the sidecar writes,
+ * plus pure helpers (`cosineSimilarity`, `meanVector`) that work on any
+ * vector regardless of which model produced it.
  *
- * Bump EMBEDDING_VERSION whenever the producing model changes — old
- * sidecars on disk are no longer comparable. `loadEmbedding` self-
- * invalidates anything that doesn't match.
+ * The CLAP-specific constants are kept here for symmetry with
+ * `mfccEmbedder.ts` (which exports the matching MFCC_* constants).
+ * `audioEmbeddingService.ts` picks one or the other at runtime based on
+ * the library setting.
+ *
+ * Bump `CLAP_EMBEDDING_VERSION` whenever the CLAP model or post-processing
+ * changes — old sidecars on disk are no longer comparable. `loadEmbedding`
+ * self-invalidates anything that doesn't match the currently active version.
  */
 
-/** 512-dim vectors from CLAP (`laion/clap-htsat-fused`). */
-export const EMBEDDING_DIM = 512;
+/** Output dimension of `laion/clap-htsat-fused` (audio tower projection). */
+export const CLAP_EMBEDDING_DIM = 512;
 
 /**
- * v1: legacy 32-dim hand-crafted MFCC + spectral stats (pre-versioning).
- * v2: same shape, scale-normalised so cosine actually compared like with like.
- * v3: CLAP 512-dim audio embedding, produced by the Python sidecar.
+ * On-disk version tag for CLAP sidecars.
+ *
+ *   v1: legacy 32-dim hand-crafted MFCC + spectral stats (pre-versioning).
+ *   v2: same 32-dim shape, scale-normalised so cosine is meaningful.
+ *   v3: CLAP 512-dim audio embedding, produced by the Python sidecar.
  */
-export const EMBEDDING_VERSION = 3;
+export const CLAP_EMBEDDING_VERSION = 3;
 
+/**
+ * Cosine similarity between two equal-length numeric vectors. Returns a
+ * value in `[-1, 1]`; returns `0` for empty / mismatched-length / all-zero
+ * inputs so callers never have to special-case those cases.
+ */
 export function cosineSimilarity(a: ArrayLike<number>, b: ArrayLike<number>): number {
   if (a.length !== b.length) return 0;
   let dot = 0;
@@ -36,7 +50,21 @@ export function cosineSimilarity(a: ArrayLike<number>, b: ArrayLike<number>): nu
   return denom > 0 ? dot / denom : 0;
 }
 
-/** Mean of a set of vectors, L2-normalized. Drops vectors of mismatched dim. */
+/**
+ * Element-wise mean of the input vectors, then L2-normalised so cosine
+ * similarity against the result stays a meaningful comparator.
+ *
+ * Robustness contract:
+ *   - Returns `null` for an empty input list.
+ *   - Vectors whose length doesn't match the first vector's length are
+ *     silently dropped. If every subsequent vector is dropped, the mean
+ *     is taken over what survived (including just the first vector).
+ *   - Returns `null` if no vector survived the dim check.
+ *
+ * Dropping mismatched dims (rather than throwing) is what lets a mixed
+ * v2 / v3 embedding period during a backfill produce *some* result
+ * instead of crashing the regenerator.
+ */
 export function meanVector(vectors: ArrayLike<number>[]): Float32Array | null {
   if (vectors.length === 0) return null;
   const dim = vectors[0]!.length;

--- a/backend/src/services/embeddings/embedderClient.test.ts
+++ b/backend/src/services/embeddings/embedderClient.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { pingEmbedder, requestEmbedding } from "./embedderClient";
+
+type FetchArgs = Parameters<typeof fetch>;
+type FetchHandler = (...args: FetchArgs) => Promise<Response> | Response;
+
+function mockFetch(handler: FetchHandler): void {
+  vi.stubGlobal("fetch", vi.fn(handler) as typeof fetch);
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = { status: 200 }): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "Content-Type": "application/json", ...(init.headers ?? {}) }
+  });
+}
+
+describe("embedderClient", () => {
+  beforeEach(() => {
+    delete process.env.AUDIO_EMBEDDER_URL;
+    delete process.env.AUDIO_EMBEDDER_TIMEOUT_MS;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe("requestEmbedding", () => {
+    it("returns the parsed vector on a happy-path response", async () => {
+      const vec = Array.from({ length: 512 }, (_, i) => (i % 7) * 0.001);
+      mockFetch(async () => jsonResponse({ vec, dim: 512, model: "stub" }));
+      const result = await requestEmbedding("/abs/path/track.mp3");
+      expect(result).not.toBeNull();
+      expect(result?.dim).toBe(512);
+      expect(result?.vec).toHaveLength(512);
+      expect(result?.model).toBe("stub");
+    });
+
+    it("POSTs to /embed with the absolute path in the JSON body", async () => {
+      const calls: { url: string; init: RequestInit }[] = [];
+      mockFetch(async (input, init) => {
+        calls.push({ url: String(input), init: init ?? {} });
+        return jsonResponse({ vec: [0, 1], dim: 2, model: "stub" });
+      });
+      await requestEmbedding("/abs/path/track.mp3");
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.url).toBe("http://127.0.0.1:7001/embed");
+      expect(calls[0]?.init.method).toBe("POST");
+      expect(JSON.parse(String(calls[0]?.init.body))).toEqual({
+        absolutePath: "/abs/path/track.mp3"
+      });
+    });
+
+    it("honors AUDIO_EMBEDDER_URL and strips trailing slashes", async () => {
+      process.env.AUDIO_EMBEDDER_URL = "http://example.local:9000/";
+      const calls: string[] = [];
+      mockFetch(async (input) => {
+        calls.push(String(input));
+        return jsonResponse({ vec: [0], dim: 1, model: "stub" });
+      });
+      await requestEmbedding("/x");
+      expect(calls[0]).toBe("http://example.local:9000/embed");
+    });
+
+    it("returns null for empty paths without calling fetch", async () => {
+      const fetcher = vi.fn();
+      vi.stubGlobal("fetch", fetcher as unknown as typeof fetch);
+      const result = await requestEmbedding("");
+      expect(result).toBeNull();
+      expect(fetcher).not.toHaveBeenCalled();
+    });
+
+    it("returns null on network errors", async () => {
+      mockFetch(async () => {
+        throw new Error("ECONNREFUSED");
+      });
+      const result = await requestEmbedding("/abs/path/track.mp3");
+      expect(result).toBeNull();
+    });
+
+    it("returns null on non-OK HTTP status", async () => {
+      mockFetch(async () => new Response("nope", { status: 500 }));
+      const result = await requestEmbedding("/abs/path/track.mp3");
+      expect(result).toBeNull();
+    });
+
+    it("returns null when the body isn't valid JSON", async () => {
+      mockFetch(async () => new Response("not json", { status: 200 }));
+      const result = await requestEmbedding("/abs/path/track.mp3");
+      expect(result).toBeNull();
+    });
+
+    it("rejects responses whose vec length does not match dim", async () => {
+      mockFetch(async () =>
+        jsonResponse({ vec: [0.1, 0.2], dim: 512, model: "stub" })
+      );
+      const result = await requestEmbedding("/abs/path/track.mp3");
+      expect(result).toBeNull();
+    });
+
+    it("rejects responses with non-finite numbers in vec", async () => {
+      mockFetch(async () =>
+        jsonResponse({ vec: [0.1, Number.NaN], dim: 2, model: "stub" })
+      );
+      const result = await requestEmbedding("/abs/path/track.mp3");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("pingEmbedder", () => {
+    it("returns ok/model on healthy response", async () => {
+      mockFetch(async () => jsonResponse({ ok: true, model: "stub" }));
+      const result = await pingEmbedder();
+      expect(result).toEqual({ ok: true, model: "stub" });
+    });
+
+    it("returns null when health check fails to connect", async () => {
+      mockFetch(async () => {
+        throw new Error("ECONNREFUSED");
+      });
+      const result = await pingEmbedder();
+      expect(result).toBeNull();
+    });
+
+    it("returns null when health body is malformed", async () => {
+      mockFetch(async () => jsonResponse({ status: "fine" }));
+      const result = await pingEmbedder();
+      expect(result).toBeNull();
+    });
+
+    it("hits /healthz at the configured base URL", async () => {
+      process.env.AUDIO_EMBEDDER_URL = "http://other.host:8000";
+      const calls: string[] = [];
+      mockFetch(async (input) => {
+        calls.push(String(input));
+        return jsonResponse({ ok: true, model: "stub" });
+      });
+      await pingEmbedder();
+      expect(calls[0]).toBe("http://other.host:8000/healthz");
+    });
+  });
+});

--- a/backend/src/services/embeddings/embedderClient.ts
+++ b/backend/src/services/embeddings/embedderClient.ts
@@ -1,0 +1,142 @@
+/**
+ * Node-side client for the audio-embedder Python sidecar.
+ *
+ * Phase 1: protocol-only. The production embedding path
+ * (`computeAndSaveEmbedding`) still uses the in-process DSP pipeline in
+ * `audioFeatures.ts`. This client exists so we can exercise the wire format
+ * end-to-end (via `npm run embed:probe`) before phase 3 swaps the production
+ * call site over.
+ *
+ * Best-effort semantics match the rest of the embedding pipeline:
+ * any failure (network, timeout, bad status, malformed body) returns `null`
+ * and logs a warning — the caller is expected to fall back gracefully.
+ */
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("embedder-client");
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:7001";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export type EmbedderResponse = {
+  vec: number[];
+  dim: number;
+  model: string;
+};
+
+export type EmbedderHealth = {
+  ok: boolean;
+  model: string;
+};
+
+function baseUrl(): string {
+  const raw = (process.env.AUDIO_EMBEDDER_URL ?? "").trim();
+  return raw.length > 0 ? raw.replace(/\/+$/, "") : DEFAULT_BASE_URL;
+}
+
+function timeoutMs(): number {
+  const raw = Number(process.env.AUDIO_EMBEDDER_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TIMEOUT_MS;
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs());
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function isValidEmbedderResponse(body: unknown): body is EmbedderResponse {
+  if (!body || typeof body !== "object") return false;
+  const r = body as Record<string, unknown>;
+  if (!Array.isArray(r.vec)) return false;
+  if (typeof r.dim !== "number") return false;
+  if (typeof r.model !== "string") return false;
+  if (r.vec.length !== r.dim) return false;
+  for (const v of r.vec) {
+    if (typeof v !== "number" || !Number.isFinite(v)) return false;
+  }
+  return true;
+}
+
+/**
+ * Ask the sidecar for an embedding of the file at `absolutePath`.
+ *
+ * The sidecar reads the file directly (same host), so we send only the path
+ * rather than the audio bytes. Returns null on any failure.
+ */
+export async function requestEmbedding(absolutePath: string): Promise<EmbedderResponse | null> {
+  if (!absolutePath) {
+    log.warn("requestEmbedding called with empty path");
+    return null;
+  }
+
+  const url = `${baseUrl()}/embed`;
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ absolutePath })
+    });
+  } catch (error) {
+    log.warn("Embedder request failed", { url, error: String(error) });
+    return null;
+  }
+
+  if (!response.ok) {
+    let detail = "";
+    try {
+      detail = (await response.text()).slice(0, 200);
+    } catch {
+      // ignore — we'll log status only
+    }
+    log.warn("Embedder returned non-OK status", { status: response.status, detail });
+    return null;
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (error) {
+    log.warn("Embedder returned non-JSON body", { error: String(error) });
+    return null;
+  }
+
+  if (!isValidEmbedderResponse(body)) {
+    log.warn("Embedder returned malformed body", { body });
+    return null;
+  }
+
+  return body;
+}
+
+/**
+ * Check the sidecar is reachable. Returns null when the health check fails,
+ * which is treated by callers as "fall back to in-process embedding".
+ */
+export async function pingEmbedder(): Promise<EmbedderHealth | null> {
+  const url = `${baseUrl()}/healthz`;
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(url, { method: "GET" });
+  } catch (error) {
+    log.debug("Embedder health check failed", { url, error: String(error) });
+    return null;
+  }
+  if (!response.ok) {
+    log.debug("Embedder health check non-OK", { status: response.status });
+    return null;
+  }
+  try {
+    const body = (await response.json()) as Partial<EmbedderHealth>;
+    if (typeof body.ok !== "boolean" || typeof body.model !== "string") return null;
+    return { ok: body.ok, model: body.model };
+  } catch (error) {
+    log.debug("Embedder health body malformed", { error: String(error) });
+    return null;
+  }
+}

--- a/backend/src/services/embeddings/embedderClient.ts
+++ b/backend/src/services/embeddings/embedderClient.ts
@@ -1,22 +1,25 @@
 /**
  * Node-side client for the audio-embedder Python sidecar.
  *
- * Phase 1: protocol-only. The production embedding path
- * (`computeAndSaveEmbedding`) still uses the in-process DSP pipeline in
- * `audioFeatures.ts`. This client exists so we can exercise the wire format
- * end-to-end (via `npm run embed:probe`) before phase 3 swaps the production
- * call site over.
+ * `computeAndSaveEmbedding` in audioEmbeddingService.ts calls this on every
+ * new upload and during the backfill loop. The sidecar runs the CLAP model;
+ * we send only the absolute path (same host, no network bytes for the audio).
  *
  * Best-effort semantics match the rest of the embedding pipeline:
  * any failure (network, timeout, bad status, malformed body) returns `null`
- * and logs a warning — the caller is expected to fall back gracefully.
+ * and logs a warning — the caller falls back to "no embedding for this track"
+ * and the ranker uses NEUTRAL_EMBEDDING_SIMILARITY in its place.
  */
 import { createLogger } from "../../utils/logger";
 
 const log = createLogger("embedder-client");
 
 const DEFAULT_BASE_URL = "http://127.0.0.1:7001";
-const DEFAULT_TIMEOUT_MS = 10_000;
+// CLAP backfill: ~1.5 s/track on a typical 3-min file, but multi-minute
+// prog-rock / live recordings (e.g. Echoes, 23 min) genuinely need 10–15 s
+// to decode + window. 60 s gives generous headroom while still failing
+// fast on a hung sidecar. Override per-call via AUDIO_EMBEDDER_TIMEOUT_MS.
+const DEFAULT_TIMEOUT_MS = 60_000;
 
 export type EmbedderResponse = {
   vec: number[];

--- a/backend/src/services/embeddings/embedderClient.ts
+++ b/backend/src/services/embeddings/embedderClient.ts
@@ -21,12 +21,17 @@ const DEFAULT_BASE_URL = "http://127.0.0.1:7001";
 // fast on a hung sidecar. Override per-call via AUDIO_EMBEDDER_TIMEOUT_MS.
 const DEFAULT_TIMEOUT_MS = 60_000;
 
+/** Wire response from the sidecar's `POST /embed`. */
 export type EmbedderResponse = {
+  /** Embedding vector. Always L2-normalised by the sidecar. */
   vec: number[];
+  /** Sidecar-reported dimension. Validated to match `vec.length` before return. */
   dim: number;
+  /** Model identifier the sidecar is using (e.g. `laion/clap-htsat-fused`). */
   model: string;
 };
 
+/** Wire response from the sidecar's `GET /healthz`. */
 export type EmbedderHealth = {
   ok: boolean;
   model: string;
@@ -52,6 +57,11 @@ async function fetchWithTimeout(url: string, init: RequestInit): Promise<Respons
   }
 }
 
+/**
+ * Structural validator for `/embed` responses. Rejects anything missing the
+ * three required fields, length mismatches between `vec` and `dim`, or
+ * non-finite numbers in `vec` (which would poison cosine similarity).
+ */
 function isValidEmbedderResponse(body: unknown): body is EmbedderResponse {
   if (!body || typeof body !== "object") return false;
   const r = body as Record<string, unknown>;

--- a/backend/src/services/embeddings/mfccEmbedder.ts
+++ b/backend/src/services/embeddings/mfccEmbedder.ts
@@ -232,6 +232,22 @@ function l2Normalize(vec: Float32Array): Float32Array {
   return vec;
 }
 
+/**
+ * Aggregate per-frame MFCC + spectral + time-domain stats into one
+ * fixed-length, L2-normalised vector. Caller passes mono PCM at
+ * `SAMPLE_RATE` (16 kHz). Returns `null` if the signal is shorter than
+ * one frame; the orchestrator treats that as "no embedding for this track".
+ *
+ * Output layout (length `MFCC_EMBEDDING_DIM` = 32):
+ *   - 13× MFCC means (scaled by 1/MFCC_SCALE)
+ *   - 13× MFCC stds (scaled by 1/MFCC_SCALE)
+ *   - spectral centroid mean (Hz / NYQUIST)
+ *   - spectral centroid std (Hz / NYQUIST)
+ *   - spectral rolloff mean (Hz / NYQUIST)
+ *   - spectral flatness mean (already 0..1)
+ *   - zero-crossing rate mean (already 0..1)
+ *   - RMS mean
+ */
 export function computeMfccVector(samples: Float32Array): Float32Array | null {
   if (samples.length < FRAME_SIZE) return null;
 

--- a/backend/src/services/embeddings/mfccEmbedder.ts
+++ b/backend/src/services/embeddings/mfccEmbedder.ts
@@ -1,0 +1,330 @@
+/**
+ * Legacy in-process audio embedder.
+ *
+ * Produces a 32-dim hand-crafted feature vector (13× MFCC mean + 13× MFCC
+ * std + spectral centroid mean/std + rolloff mean + flatness mean + ZCR
+ * mean + RMS mean), L2-normalised. This is the pipeline that shipped
+ * before CLAP and is kept here for operators who disable AI recommendation
+ * to spare a light server the ~1 GB CLAP sidecar.
+ *
+ * Pipeline: ffmpeg → mono 16 kHz Float32 PCM → DSP → 32-dim vector.
+ * No external dependencies beyond ffmpeg on PATH.
+ */
+
+import { spawn } from "node:child_process";
+
+export const SAMPLE_RATE = 16000;
+export const FRAME_SIZE = 1024;
+export const HOP_SIZE = 512;
+export const NUM_MEL_FILTERS = 40;
+export const NUM_MFCC_COEFFS = 13;
+
+/** 13 MFCC means + 13 stds + 6 spectral / time-domain scalars. */
+export const MFCC_EMBEDDING_DIM = 32;
+export const MFCC_EMBEDDING_VERSION = 2;
+
+const NYQUIST = SAMPLE_RATE / 2;
+const MFCC_SCALE = 50;
+
+// ── Window ─────────────────────────────────────────────────────────
+
+const HANN = (() => {
+  const w = new Float32Array(FRAME_SIZE);
+  for (let i = 0; i < FRAME_SIZE; i++) {
+    w[i] = 0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (FRAME_SIZE - 1));
+  }
+  return w;
+})();
+
+// ── FFT (Cooley-Tukey, in-place radix-2) ──────────────────────────
+
+export function fft(real: Float32Array, imag: Float32Array): void {
+  const n = real.length;
+  let j = 0;
+  for (let i = 1; i < n; i++) {
+    let bit = n >> 1;
+    while (j & bit) {
+      j ^= bit;
+      bit >>= 1;
+    }
+    j ^= bit;
+    if (i < j) {
+      const tr = real[i]!;
+      const ti = imag[i]!;
+      real[i] = real[j]!;
+      imag[i] = imag[j]!;
+      real[j] = tr;
+      imag[j] = ti;
+    }
+  }
+  for (let size = 2; size <= n; size <<= 1) {
+    const half = size >> 1;
+    const angleStep = (-2 * Math.PI) / size;
+    for (let block = 0; block < n; block += size) {
+      for (let k = 0; k < half; k++) {
+        const angle = angleStep * k;
+        const wr = Math.cos(angle);
+        const wi = Math.sin(angle);
+        const idx = block + k;
+        const jdx = idx + half;
+        const tre = real[jdx]! * wr - imag[jdx]! * wi;
+        const tim = real[jdx]! * wi + imag[jdx]! * wr;
+        real[jdx] = real[idx]! - tre;
+        imag[jdx] = imag[idx]! - tim;
+        real[idx] = real[idx]! + tre;
+        imag[idx] = imag[idx]! + tim;
+      }
+    }
+  }
+}
+
+// ── Mel filterbank ────────────────────────────────────────────────
+
+function hzToMel(hz: number): number {
+  return 2595 * Math.log10(1 + hz / 700);
+}
+
+function melToHz(mel: number): number {
+  return 700 * (10 ** (mel / 2595) - 1);
+}
+
+function buildMelFilterbank(numFilters: number, fftSize: number, sampleRate: number): Float32Array[] {
+  const halfFft = fftSize / 2 + 1;
+  const melMin = hzToMel(0);
+  const melMax = hzToMel(sampleRate / 2);
+  const points: number[] = [];
+  for (let i = 0; i <= numFilters + 1; i++) {
+    points.push(melMin + ((melMax - melMin) * i) / (numFilters + 1));
+  }
+  const bins = points.map(melToHz).map((hz) => Math.floor(((fftSize + 1) * hz) / sampleRate));
+
+  const filters: Float32Array[] = [];
+  for (let m = 1; m <= numFilters; m++) {
+    const filter = new Float32Array(halfFft);
+    const lo = bins[m - 1]!;
+    const ce = bins[m]!;
+    const hi = bins[m + 1]!;
+    for (let k = lo; k < ce; k++) filter[k] = ce === lo ? 0 : (k - lo) / (ce - lo);
+    for (let k = ce; k < hi; k++) filter[k] = hi === ce ? 0 : (hi - k) / (hi - ce);
+    filters.push(filter);
+  }
+  return filters;
+}
+
+const MEL_FILTERS = buildMelFilterbank(NUM_MEL_FILTERS, FRAME_SIZE, SAMPLE_RATE);
+
+// ── DCT-II ────────────────────────────────────────────────────────
+
+function dctII(input: Float32Array, numCoeffs: number): Float32Array {
+  const N = input.length;
+  const out = new Float32Array(numCoeffs);
+  const factor = Math.PI / N;
+  for (let k = 0; k < numCoeffs; k++) {
+    let sum = 0;
+    for (let n = 0; n < N; n++) sum += input[n]! * Math.cos(factor * (n + 0.5) * k);
+    out[k] = sum;
+  }
+  return out;
+}
+
+// ── Per-frame features ────────────────────────────────────────────
+
+type FrameFeatures = {
+  mfcc: Float32Array;
+  centroid: number;
+  rolloff: number;
+  flatness: number;
+  rms: number;
+  zcr: number;
+};
+
+function frameFeatures(
+  frame: Float32Array,
+  real: Float32Array,
+  imag: Float32Array,
+  mag: Float32Array
+): FrameFeatures {
+  const N = frame.length;
+  for (let i = 0; i < N; i++) {
+    real[i] = frame[i]! * HANN[i]!;
+    imag[i] = 0;
+  }
+  fft(real, imag);
+
+  const half = N / 2 + 1;
+  let totalEnergy = 0;
+  for (let k = 0; k < half; k++) {
+    const re = real[k]!;
+    const im = imag[k]!;
+    const m = Math.sqrt(re * re + im * im);
+    mag[k] = m;
+    totalEnergy += m;
+  }
+
+  let weightedFreq = 0;
+  for (let k = 0; k < half; k++) weightedFreq += ((k * SAMPLE_RATE) / N) * mag[k]!;
+  const centroid = totalEnergy > 0 ? weightedFreq / totalEnergy : 0;
+
+  const rolloffThreshold = totalEnergy * 0.85;
+  let cumulative = 0;
+  let rolloff = SAMPLE_RATE / 2;
+  for (let k = 0; k < half; k++) {
+    cumulative += mag[k]!;
+    if (cumulative >= rolloffThreshold) {
+      rolloff = (k * SAMPLE_RATE) / N;
+      break;
+    }
+  }
+
+  let logSum = 0;
+  let arithSum = 0;
+  let valid = 0;
+  for (let k = 1; k < half; k++) {
+    const m = mag[k]!;
+    if (m > 1e-10) {
+      logSum += Math.log(m);
+      arithSum += m;
+      valid++;
+    }
+  }
+  const flatness = valid > 0 && arithSum > 0 ? Math.exp(logSum / valid) / (arithSum / valid) : 0;
+
+  const melEnergies = new Float32Array(NUM_MEL_FILTERS);
+  for (let m = 0; m < NUM_MEL_FILTERS; m++) {
+    const filter = MEL_FILTERS[m]!;
+    let energy = 0;
+    for (let k = 0; k < half; k++) energy += mag[k]! * mag[k]! * filter[k]!;
+    melEnergies[m] = Math.log(energy + 1e-10);
+  }
+  const mfcc = dctII(melEnergies, NUM_MFCC_COEFFS);
+
+  let sumSq = 0;
+  let zeroCrossings = 0;
+  for (let i = 0; i < N; i++) {
+    const s = frame[i]!;
+    sumSq += s * s;
+    if (i > 0 && (frame[i - 1]! >= 0) !== (s >= 0)) zeroCrossings++;
+  }
+  const rms = Math.sqrt(sumSq / N);
+  const zcr = zeroCrossings / N;
+
+  return { mfcc, centroid, rolloff, flatness, rms, zcr };
+}
+
+// ── Whole-track aggregation ────────────────────────────────────────
+
+function meanStd(values: number[]): { mean: number; std: number } {
+  if (values.length === 0) return { mean: 0, std: 0 };
+  let sum = 0;
+  for (const v of values) sum += v;
+  const mean = sum / values.length;
+  let sqDiff = 0;
+  for (const v of values) sqDiff += (v - mean) ** 2;
+  return { mean, std: Math.sqrt(sqDiff / values.length) };
+}
+
+function l2Normalize(vec: Float32Array): Float32Array {
+  let sumSq = 0;
+  for (let i = 0; i < vec.length; i++) sumSq += vec[i]! * vec[i]!;
+  const norm = Math.sqrt(sumSq);
+  if (norm < 1e-10) return vec;
+  for (let i = 0; i < vec.length; i++) vec[i] = vec[i]! / norm;
+  return vec;
+}
+
+export function computeMfccVector(samples: Float32Array): Float32Array | null {
+  if (samples.length < FRAME_SIZE) return null;
+
+  const mfccByCoeff: number[][] = Array.from({ length: NUM_MFCC_COEFFS }, () => []);
+  const centroids: number[] = [];
+  const rolloffs: number[] = [];
+  const flatnesses: number[] = [];
+  const rmsValues: number[] = [];
+  const zcrs: number[] = [];
+
+  const frame = new Float32Array(FRAME_SIZE);
+  const real = new Float32Array(FRAME_SIZE);
+  const imag = new Float32Array(FRAME_SIZE);
+  const mag = new Float32Array(FRAME_SIZE / 2 + 1);
+  for (let start = 0; start + FRAME_SIZE <= samples.length; start += HOP_SIZE) {
+    for (let i = 0; i < FRAME_SIZE; i++) frame[i] = samples[start + i]!;
+    const f = frameFeatures(frame, real, imag, mag);
+    for (let c = 0; c < NUM_MFCC_COEFFS; c++) mfccByCoeff[c]!.push(f.mfcc[c]!);
+    centroids.push(f.centroid);
+    rolloffs.push(f.rolloff);
+    flatnesses.push(f.flatness);
+    rmsValues.push(f.rms);
+    zcrs.push(f.zcr);
+  }
+
+  if (centroids.length === 0) return null;
+
+  const mfccStats = mfccByCoeff.map(meanStd);
+  const out = new Float32Array(MFCC_EMBEDDING_DIM);
+  let idx = 0;
+  for (let c = 0; c < NUM_MFCC_COEFFS; c++) out[idx++] = mfccStats[c]!.mean / MFCC_SCALE;
+  for (let c = 0; c < NUM_MFCC_COEFFS; c++) out[idx++] = mfccStats[c]!.std / MFCC_SCALE;
+  const cm = meanStd(centroids);
+  out[idx++] = cm.mean / NYQUIST;
+  out[idx++] = cm.std / NYQUIST;
+  out[idx++] = meanStd(rolloffs).mean / NYQUIST;
+  out[idx++] = meanStd(flatnesses).mean;
+  out[idx++] = meanStd(zcrs).mean;
+  out[idx++] = meanStd(rmsValues).mean;
+
+  return l2Normalize(out);
+}
+
+// ── Decode ────────────────────────────────────────────────────────
+
+/**
+ * Decode an audio file to mono 16 kHz Float32 PCM via ffmpeg. Returns
+ * the raw samples as a Float32Array. Used only when AI recommendation
+ * is disabled; the CLAP sidecar handles its own decoding.
+ */
+export function decodeToPcm(absolutePath: string): Promise<Float32Array> {
+  return new Promise((resolve, reject) => {
+    const ffmpeg = spawn(
+      "ffmpeg",
+      ["-v", "error", "-i", absolutePath, "-vn", "-ac", "1", "-ar", String(SAMPLE_RATE), "-f", "f32le", "-"],
+      { stdio: ["ignore", "pipe", "pipe"] }
+    );
+
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    let stderr = "";
+
+    ffmpeg.stdout.on("data", (chunk: Buffer) => {
+      chunks.push(chunk);
+      totalBytes += chunk.length;
+    });
+
+    ffmpeg.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+      if (stderr.length > 4096) stderr = stderr.slice(-4096);
+    });
+
+    ffmpeg.on("error", (err) => reject(new Error(`ffmpeg failed to start: ${err.message}`)));
+
+    ffmpeg.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`ffmpeg exited with code ${code}: ${stderr.trim()}`));
+        return;
+      }
+      // Buffer.concat's underlying ArrayBuffer offset isn't guaranteed to be
+      // 4-byte aligned, which is required to construct a Float32Array view.
+      const usable = totalBytes - (totalBytes % 4);
+      const aligned = new ArrayBuffer(usable);
+      const dst = new Uint8Array(aligned);
+      let offset = 0;
+      for (const chunk of chunks) {
+        const remaining = usable - offset;
+        if (remaining <= 0) break;
+        const len = Math.min(chunk.length, remaining);
+        dst.set(chunk.subarray(0, len), offset);
+        offset += len;
+      }
+      resolve(new Float32Array(aligned));
+    });
+  });
+}

--- a/backend/src/services/librarySettings/librarySettings.test.ts
+++ b/backend/src/services/librarySettings/librarySettings.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let tmpDir: string;
+
+vi.mock("../../utils/paths", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../utils/paths")>();
+  return {
+    ...original,
+    get dataRoot() {
+      return path.join(tmpDir, "data");
+    }
+  };
+});
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "library-settings-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("librarySettings", () => {
+  it("returns aiRecommendation=true by default when no file exists", async () => {
+    const { getLibrarySettings } = await import("./librarySettings");
+    const settings = await getLibrarySettings();
+    expect(settings.aiRecommendation).toBe(true);
+  });
+
+  it("persists an update and reads it back", async () => {
+    const { getLibrarySettings, updateLibrarySettings } = await import("./librarySettings");
+    const updated = await updateLibrarySettings({ aiRecommendation: false });
+    expect(updated.aiRecommendation).toBe(false);
+
+    const reloaded = await getLibrarySettings();
+    expect(reloaded.aiRecommendation).toBe(false);
+  });
+
+  it("ignores non-boolean values in a patch", async () => {
+    const { getLibrarySettings, updateLibrarySettings } = await import("./librarySettings");
+    await updateLibrarySettings({ aiRecommendation: false });
+
+    // Pretend a misbehaving client sent a string. Should keep current value.
+    const after = await updateLibrarySettings({ aiRecommendation: "off" as unknown as boolean });
+    expect(after.aiRecommendation).toBe(false);
+
+    const reloaded = await getLibrarySettings();
+    expect(reloaded.aiRecommendation).toBe(false);
+  });
+
+  it("falls back to default when the on-disk value is malformed", async () => {
+    const { getLibrarySettings } = await import("./librarySettings");
+    const configDir = path.join(tmpDir, "data", "config");
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(
+      path.join(configDir, "library-settings.json"),
+      JSON.stringify({ aiRecommendation: "garbage" })
+    );
+
+    const settings = await getLibrarySettings();
+    expect(settings.aiRecommendation).toBe(true);
+  });
+});

--- a/backend/src/services/librarySettings/librarySettings.ts
+++ b/backend/src/services/librarySettings/librarySettings.ts
@@ -29,6 +29,11 @@ const DEFAULT_SETTINGS: LibrarySettings = {
   aiRecommendation: true
 };
 
+/**
+ * Read the current library-wide settings. Missing or malformed fields
+ * fall back to `DEFAULT_SETTINGS`, so callers always get a fully-populated
+ * value and never have to special-case "settings file doesn't exist yet".
+ */
 export async function getLibrarySettings(): Promise<LibrarySettings> {
   const raw = await readJsonFile<Partial<LibrarySettings>>(settingsFile(), {});
   return {
@@ -38,6 +43,14 @@ export async function getLibrarySettings(): Promise<LibrarySettings> {
   };
 }
 
+/**
+ * Merge `patch` into the current settings and persist atomically. Fields
+ * whose patch value isn't a valid type are silently ignored — the API
+ * route is the right layer for telling a misbehaving client off, this
+ * helper is just defensive about what lands on disk.
+ *
+ * Returns the resulting full settings object.
+ */
 export async function updateLibrarySettings(
   patch: Partial<LibrarySettings>
 ): Promise<LibrarySettings> {

--- a/backend/src/services/librarySettings/librarySettings.ts
+++ b/backend/src/services/librarySettings/librarySettings.ts
@@ -1,0 +1,54 @@
+/**
+ * Admin-level toggles for library-wide behaviour. Persisted as JSON in the
+ * config dir so they survive restarts and can be edited by hand in a pinch.
+ */
+
+import path from "node:path";
+
+import { dataRoot } from "../../utils/paths";
+import { ensureDir, readJsonFile, writeJsonAtomic } from "../../utils/fs";
+
+function settingsFile(): string {
+  return path.join(dataRoot, "config", "library-settings.json");
+}
+
+export type LibrarySettings = {
+  /**
+   * When true, new uploads embed via the CLAP sidecar (512-dim) and the
+   * for-you ranker leans on embedding cosine as the primary fit signal.
+   *
+   * When false, embeddings fall back to the legacy 32-dim MFCC pipeline
+   * (no Python, no sidecar) and the ranker reverts to its pre-CLAP
+   * weights and pre-rank filters. Designed for light servers that don't
+   * want to host the ~1 GB CLAP runtime.
+   */
+  aiRecommendation: boolean;
+};
+
+const DEFAULT_SETTINGS: LibrarySettings = {
+  aiRecommendation: true
+};
+
+export async function getLibrarySettings(): Promise<LibrarySettings> {
+  const raw = await readJsonFile<Partial<LibrarySettings>>(settingsFile(), {});
+  return {
+    aiRecommendation: typeof raw.aiRecommendation === "boolean"
+      ? raw.aiRecommendation
+      : DEFAULT_SETTINGS.aiRecommendation
+  };
+}
+
+export async function updateLibrarySettings(
+  patch: Partial<LibrarySettings>
+): Promise<LibrarySettings> {
+  const current = await getLibrarySettings();
+  const next: LibrarySettings = {
+    aiRecommendation: typeof patch.aiRecommendation === "boolean"
+      ? patch.aiRecommendation
+      : current.aiRecommendation
+  };
+  const file = settingsFile();
+  await ensureDir(path.dirname(file));
+  await writeJsonAtomic(file, next);
+  return next;
+}

--- a/backend/src/services/playlists/forYou/generate.ts
+++ b/backend/src/services/playlists/forYou/generate.ts
@@ -2,13 +2,8 @@ import { createLogger } from "../../../utils/logger";
 import { normalizeGenreLabel } from "../../genre/genreSynonymService";
 import { getUserPlayCounts } from "../../activity/playCountStore";
 import { getRecentSkipCounts } from "../../activity/skipStore";
-import { loadEmbedding } from "../../embeddings/audioEmbeddingService";
-import {
-  cosineSimilarity,
-  meanVector,
-  EMBEDDING_DIM,
-  EMBEDDING_VERSION
-} from "../../embeddings/audioFeatures";
+import { getActiveEmbeddingProfile, loadEmbedding } from "../../embeddings/audioEmbeddingService";
+import { cosineSimilarity, meanVector } from "../../embeddings/audioFeatures";
 import type { IndexStore } from "../../indexer/indexStore";
 import type { Track } from "../../../types/library";
 import { ForYouTraceBuilder, type ForYouTrace, type ScoredTrackTrace } from "../playlistTrace";
@@ -19,10 +14,12 @@ import {
   noveltyScore,
   scoreFeatures,
   yearProximity,
-  DEFAULT_WEIGHTS,
+  CLAP_WEIGHTS,
+  MFCC_WEIGHTS,
   NEUTRAL_EMBEDDING_SIMILARITY,
   SKIP_HARD_FILTER_THRESHOLD,
-  type CandidateFeatures
+  type CandidateFeatures,
+  type RankerWeights
 } from "../forYouRanker";
 import { getUserDismissals } from "./dismissals";
 import { slugify } from "./paths";
@@ -43,11 +40,21 @@ const ALBUM_DEPTH_WINDOW_DAYS = 60;
 const ALBUM_DEPTH_THRESHOLD = 0.7;
 const RECENT_SKIPS_WINDOW_DAYS = 60;
 
-// Candidate-pool fallbacks (broaden the pool beyond strict genre+year match).
-// Phase 4 (2026-05) loosened both: CLAP cosine in the ranker now decides
-// "actually similar?", so the pre-rank filters can be coarse safety rails.
-const GENRE_JACCARD_FLOOR = 0.1;
-const YEAR_FALLBACK_WINDOW = 12;
+/**
+ * Candidate-pool fallbacks. Two profiles, picked by the active embedding
+ * model. CLAP cosine in the ranker can judge "actually similar?" reliably,
+ * so the pre-rank filters can be loose. MFCC can't, so we keep them strict
+ * to compensate.
+ */
+type CandidateFilterProfile = { genreJaccardFloor: number; yearFallbackWindow: number };
+const CLAP_CANDIDATE_FILTERS: CandidateFilterProfile = {
+  genreJaccardFloor: 0.1,
+  yearFallbackWindow: 12
+};
+const MFCC_CANDIDATE_FILTERS: CandidateFilterProfile = {
+  genreJaccardFloor: 0.2,
+  yearFallbackWindow: 7
+};
 
 // ── Aggregate signals ─────────────────────────────────────────────
 
@@ -266,7 +273,8 @@ function gatherCandidates(
   profile: { genres: string[]; minYear: number; maxYear: number },
   seedTracks: Track[],
   allTracks: Track[],
-  trackRecentSkips: ReadonlyMap<string, number>
+  trackRecentSkips: ReadonlyMap<string, number>,
+  filters: CandidateFilterProfile
 ): Candidate[] {
   const seedArtistLower = seedArtist.toLowerCase();
   const seedGenres = new Set(profile.genres);
@@ -274,8 +282,8 @@ function gatherCandidates(
   const seedAlbumArtists = buildSeedAlbumArtists(seedTracks);
   seedAlbumArtists.add(seedArtistLower);
   const midYear = (profile.minYear + profile.maxYear) / 2;
-  const yearLow = midYear - YEAR_FALLBACK_WINDOW;
-  const yearHigh = midYear + YEAR_FALLBACK_WINDOW;
+  const yearLow = midYear - filters.yearFallbackWindow;
+  const yearHigh = midYear + filters.yearFallbackWindow;
 
   const candidates = new Map<string, Candidate>();
 
@@ -288,7 +296,7 @@ function gatherCandidates(
     let source: Candidate["source"] | null = null;
 
     const trackGenres = track.tags.genre ?? [];
-    if (trackGenres.length > 0 && genreJaccard(trackGenres, seedGenres) >= GENRE_JACCARD_FLOOR) {
+    if (trackGenres.length > 0 && genreJaccard(trackGenres, seedGenres) >= filters.genreJaccardFloor) {
       source = "genre";
     }
 
@@ -369,12 +377,13 @@ function rankCandidates(
   midYear: number,
   seedAlbumKeys: ReadonlySet<string>,
   signals: SignalMaps,
-  similarityByTrackId: ReadonlyMap<string, number>
+  similarityByTrackId: ReadonlyMap<string, number>,
+  weights: RankerWeights
 ): RankedCandidate[] {
   return candidates
     .map((c) => {
       const features = computeFeatures(c, seedGenres, midYear, seedAlbumKeys, signals, similarityByTrackId);
-      const rawScore = scoreFeatures(features);
+      const rawScore = scoreFeatures(features, weights);
       const jitter = fnvJitter(`${userId}|${seedKey}|${c.track.id}`);
       return { ...c, features, rawScore, score: rawScore + jitter };
     })
@@ -560,7 +569,9 @@ async function buildForYouPlaylist(
   indexStore: IndexStore,
   allTracks: Track[],
   signals: SignalMaps,
-  userId: string
+  userId: string,
+  weights: RankerWeights,
+  filters: CandidateFilterProfile
 ): Promise<BuildResult> {
   const profile = getArtistProfile(seedArtist, indexStore);
   const baseTrace: BuildTrace = {
@@ -583,7 +594,7 @@ async function buildForYouPlaylist(
   const seedGenres = new Set(profile.genres);
   const midYear = (profile.minYear + profile.maxYear) / 2;
 
-  const candidates = gatherCandidates(seedArtist, profile, seedTracks, allTracks, signals.trackRecentSkips);
+  const candidates = gatherCandidates(seedArtist, profile, seedTracks, allTracks, signals.trackRecentSkips, filters);
   baseTrace.candidatePoolSize = candidates.length;
   baseTrace.peerTrackCount = candidates.length;
 
@@ -615,7 +626,8 @@ async function buildForYouPlaylist(
     midYear,
     seedAlbumKeys,
     signals,
-    similarityByTrackId
+    similarityByTrackId,
+    weights
   );
 
   const lifetimePlays = signals.artistLifetimePlays.get(seedKey) ?? 0;
@@ -640,7 +652,7 @@ async function buildForYouPlaylist(
         recentSkipCount: signals.trackRecentSkips.get(t.id) ?? 0,
         embeddingSimilarity: 1
       };
-      const rawScore = scoreFeatures(features);
+      const rawScore = scoreFeatures(features, weights);
       return {
         track: t,
         artist: seedKey,
@@ -719,13 +731,19 @@ export async function generateForYouPlaylistsWithTrace(
   indexStore: IndexStore
 ): Promise<GenerationResult> {
   const builder = new ForYouTraceBuilder(userId);
+
+  const embeddingProfile = await getActiveEmbeddingProfile();
+  const weights = embeddingProfile.model === "clap" ? CLAP_WEIGHTS : MFCC_WEIGHTS;
+  const filters =
+    embeddingProfile.model === "clap" ? CLAP_CANDIDATE_FILTERS : MFCC_CANDIDATE_FILTERS;
+
   builder.setRanker({
-    weights: DEFAULT_WEIGHTS,
-    embeddingDim: EMBEDDING_DIM,
-    embeddingVersion: EMBEDDING_VERSION,
+    weights,
+    embeddingDim: embeddingProfile.dim,
+    embeddingVersion: embeddingProfile.version,
     candidateFilters: {
-      genreJaccardFloor: GENRE_JACCARD_FLOOR,
-      yearFallbackWindow: YEAR_FALLBACK_WINDOW
+      genreJaccardFloor: filters.genreJaccardFloor,
+      yearFallbackWindow: filters.yearFallbackWindow
     }
   });
 
@@ -773,7 +791,16 @@ export async function generateForYouPlaylistsWithTrace(
     }
     attemptedSeeds++;
 
-    const result = await buildForYouPlaylist(candidate.artist, candidate.score, indexStore, allTracks, signals, userId);
+    const result = await buildForYouPlaylist(
+      candidate.artist,
+      candidate.score,
+      indexStore,
+      allTracks,
+      signals,
+      userId,
+      weights,
+      filters
+    );
 
     if (result.playlist) {
       playlists.push(result.playlist);

--- a/backend/src/services/playlists/forYou/generate.ts
+++ b/backend/src/services/playlists/forYou/generate.ts
@@ -41,10 +41,10 @@ const ALBUM_DEPTH_THRESHOLD = 0.7;
 const RECENT_SKIPS_WINDOW_DAYS = 60;
 
 /**
- * Candidate-pool fallbacks. Two profiles, picked by the active embedding
- * model. CLAP cosine in the ranker can judge "actually similar?" reliably,
- * so the pre-rank filters can be loose. MFCC can't, so we keep them strict
- * to compensate.
+ * Pre-rank candidate-pool filters. Two profiles, picked by the active
+ * embedding model. CLAP cosine in the ranker judges "actually similar?"
+ * reliably, so the pre-rank filters can be loose. MFCC can't, so we keep
+ * them strict to compensate for the weaker ranking signal.
  */
 type CandidateFilterProfile = { genreJaccardFloor: number; yearFallbackWindow: number };
 const CLAP_CANDIDATE_FILTERS: CandidateFilterProfile = {
@@ -55,6 +55,20 @@ const MFCC_CANDIDATE_FILTERS: CandidateFilterProfile = {
   genreJaccardFloor: 0.2,
   yearFallbackWindow: 7
 };
+
+/**
+ * Resolve the matching ranker weights + pre-rank filters for an embedding
+ * profile. Keeps the "if model === 'clap' else …" dispatch in one place
+ * so adding a third model means one switch instead of two.
+ */
+function rankerProfileFor(model: "clap" | "mfcc"): {
+  weights: RankerWeights;
+  filters: CandidateFilterProfile;
+} {
+  return model === "clap"
+    ? { weights: CLAP_WEIGHTS, filters: CLAP_CANDIDATE_FILTERS }
+    : { weights: MFCC_WEIGHTS, filters: MFCC_CANDIDATE_FILTERS };
+}
 
 // ── Aggregate signals ─────────────────────────────────────────────
 
@@ -733,18 +747,13 @@ export async function generateForYouPlaylistsWithTrace(
   const builder = new ForYouTraceBuilder(userId);
 
   const embeddingProfile = await getActiveEmbeddingProfile();
-  const weights = embeddingProfile.model === "clap" ? CLAP_WEIGHTS : MFCC_WEIGHTS;
-  const filters =
-    embeddingProfile.model === "clap" ? CLAP_CANDIDATE_FILTERS : MFCC_CANDIDATE_FILTERS;
+  const { weights, filters } = rankerProfileFor(embeddingProfile.model);
 
   builder.setRanker({
     weights,
     embeddingDim: embeddingProfile.dim,
     embeddingVersion: embeddingProfile.version,
-    candidateFilters: {
-      genreJaccardFloor: filters.genreJaccardFloor,
-      yearFallbackWindow: filters.yearFallbackWindow
-    }
+    candidateFilters: { ...filters }
   });
 
   const playCounts = await getUserPlayCounts(userId);

--- a/backend/src/services/playlists/forYou/generate.ts
+++ b/backend/src/services/playlists/forYou/generate.ts
@@ -3,7 +3,12 @@ import { normalizeGenreLabel } from "../../genre/genreSynonymService";
 import { getUserPlayCounts } from "../../activity/playCountStore";
 import { getRecentSkipCounts } from "../../activity/skipStore";
 import { loadEmbedding } from "../../embeddings/audioEmbeddingService";
-import { cosineSimilarity, meanVector } from "../../embeddings/audioFeatures";
+import {
+  cosineSimilarity,
+  meanVector,
+  EMBEDDING_DIM,
+  EMBEDDING_VERSION
+} from "../../embeddings/audioFeatures";
 import type { IndexStore } from "../../indexer/indexStore";
 import type { Track } from "../../../types/library";
 import { ForYouTraceBuilder, type ForYouTrace, type ScoredTrackTrace } from "../playlistTrace";
@@ -14,6 +19,7 @@ import {
   noveltyScore,
   scoreFeatures,
   yearProximity,
+  DEFAULT_WEIGHTS,
   NEUTRAL_EMBEDDING_SIMILARITY,
   SKIP_HARD_FILTER_THRESHOLD,
   type CandidateFeatures
@@ -713,6 +719,15 @@ export async function generateForYouPlaylistsWithTrace(
   indexStore: IndexStore
 ): Promise<GenerationResult> {
   const builder = new ForYouTraceBuilder(userId);
+  builder.setRanker({
+    weights: DEFAULT_WEIGHTS,
+    embeddingDim: EMBEDDING_DIM,
+    embeddingVersion: EMBEDDING_VERSION,
+    candidateFilters: {
+      genreJaccardFloor: GENRE_JACCARD_FLOOR,
+      yearFallbackWindow: YEAR_FALLBACK_WINDOW
+    }
+  });
 
   const playCounts = await getUserPlayCounts(userId);
   const recentSkips = await getRecentSkipCounts(userId, RECENT_SKIPS_WINDOW_DAYS);

--- a/backend/src/services/playlists/forYou/generate.ts
+++ b/backend/src/services/playlists/forYou/generate.ts
@@ -32,8 +32,29 @@ const MIN_DISTINCT_ARTISTS = 3;
 const MAX_SEEDS = 6;
 const TRACKS_PER_PLAYLIST = 25;
 const MAX_PER_PEER_ARTIST = 4;
+/** Per-album cap for peer picks — keeps a single album from dominating a playlist. */
 const MAX_PER_ALBUM = 2;
+/**
+ * Per-album cap for *seed* picks. Looser than the peer cap because a user
+ * who clicks "20s with Architects" is asking for Architects: if their
+ * library only has one Architects album, capping at 2 leaves 3-track
+ * playlists that don't deliver on the seed name. 4 strikes a balance —
+ * still spreads picks when the user has multiple albums per seed artist.
+ */
+const MAX_PER_ALBUM_SEED = 4;
 const TOP_REJECTIONS_RECORDED = 5;
+
+/**
+ * Score penalty applied to candidates that were already picked for a
+ * previous playlist in the *same regeneration*. Stops a handful of
+ * universal-cosine tracks (e.g. one Pink Floyd track that CLAP rates
+ * compatibly with every metalcore seed) from showing up in all five
+ * for-you playlists. Tuned to be slightly larger than the typical gap
+ * between consecutive picks (~0.05) so a reused track loses a slot to
+ * the next-best unused candidate, but stays large enough below feature
+ * weights that a truly-better candidate can still win on merit.
+ */
+const CROSS_PLAYLIST_REUSE_PENALTY = 0.12;
 
 const RECENT_PLAYS_WINDOW_DAYS = 30;
 const ALBUM_DEPTH_WINDOW_DAYS = 60;
@@ -392,14 +413,16 @@ function rankCandidates(
   seedAlbumKeys: ReadonlySet<string>,
   signals: SignalMaps,
   similarityByTrackId: ReadonlyMap<string, number>,
-  weights: RankerWeights
+  weights: RankerWeights,
+  alreadyUsedTrackIds: ReadonlySet<string>
 ): RankedCandidate[] {
   return candidates
     .map((c) => {
       const features = computeFeatures(c, seedGenres, midYear, seedAlbumKeys, signals, similarityByTrackId);
       const rawScore = scoreFeatures(features, weights);
+      const reusePenalty = alreadyUsedTrackIds.has(c.track.id) ? CROSS_PLAYLIST_REUSE_PENALTY : 0;
       const jitter = fnvJitter(`${userId}|${seedKey}|${c.track.id}`);
-      return { ...c, features, rawScore, score: rawScore + jitter };
+      return { ...c, features, rawScore, score: rawScore - reusePenalty + jitter };
     })
     .sort((a, b) => b.score - a.score);
 }
@@ -585,7 +608,8 @@ async function buildForYouPlaylist(
   signals: SignalMaps,
   userId: string,
   weights: RankerWeights,
-  filters: CandidateFilterProfile
+  filters: CandidateFilterProfile,
+  alreadyUsedTrackIds: ReadonlySet<string>
 ): Promise<BuildResult> {
   const profile = getArtistProfile(seedArtist, indexStore);
   const baseTrace: BuildTrace = {
@@ -641,7 +665,8 @@ async function buildForYouPlaylist(
     seedAlbumKeys,
     signals,
     similarityByTrackId,
-    weights
+    weights,
+    alreadyUsedTrackIds
   );
 
   const lifetimePlays = signals.artistLifetimePlays.get(seedKey) ?? 0;
@@ -679,7 +704,7 @@ async function buildForYouPlaylist(
     })
     .sort((a, b) => b.score - a.score);
 
-  const seedPick = pickWithCaps(seedRanked, seedQuota, seedQuota, MAX_PER_ALBUM);
+  const seedPick = pickWithCaps(seedRanked, seedQuota, seedQuota, MAX_PER_ALBUM_SEED);
   const peerPick = pickWithCaps(ranked, peerQuota, MAX_PER_PEER_ARTIST, MAX_PER_ALBUM);
 
   const combined = [...seedPick.picked, ...peerPick.picked];
@@ -753,7 +778,14 @@ export async function generateForYouPlaylistsWithTrace(
     weights,
     embeddingDim: embeddingProfile.dim,
     embeddingVersion: embeddingProfile.version,
-    candidateFilters: { ...filters }
+    candidateFilters: { ...filters },
+    diversityKnobs: {
+      crossPlaylistReusePenalty: CROSS_PLAYLIST_REUSE_PENALTY,
+      maxPerAlbumSeed: MAX_PER_ALBUM_SEED,
+      maxPerAlbumPeer: MAX_PER_ALBUM,
+      maxPerPeerArtist: MAX_PER_PEER_ARTIST,
+      tracksPerPlaylist: TRACKS_PER_PLAYLIST
+    }
   });
 
   const playCounts = await getUserPlayCounts(userId);
@@ -789,6 +821,12 @@ export async function generateForYouPlaylistsWithTrace(
   const dismissals = await getUserDismissals(userId);
   const allTracks = indexStore.getSnapshot().tracks;
   const playlists: ForYouPlaylist[] = [];
+  /**
+   * Track IDs already placed in an earlier playlist this run. Passed into
+   * each subsequent buildForYouPlaylist call so the ranker can penalise
+   * reuse — see CROSS_PLAYLIST_REUSE_PENALTY.
+   */
+  const alreadyUsedTrackIds = new Set<string>();
   let attemptedSeeds = 0;
 
   for (const candidate of seedCandidates) {
@@ -808,11 +846,13 @@ export async function generateForYouPlaylistsWithTrace(
       signals,
       userId,
       weights,
-      filters
+      filters,
+      alreadyUsedTrackIds
     );
 
     if (result.playlist) {
       playlists.push(result.playlist);
+      for (const tid of result.playlist.trackIds) alreadyUsedTrackIds.add(tid);
       builder.recordSeedChosen(candidate.artist);
       builder.recordPlaylist({
         seed: candidate.artist,

--- a/backend/src/services/playlists/forYou/generate.ts
+++ b/backend/src/services/playlists/forYou/generate.ts
@@ -37,9 +37,11 @@ const ALBUM_DEPTH_WINDOW_DAYS = 60;
 const ALBUM_DEPTH_THRESHOLD = 0.7;
 const RECENT_SKIPS_WINDOW_DAYS = 60;
 
-// Candidate-pool fallbacks (broaden the pool beyond strict genre+year match)
-const GENRE_JACCARD_FLOOR = 0.2;
-const YEAR_FALLBACK_WINDOW = 7;
+// Candidate-pool fallbacks (broaden the pool beyond strict genre+year match).
+// Phase 4 (2026-05) loosened both: CLAP cosine in the ranker now decides
+// "actually similar?", so the pre-rank filters can be coarse safety rails.
+const GENRE_JACCARD_FLOOR = 0.1;
+const YEAR_FALLBACK_WINDOW = 12;
 
 // ── Aggregate signals ─────────────────────────────────────────────
 

--- a/backend/src/services/playlists/forYou/generate.ts
+++ b/backend/src/services/playlists/forYou/generate.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "../../../utils/logger";
+import { extractPrimaryArtist } from "../../../utils/music";
 import { normalizeGenreLabel } from "../../genre/genreSynonymService";
 import { getUserPlayCounts } from "../../activity/playCountStore";
 import { getRecentSkipCounts } from "../../activity/skipStore";
@@ -256,20 +257,34 @@ function selectSeeds(signals: SignalMaps, indexStore: IndexStore): SeedCandidate
 
 type Candidate = {
   track: Track;
+  /** Full lowercased artist tag — used for signals lookup + display. */
   artist: string;
+  /**
+   * Primary artist (lowercased), stripped of `; X` / `feat. Y` / `ft. Z`
+   * suffixes. Used as the per-artist cap key so collab variants share a
+   * cap with their primary — otherwise "Bring Me The Horizon",
+   * "Bring Me The Horizon; AURORA", "Bring Me The Horizon; Underoath"
+   * etc. each get their own MAX_PER_PEER_ARTIST budget and the cap stops
+   * doing anything useful.
+   */
+  capKey: string;
   album: string;
   source: "genre" | "album-artist" | "label" | "year-fallback";
 };
 
 /**
- * Composite "<artist>::<album>" key used everywhere we deduplicate or cap on
- * album. Keying on album name alone collides across artists ("Greatest Hits",
- * self-titled debuts, etc.).
+ * Composite "<primary-artist>::<album>" key used everywhere we deduplicate
+ * or cap on album. The artist prefix avoids collisions across artists
+ * (multiple "Greatest Hits", self-titled debuts, etc.). Using the *primary*
+ * artist also makes collab variants of the same album share a key —
+ * without this, "Bring Me The Horizon::post human nex gen" and
+ * "Bring Me The Horizon; AURORA::post human nex gen" count as separate
+ * albums and the per-album cap lets 4–5 tracks from one album through.
  */
 function albumKey(artist: string | undefined, album: string | undefined): string {
   const b = (album ?? "").toLowerCase().trim();
   if (!b) return "";
-  const a = (artist ?? "").toLowerCase().trim();
+  const a = extractPrimaryArtist((artist ?? "").trim()).toLowerCase();
   return `${a}::${b}`;
 }
 
@@ -364,6 +379,7 @@ function gatherCandidates(
       candidates.set(track.id, {
         track,
         artist: trackArtist,
+        capKey: extractPrimaryArtist(trackArtist),
         album: albumKey(track.tags.artist, track.tags.album),
         source
       });
@@ -471,7 +487,10 @@ function pickWithCaps(
       passedOver.push(c);
       continue;
     }
-    const artistCount = artistCounts.get(c.artist) ?? 0;
+    // Cap on primary artist (capKey) so collab variants of the same artist
+    // share a budget. c.album is already keyed on the primary artist —
+    // see albumKey() above.
+    const artistCount = artistCounts.get(c.capKey) ?? 0;
     const albumCount = c.album ? albumCounts.get(c.album) ?? 0 : 0;
     if (artistCount >= perArtist) {
       passedOver.push(c);
@@ -482,7 +501,7 @@ function pickWithCaps(
       continue;
     }
     picked.push(c);
-    artistCounts.set(c.artist, artistCount + 1);
+    artistCounts.set(c.capKey, artistCount + 1);
     if (c.album) albumCounts.set(c.album, albumCount + 1);
   }
 
@@ -695,6 +714,8 @@ async function buildForYouPlaylist(
       return {
         track: t,
         artist: seedKey,
+        // seedKey is already the canonical primary artist (selectSeeds resolves it).
+        capKey: seedKey,
         album: albumKey(t.tags.artist, t.tags.album),
         source: "genre" as const,
         features,
@@ -731,7 +752,10 @@ async function buildForYouPlaylist(
     rejection: "cap-or-overflow"
   }));
 
-  const distinctPeerArtists = new Set(peerPick.picked.map((c) => c.artist)).size;
+  // Count distinct *primary* peer artists so the naming heuristic
+  // ("Artist & friends") doesn't get fooled by collab tags into thinking
+  // there are more distinct peers than there really are.
+  const distinctPeerArtists = new Set(peerPick.picked.map((c) => c.capKey)).size;
   const peerShare = combined.length > 0 ? peerPick.picked.length / combined.length : 0;
   const decade = dominantDecade(sequenced.map((c) => c.track));
   const name = namePlaylist(seedArtist, distinctPeerArtists, peerShare, decade);

--- a/backend/src/services/playlists/forYouPlaylistService.test.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.test.ts
@@ -531,4 +531,122 @@ describe("forYouPlaylistService", () => {
     const chosenIncludesPF = trace!.seedSelection.chosen.includes("Pink Floyd");
     expect(chosenIncludesPF).toBe(false);
   });
+
+  it("allows >2 seed tracks from a single album (seed pick uses MAX_PER_ALBUM_SEED, not the peer cap)", async () => {
+    const { generateForYouPlaylists } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    // Seed artist has only ONE album with 8 tracks. With the old MAX_PER_ALBUM=2
+    // cap shared by seed + peer picks, only 2 seed tracks would land. The seed-
+    // specific cap (4) should allow at least 4.
+    const tracks: Track[] = [];
+    for (let i = 0; i < 8; i++) {
+      tracks.push(makeTrack({ id: `seed-${i}`, tags: { artist: "Pink Floyd", album: "Meddle", genre: ["Rock"], year: 1971 } }));
+    }
+    // A handful of peer artists so the playlist can fill out and seed quota is
+    // not bound by lack of candidates.
+    for (let i = 0; i < 8; i++) {
+      tracks.push(makeTrack({ id: `peer-${i}`, tags: { artist: "Other Band", album: `ob-${i}`, genre: ["Rock"], year: 1972 } }));
+    }
+    for (let i = 0; i < 4; i++) {
+      tracks.push(makeTrack({ id: `third-${i}`, tags: { artist: "Third Band", album: `tb-${i}`, genre: ["Rock"], year: 1972 } }));
+    }
+
+    const indexStore = makeMockIndexStore(tracks);
+    const dir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(dir);
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 8; i++) playCounts[`seed-${i}`] = { count: 5, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["peer-0"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["third-0"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    await writeJsonAtomic(path.join(dir, "play-counts.json"), { tracks: playCounts });
+
+    const result = await generateForYouPlaylists("user-1", indexStore);
+    const pinkFloyd = result.find((p) => p.seedArtist === "Pink Floyd");
+    expect(pinkFloyd).toBeDefined();
+    const seedTracks = pinkFloyd!.trackIds.filter((id) => id.startsWith("seed-"));
+    expect(seedTracks.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("records the diversity knobs (incl. cross-playlist reuse penalty) in the trace", async () => {
+    const { regenerateForYouPlaylists, loadForYouTrace } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    const artists = ["Pink Floyd", "Led Zeppelin", "Deep Purple", "Black Sabbath"];
+    const tracks: Track[] = [];
+    for (let i = 0; i < 60; i++) {
+      const artist = artists[i % 4]!;
+      tracks.push(makeTrack({ id: `track-${i}`, tags: { artist, album: `${artist}-${i % 3}`, genre: ["Rock"], year: 1972 + (i % 6) } }));
+    }
+    const indexStore = makeMockIndexStore(tracks);
+    const dir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(dir);
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 30; i++) playCounts[`track-${i}`] = { count: 2, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    await writeJsonAtomic(path.join(dir, "play-counts.json"), { tracks: playCounts });
+
+    await regenerateForYouPlaylists("user-1", indexStore);
+    const trace = await loadForYouTrace("user-1");
+    expect(trace).not.toBeNull();
+    expect(trace!.ranker?.diversityKnobs).toBeDefined();
+    const knobs = trace!.ranker!.diversityKnobs!;
+    expect(knobs.crossPlaylistReusePenalty).toBeGreaterThan(0);
+    expect(knobs.maxPerAlbumSeed).toBeGreaterThanOrEqual(4);
+    expect(knobs.maxPerAlbumPeer).toBe(2);
+    expect(knobs.maxPerPeerArtist).toBe(4);
+    expect(knobs.tracksPerPlaylist).toBe(25);
+  });
+
+  it("does not place the same track in every for-you playlist (cross-playlist reuse penalty)", async () => {
+    const { regenerateForYouPlaylists, loadForYouPlaylists } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    // Two seed artists with full play history; one shared peer-artist pool of
+    // 10 tracks. Without the cross-playlist penalty, the per-peer-artist cap
+    // (4) would let the *same* 4 peer tracks land in both seeded playlists.
+    // With the penalty, the second playlist should rotate to at least one
+    // *different* peer track.
+    const tracks: Track[] = [];
+    for (let i = 0; i < 8; i++) {
+      tracks.push(makeTrack({ id: `pf-${i}`, tags: { artist: "Pink Floyd", album: `pf-${i % 2}`, genre: ["Rock"], year: 1972 } }));
+    }
+    for (let i = 0; i < 8; i++) {
+      tracks.push(makeTrack({ id: `lz-${i}`, tags: { artist: "Led Zeppelin", album: `lz-${i % 2}`, genre: ["Rock"], year: 1972 } }));
+    }
+    for (let i = 0; i < 10; i++) {
+      tracks.push(makeTrack({ id: `peer-${i}`, tags: { artist: "Peer Band", album: `pb-${i}`, genre: ["Rock"], year: 1972 } }));
+    }
+    // Extra distinct artist so MIN_DISTINCT_ARTISTS=3 is met.
+    for (let i = 0; i < 4; i++) {
+      tracks.push(makeTrack({ id: `other-${i}`, tags: { artist: "Other Band", album: `ob-${i}`, genre: ["Rock"], year: 1972 } }));
+    }
+
+    const indexStore = makeMockIndexStore(tracks);
+    const dir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(dir);
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 8; i++) {
+      playCounts[`pf-${i}`] = { count: 5, lastPlayedAt: "2026-04-01T00:00:00Z" };
+      playCounts[`lz-${i}`] = { count: 5, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    }
+    playCounts["other-0"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    await writeJsonAtomic(path.join(dir, "play-counts.json"), { tracks: playCounts });
+
+    await regenerateForYouPlaylists("user-1", indexStore);
+    const playlists = await loadForYouPlaylists("user-1");
+    const pf = playlists.find((p) => p.seedArtist === "Pink Floyd");
+    const lz = playlists.find((p) => p.seedArtist === "Led Zeppelin");
+    expect(pf).toBeDefined();
+    expect(lz).toBeDefined();
+
+    const peerInPf = pf!.trackIds.filter((id) => id.startsWith("peer-"));
+    const peerInLz = lz!.trackIds.filter((id) => id.startsWith("peer-"));
+    // Both playlists should contain peer tracks (sanity check on the harness).
+    expect(peerInPf.length).toBeGreaterThan(0);
+    expect(peerInLz.length).toBeGreaterThan(0);
+    // The reuse penalty should push the second playlist to pick at least one
+    // peer track that didn't land in the first.
+    const overlap = peerInLz.filter((id) => peerInPf.includes(id));
+    expect(overlap.length).toBeLessThan(peerInLz.length);
+  });
 });

--- a/backend/src/services/playlists/forYouPlaylistService.test.ts
+++ b/backend/src/services/playlists/forYouPlaylistService.test.ts
@@ -597,6 +597,97 @@ describe("forYouPlaylistService", () => {
     expect(knobs.tracksPerPlaylist).toBe(25);
   });
 
+  it("treats collab variants as the same artist for the per-peer-artist cap", async () => {
+    const { generateForYouPlaylists } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    // Seed: Pink Floyd. Peer pool: one band ("Big Band") with many collab
+    // variants — each currently gets its own MAX_PER_PEER_ARTIST=4 budget
+    // because they have different exact artist strings, so without the
+    // primary-artist cap fix the cap effectively never binds.
+    const tracks: Track[] = [];
+    for (let i = 0; i < 10; i++) {
+      tracks.push(makeTrack({ id: `seed-${i}`, tags: { artist: "Pink Floyd", album: `pf-${i}`, genre: ["Rock"], year: 1973 } }));
+    }
+    // 3 plain Big Band + 6 collab variants (one per featured guest) = 9
+    // candidate tracks that would all bypass the cap with the old keying.
+    tracks.push(makeTrack({ id: `bb-1`, tags: { artist: "Big Band", album: "X", genre: ["Rock"], year: 1973 } }));
+    tracks.push(makeTrack({ id: `bb-2`, tags: { artist: "Big Band", album: "X", genre: ["Rock"], year: 1973 } }));
+    tracks.push(makeTrack({ id: `bb-3`, tags: { artist: "Big Band", album: "X", genre: ["Rock"], year: 1973 } }));
+    for (let i = 0; i < 6; i++) {
+      tracks.push(makeTrack({
+        id: `bb-feat-${i}`,
+        tags: { artist: `Big Band; Guest ${i}`, album: `Y-${i}`, genre: ["Rock"], year: 1973 }
+      }));
+    }
+    // Extra distinct peers so MIN_DISTINCT_ARTISTS=3 is met.
+    for (let i = 0; i < 4; i++) {
+      tracks.push(makeTrack({ id: `other-${i}`, tags: { artist: `Other ${i}`, album: `o-${i}`, genre: ["Rock"], year: 1973 } }));
+    }
+
+    const indexStore = makeMockIndexStore(tracks);
+    const dir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(dir);
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 10; i++) playCounts[`seed-${i}`] = { count: 5, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["other-0"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["other-1"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["other-2"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    await writeJsonAtomic(path.join(dir, "play-counts.json"), { tracks: playCounts });
+
+    const result = await generateForYouPlaylists("user-1", indexStore);
+    const pinkFloyd = result.find((p) => p.seedArtist === "Pink Floyd");
+    expect(pinkFloyd).toBeDefined();
+
+    // All Big-Band-anything tracks (plain + collabs) must collectively
+    // stay within MAX_PER_PEER_ARTIST = 4 in a non-Big-Band-seeded playlist.
+    const bigBandLike = pinkFloyd!.trackIds.filter((id) => id.startsWith("bb-")).length;
+    expect(bigBandLike).toBeLessThanOrEqual(4);
+  });
+
+  it("counts collab variants of the same album under one per-album cap", async () => {
+    const { generateForYouPlaylists } = await import("./forYouPlaylistService");
+    const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");
+
+    // Seed: Pink Floyd. Peer: one album by "Big Band" with 5 tracks, but
+    // tagged with 5 different collab variants. Each variant currently has
+    // its own albumKey under the old logic, defeating MAX_PER_ALBUM=2.
+    const tracks: Track[] = [];
+    for (let i = 0; i < 10; i++) {
+      tracks.push(makeTrack({ id: `seed-${i}`, tags: { artist: "Pink Floyd", album: `pf-${i}`, genre: ["Rock"], year: 1973 } }));
+    }
+    // 5 tracks all from the same album, but each tagged with a different
+    // collab string. Under the old keying these get 5 different album
+    // cap slots; under the fix they share one slot capped at 2.
+    tracks.push(makeTrack({ id: `bb-1`, tags: { artist: "Big Band", album: "Greatest Hits", genre: ["Rock"], year: 1973 } }));
+    tracks.push(makeTrack({ id: `bb-2`, tags: { artist: "Big Band", album: "Greatest Hits", genre: ["Rock"], year: 1973 } }));
+    tracks.push(makeTrack({ id: `bb-3`, tags: { artist: "Big Band; Guest A", album: "Greatest Hits", genre: ["Rock"], year: 1973 } }));
+    tracks.push(makeTrack({ id: `bb-4`, tags: { artist: "Big Band feat. Guest B", album: "Greatest Hits", genre: ["Rock"], year: 1973 } }));
+    tracks.push(makeTrack({ id: `bb-5`, tags: { artist: "Big Band; Guest C", album: "Greatest Hits", genre: ["Rock"], year: 1973 } }));
+    // Extra distinct peers so MIN_DISTINCT_ARTISTS=3 is met.
+    for (let i = 0; i < 4; i++) {
+      tracks.push(makeTrack({ id: `other-${i}`, tags: { artist: `Other ${i}`, album: `o-${i}`, genre: ["Rock"], year: 1973 } }));
+    }
+
+    const indexStore = makeMockIndexStore(tracks);
+    const dir = path.join(tmpDir, "data", "storage", "users", "user-1");
+    await ensureDir(dir);
+    const playCounts: Record<string, { count: number; lastPlayedAt: string }> = {};
+    for (let i = 0; i < 10; i++) playCounts[`seed-${i}`] = { count: 5, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["other-0"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["other-1"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    playCounts["other-2"] = { count: 1, lastPlayedAt: "2026-04-01T00:00:00Z" };
+    await writeJsonAtomic(path.join(dir, "play-counts.json"), { tracks: playCounts });
+
+    const result = await generateForYouPlaylists("user-1", indexStore);
+    const pinkFloyd = result.find((p) => p.seedArtist === "Pink Floyd");
+    expect(pinkFloyd).toBeDefined();
+
+    // Across all collab tags of the same album, MAX_PER_ALBUM = 2 must hold.
+    const sameAlbumPicks = pinkFloyd!.trackIds.filter((id) => id.startsWith("bb-")).length;
+    expect(sameAlbumPicks).toBeLessThanOrEqual(2);
+  });
+
   it("does not place the same track in every for-you playlist (cross-playlist reuse penalty)", async () => {
     const { regenerateForYouPlaylists, loadForYouPlaylists } = await import("./forYouPlaylistService");
     const { ensureDir, writeJsonAtomic } = await import("../../utils/fs");

--- a/backend/src/services/playlists/forYouRanker.test.ts
+++ b/backend/src/services/playlists/forYouRanker.test.ts
@@ -151,10 +151,11 @@ describe("forYouRanker", () => {
     });
 
     it("uses the documented default weights", () => {
-      expect(DEFAULT_WEIGHTS.genreOverlap).toBe(0.4);
+      // Phase 4 rebalance: embedding cosine is the primary fit signal.
+      expect(DEFAULT_WEIGHTS.embeddingSimilarity).toBe(0.4);
+      expect(DEFAULT_WEIGHTS.genreOverlap).toBe(0.25);
       expect(DEFAULT_WEIGHTS.albumOverlapWithSeed).toBeLessThan(0);
       expect(DEFAULT_WEIGHTS.skipPenalty).toBeLessThan(0);
-      expect(DEFAULT_WEIGHTS.embeddingSimilarity).toBeGreaterThan(0);
     });
   });
 });

--- a/backend/src/services/playlists/forYouRanker.ts
+++ b/backend/src/services/playlists/forYouRanker.ts
@@ -32,14 +32,20 @@ export type RankerWeights = {
   embeddingSimilarity: number;
 };
 
+/**
+ * Phase 4 rebalance (2026-05): with CLAP embeddings landing in v3 sidecars,
+ * shift relevance signal from tag-overlap to learned audio similarity.
+ * Genre and year are now coarse safety rails; embedding cosine is the
+ * primary fit signal. See docs/ai-playlist-spike.md §5.
+ */
 export const DEFAULT_WEIGHTS: RankerWeights = {
-  genreOverlap: 0.40,
-  yearProximity: 0.20,
+  genreOverlap: 0.25,
+  yearProximity: 0.10,
   libraryPopularity: 0.15,
   novelty: 0.15,
   albumOverlapWithSeed: -0.30,
   skipPenalty: -0.20,
-  embeddingSimilarity: 0.10
+  embeddingSimilarity: 0.40
 };
 
 /** Neutral similarity score when an embedding is unavailable. */

--- a/backend/src/services/playlists/forYouRanker.ts
+++ b/backend/src/services/playlists/forYouRanker.ts
@@ -2,32 +2,48 @@
  * Pure scoring helpers for For You peer ranking. No I/O, no side effects —
  * everything here is unit-testable in isolation. The ranker turns a candidate
  * track into a score by combining genre overlap, year proximity, library
- * popularity, novelty, and an album-overlap penalty.
+ * popularity, novelty, and an album-overlap penalty, then weighting each by
+ * a `RankerWeights` preset that depends on which embedding backend produced
+ * the vectors (see CLAP_WEIGHTS vs MFCC_WEIGHTS).
  */
 
 import { normalizeGenreLabel } from "../genre/genreSynonymService";
 
+/**
+ * Per-candidate signals fed into `scoreFeatures`. All but `recentSkipCount`
+ * are normalised to `[0, 1]`. `recentSkipCount` is the raw count of recent
+ * skips and is clamped to `SKIP_SOFT_CAP` before the linear combination.
+ */
 export type CandidateFeatures = {
+  /** Jaccard overlap between candidate genres and the seed genre set. */
   genreOverlap: number;
+  /** Gaussian-on-year proximity to the seed era's midpoint; 1 = same year. */
   yearProximity: number;
+  /** Log-scaled artist popularity within the user's library. */
   libraryPopularity: number;
+  /** 1 / (1 + recentPlays); favours tracks the user hasn't recently played. */
   novelty: number;
+  /** 1 if the candidate shares an album with any seed track, else 0. Penalty. */
   albumOverlapWithSeed: number;
+  /** Raw skip count in the recency window; clamped via SKIP_SOFT_CAP in the score. */
   recentSkipCount: number;
   /**
    * Cosine similarity between the candidate's audio embedding and the mean
-   * embedding of the seed tracks. Range -1..1; 0.5 is the neutral value used
-   * when either side is missing an embedding.
+   * embedding of the seed tracks. Range -1..1; `NEUTRAL_EMBEDDING_SIMILARITY`
+   * (0.5) is the value used when either side is missing an embedding.
    */
   embeddingSimilarity: number;
 };
 
+/** Linear-combination weights applied to a `CandidateFeatures`. */
 export type RankerWeights = {
   genreOverlap: number;
   yearProximity: number;
   libraryPopularity: number;
   novelty: number;
+  /** Should be negative — albumOverlapWithSeed deepens the penalty when set. */
   albumOverlapWithSeed: number;
+  /** Should be negative — multiplied by min(recentSkipCount, SKIP_SOFT_CAP). */
   skipPenalty: number;
   embeddingSimilarity: number;
 };
@@ -64,7 +80,13 @@ export const MFCC_WEIGHTS: RankerWeights = {
   embeddingSimilarity: 0.10
 };
 
-/** Default = AI on. Setting flips the active preset at generation time. */
+/**
+ * Default preset used by `scoreFeatures` callers that don't pass weights
+ * explicitly (mostly tests). The production for-you generator picks
+ * CLAP_WEIGHTS or MFCC_WEIGHTS at generation time based on the library
+ * setting and passes that through — so this default only governs callers
+ * that haven't been threaded through the toggle.
+ */
 export const DEFAULT_WEIGHTS: RankerWeights = CLAP_WEIGHTS;
 
 /** Neutral similarity score when an embedding is unavailable. */
@@ -136,6 +158,14 @@ export function fnvJitter(seed: string, range: number = JITTER_RANGE): number {
   return (norm - 0.5) * range;
 }
 
+/**
+ * Linear combination of `features` × `weights`. `recentSkipCount` is
+ * clamped to `SKIP_SOFT_CAP` before being multiplied, so a track that's
+ * been skipped many times doesn't keep deepening the penalty indefinitely.
+ *
+ * No jitter / no randomness here — sequencing (`fnvJitter`) is applied
+ * by the caller on the raw score.
+ */
 export function scoreFeatures(features: CandidateFeatures, weights: RankerWeights = DEFAULT_WEIGHTS): number {
   const cappedSkips = Math.min(features.recentSkipCount, SKIP_SOFT_CAP);
   return (

--- a/backend/src/services/playlists/forYouRanker.ts
+++ b/backend/src/services/playlists/forYouRanker.ts
@@ -33,12 +33,12 @@ export type RankerWeights = {
 };
 
 /**
- * Phase 4 rebalance (2026-05): with CLAP embeddings landing in v3 sidecars,
- * shift relevance signal from tag-overlap to learned audio similarity.
- * Genre and year are now coarse safety rails; embedding cosine is the
- * primary fit signal. See docs/ai-playlist-spike.md §5.
+ * CLAP-aware weights (phase 4, 2026-05). With semantic audio embeddings
+ * landing in v3 sidecars, the relevance signal shifts from tag-overlap to
+ * learned audio similarity. Genre/year become coarse safety rails;
+ * embedding cosine is the primary fit signal.
  */
-export const DEFAULT_WEIGHTS: RankerWeights = {
+export const CLAP_WEIGHTS: RankerWeights = {
   genreOverlap: 0.25,
   yearProximity: 0.10,
   libraryPopularity: 0.15,
@@ -47,6 +47,25 @@ export const DEFAULT_WEIGHTS: RankerWeights = {
   skipPenalty: -0.20,
   embeddingSimilarity: 0.40
 };
+
+/**
+ * Legacy weights, used when AI recommendation is disabled and embeddings
+ * fall back to the 32-dim MFCC pipeline. MFCCs capture timbre but not
+ * musical structure, so we can only trust them at a small weight; genre
+ * and year carry the rest of the load.
+ */
+export const MFCC_WEIGHTS: RankerWeights = {
+  genreOverlap: 0.40,
+  yearProximity: 0.20,
+  libraryPopularity: 0.15,
+  novelty: 0.15,
+  albumOverlapWithSeed: -0.30,
+  skipPenalty: -0.20,
+  embeddingSimilarity: 0.10
+};
+
+/** Default = AI on. Setting flips the active preset at generation time. */
+export const DEFAULT_WEIGHTS: RankerWeights = CLAP_WEIGHTS;
 
 /** Neutral similarity score when an embedding is unavailable. */
 export const NEUTRAL_EMBEDDING_SIMILARITY = 0.5;

--- a/backend/src/services/playlists/playlistTrace.ts
+++ b/backend/src/services/playlists/playlistTrace.ts
@@ -53,6 +53,29 @@ export type ForYouPlaylistTrace = {
   rejection?: string;
 };
 
+/**
+ * Snapshot of the ranker configuration used for this regeneration. Captured
+ * so traces stay interpretable after weight tweaks — a few months later you
+ * can still tell "did this pick happen under the embedding-heavy weights
+ * or the older genre-heavy ones?". Optional on older trace files written
+ * before this field existed.
+ */
+export type RankerSnapshot = {
+  weights: {
+    genreOverlap: number;
+    yearProximity: number;
+    libraryPopularity: number;
+    novelty: number;
+    albumOverlapWithSeed: number;
+    skipPenalty: number;
+    embeddingSimilarity: number;
+  };
+  embeddingDim: number;
+  embeddingVersion: number;
+  /** e.g. GENRE_JACCARD_FLOOR, YEAR_FALLBACK_WINDOW — the pre-rank filters. */
+  candidateFilters?: Record<string, number>;
+};
+
 export type ForYouTrace = {
   generatedAt: string;
   userId: string;
@@ -60,6 +83,7 @@ export type ForYouTrace = {
   totalPlays: number;
   distinctArtists: number;
   skipReason?: "below-min-plays" | "below-min-artists";
+  ranker?: RankerSnapshot;
   seedSelection: {
     candidates: SeedCandidateTrace[];
     chosen: string[];
@@ -106,6 +130,7 @@ export class ForYouTraceBuilder {
   private readonly chosen: string[] = [];
   private readonly skipped: SeedSkippedTrace[] = [];
   private readonly playlists: ForYouPlaylistTrace[] = [];
+  private ranker: RankerSnapshot | undefined;
 
   constructor(userId: string) {
     this.userId = userId;
@@ -118,6 +143,10 @@ export class ForYouTraceBuilder {
 
   setSkipReason(reason: NonNullable<ForYouTrace["skipReason"]>): void {
     this.skipReason = reason;
+  }
+
+  setRanker(snapshot: RankerSnapshot): void {
+    this.ranker = snapshot;
   }
 
   recordSeedCandidate(entry: SeedCandidateTrace): void {
@@ -144,6 +173,7 @@ export class ForYouTraceBuilder {
       totalPlays: this.totalPlays,
       distinctArtists: this.distinctArtists,
       ...(this.skipReason ? { skipReason: this.skipReason } : {}),
+      ...(this.ranker ? { ranker: this.ranker } : {}),
       seedSelection: {
         candidates: this.candidates,
         chosen: this.chosen,

--- a/backend/src/services/playlists/playlistTrace.ts
+++ b/backend/src/services/playlists/playlistTrace.ts
@@ -74,6 +74,13 @@ export type RankerSnapshot = {
   embeddingVersion: number;
   /** e.g. GENRE_JACCARD_FLOOR, YEAR_FALLBACK_WINDOW — the pre-rank filters. */
   candidateFilters?: Record<string, number>;
+  /**
+   * Knobs governing playlist-level diversity (cross-playlist reuse penalty,
+   * per-album / per-artist caps, total tracks per playlist). Captured so a
+   * future reader can tell whether a regenerated playlist's shape is
+   * explained by the *limits* in force at the time or by the candidate pool.
+   */
+  diversityKnobs?: Record<string, number>;
 };
 
 export type ForYouTrace = {

--- a/backend/src/services/playlists/playlistTrace.ts
+++ b/backend/src/services/playlists/playlistTrace.ts
@@ -145,6 +145,13 @@ export class ForYouTraceBuilder {
     this.skipReason = reason;
   }
 
+  /**
+   * Record which ranker configuration was active for this regeneration.
+   * Should be called once at the top of `generateForYouPlaylistsWithTrace`
+   * before any playlist work; the snapshot is included on the final trace
+   * so future readers can reproduce the picks even after the weights
+   * have moved on.
+   */
   setRanker(snapshot: RankerSnapshot): void {
     this.ranker = snapshot;
   }

--- a/docs/ai-playlist-spike.md
+++ b/docs/ai-playlist-spike.md
@@ -1,0 +1,168 @@
+# Specialized music embeddings — proposal
+
+Drafted 2026-05-14. Sister doc to `docs/roadmap-next.md` (P3).
+
+P3 is "AI-assisted automatic playlists". An earlier draft of this doc proposed wiring a general-purpose LLM into the ranker. **That direction is rejected.** Anthropic-style models are the wrong tool here: they're expensive per call, opaque, and they don't actually understand audio. The right tool is a *specialized, free, open-source music model* that produces real semantic embeddings.
+
+This doc is an implementation proposal, not a research spike. The deliverable is shipped playlists, not an eval harness.
+
+---
+
+## 1. The actual problem
+
+The for-you generator (`backend/src/services/playlists/forYou/generate.ts`) and personal-mix generator already use audio embeddings — `embeddingSimilarity` is one feature in the ranker. But it carries only `0.10` weight (`forYouRanker.ts:36–43`) while `genreOverlap` carries `0.40` and `yearProximity` carries `0.20`.
+
+Why so little trust in the embeddings? Because of what they are.
+
+`backend/src/services/embeddings/audioFeatures.ts` produces a **32-dim hand-crafted DSP vector**: 13 MFCC means + 13 MFCC stds + spectral centroid mean/std + rolloff mean + flatness mean + zero-crossing rate mean + RMS mean. L2-normalized.
+
+This is a **timbral fingerprint**. It captures "what does this signal sound like spectrally" — roughly *instrument timbre + production texture*. It does **not** capture:
+
+- Melody, harmony, chord progressions
+- Rhythm patterns beyond gross energy
+- Genre semantics
+- Mood / valence / energy
+- Vocal style
+- Anything a human would call "musical identity"
+
+Two tracks with similar spectral envelopes (e.g. a piano ballad and a piano-led intro of a metal song before the drop) can score high cosine. Two tracks with the same melody played on different instruments score low. This is why the ranker can't trust the feature past `0.10` — and *that* is why genre and year tags dominate, and *that* is why playlists feel narrow.
+
+**Replacing the embedding model is the right intervention.** Cap-and-sequence, candidate gathering, signal computation all stay. Only `computeFeatureVector` changes.
+
+---
+
+## 2. Chosen model — CLAP (LAION)
+
+**Model: `laion/clap-htsat-fused`** (HuggingFace).
+
+- **License:** Apache-2.0. Permissive, no non-commercial restriction.
+- **Architecture:** HTSAT (Hierarchical Token-Semantic Audio Transformer) audio encoder + RoBERTa text encoder, fused into a single 512-dim joint embedding space.
+- **Training:** Contrastive (audio, text) pairs from LAION-Audio-630k, including music tagging datasets.
+- **Output dim:** 512.
+- **Sample rate:** 48 kHz mono.
+- **Compute:** CPU-feasible (~0.5–1 s per 3-minute track, batched).
+
+Why CLAP over the alternatives we considered:
+
+- vs. **MERT-v1-95M**: MERT is marginally stronger on pure music benchmarks but its CC-BY-NC license blocks any future commercial path. CLAP is Apache-2 and competitive on music tasks.
+- vs. **OpenL3**: CLAP is newer, trained on larger/cleaner data, and beats OpenL3 across MIR benchmarks.
+- vs. **MERT-v1-330M**: needs GPU we don't assume the user has.
+
+CLAP brings a real **bonus capability** the others don't: text and audio live in the *same* 512-dim space. A natural-language description ("jazzy mellow Sunday morning") encodes to the same kind of vector as an audio clip, so similarity becomes a free cosine query. We don't ship that feature in this proposal — it's filed as a follow-up in §9 — but the option exists because we picked CLAP.
+
+---
+
+## 3. Why this is "AI" in the sense that matters
+
+The user's framing was "specialized free AI", and that's what these models are:
+
+- They're **neural networks** with millions of parameters, trained on hundreds of thousands of hours of music with self-supervised objectives that capture musical structure.
+- They produce **semantic embeddings** — two tracks that are "musically similar" in a way humans would recognize end up near each other in vector space, even if their MFCCs differ.
+- They're **specialized** — trained on music, not general language or general audio.
+- They're **free** — model weights are downloadable, run locally, no per-request cost, no telemetry, no rate limits.
+- They're **deterministic** — same audio in → same vector out. No prompt drift, no API outages.
+
+Calling them "AI" is technically correct in the same sense that a hosted LLM is AI — neural net, large parameter count, learned from data. The difference is *where* the intelligence sits (in the weights you ship) versus *who pays for it each time* (you, every call, to a remote provider).
+
+---
+
+## 4. Integration — Python sidecar
+
+A long-running Python process loads CLAP into memory once, exposes a small local HTTP endpoint, and embeds tracks on request. Node calls it; the sidecar handles ffmpeg decoding (or `torchaudio` resampling), forward pass, and returns a 512-float vector.
+
+Layout:
+
+```
+backend/python-services/audio-embedder/
+├── server.py          # FastAPI app, single POST /embed { absolutePath } → { vec }
+├── model.py           # CLAP loading + windowed inference + mean-pool
+├── requirements.txt   # torch, transformers, librosa or torchaudio, fastapi, uvicorn
+├── setup.md           # one-page operator doc: install, run, troubleshoot
+└── start.sh           # launches uvicorn on a fixed local port
+```
+
+Node side: a tiny `embedderClient.ts` that POSTs to the sidecar with a short timeout + retry. Replace the body of `computeAndSaveEmbedding` to call it instead of running TS DSP. The existing `withSlot(...)` concurrency queue stays — it now throttles HTTP calls to the sidecar instead of ffmpeg processes.
+
+Operational notes:
+- **Cold start:** CLAP loads in ~10 s. Sidecar stays running, so this is paid once at server startup.
+- **Memory:** ~1 GB resident with the model loaded. Comparable to a Node worker.
+- **Lifecycle:** systemd unit (or process manager already in use) supervises both Node and the sidecar; if the sidecar dies, Node's HTTP call fails fast and the existing "embedding is best-effort, skip on failure" path kicks in.
+- **Window strategy:** CLAP was trained on 10-second clips. For tracks > 10 s, take three overlapping windows (start, middle, end), encode each, mean-pool. Documented in `model.py`.
+
+Rejected alternatives: **ONNX Runtime in Node** (CLAP's HTSAT has custom ops and a non-trivial export path; preprocessing in TS is painful), **one-shot Python CLI per track** (pays the 10 s model load on every call — unusable for backfill).
+
+---
+
+## 5. Ranker reweighting
+
+Once embeddings actually carry musical meaning, the linear weights in `forYouRanker.ts` should rebalance:
+
+| Feature | Current | Proposed |
+|---|---:|---:|
+| `genreOverlap` | 0.40 | 0.25 |
+| `yearProximity` | 0.20 | 0.10 |
+| `libraryPopularity` | 0.15 | 0.15 |
+| `novelty` | 0.15 | 0.15 |
+| `albumOverlapWithSeed` | -0.30 | -0.30 |
+| `skipPenalty` | -0.20 | -0.20 |
+| **`embeddingSimilarity`** | **0.10** | **0.40** |
+
+Rationale: shift relevance signal from *tag-overlap* (which is brittle and arbitrary) to *learned audio similarity* (which is robust and continuous). The narrowness levers from the rejected spike (`GENRE_JACCARD_FLOOR = 0.2`, `YEAR_FALLBACK_WINDOW = 7`) can also relax — likely to `0.1` and `12` respectively — because the embedding is now the safety net that catches "is this actually similar".
+
+These numbers are starting points, not commitments. The new weights ship behind the same trace mechanism (`finalOrder` records each feature's contribution), so we can post-hoc inspect which tracks moved up/down and why.
+
+---
+
+## 6. Migration
+
+The existing pipeline already has the lever we need: `EMBEDDING_VERSION` in `audioFeatures.ts:28`. `loadEmbedding` returns null on version mismatch, and `backfillMissingEmbeddings` regenerates anything missing. Bumping the version invalidates all old sidecars; the next backfill recomputes everything with the new model.
+
+Concrete plan:
+- New `EMBEDDING_VERSION = 3`.
+- New file layout: `data/embeddings/<trackId>.json` keeps the same path so dismissals/dedup code untouched.
+- Vector dimension changes (32 → 512 for CLAP). `EMBEDDING_DIM` becomes a config constant; ranker code is already dimension-agnostic (cosine works on any dim).
+- Backfill triggered manually for first pass (`npm run embed:backfill`), then automatic for new uploads via the existing hook.
+- During the backfill window, for-you regeneration sees a mix of v2 and v3 sidecars. Mixing is unsafe (different geometries). Guard: ranker skips embedding similarity entirely until *both* the seed track set and the candidate set are fully v3. Trace records the skip reason.
+
+CPU cost estimate: CLAP on CPU ≈ 0.5–1 s per track (three 10 s windows, batched forward pass). 30 k-track library ≈ 4–8 h one-time. Reasonable to run overnight.
+
+Disk cost: 512 × ~8 B (float32 in JSON as numbers) ≈ ~4 kB per sidecar × 30 k tracks ≈ 120 MB. Roughly 4× current. Fine.
+
+---
+
+## 7. Phased PRs
+
+| Phase | Scope | Acceptance |
+|---|---|---|
+| **0 — Proposal** (this doc) | Land this design doc on master. | Doc reviewed. |
+| **1 — Sidecar skeleton** | `backend/python-services/audio-embedder/` with a *stub* model returning a deterministic dummy vector. Node-side `embedderClient.ts`. Unit tests on the client (mock socket). Docker-compose wiring optional but documented. | `npm run embed:probe` end-to-end returns a vector. No production behavior changes yet (still using v2 path). |
+| **2 — Real model** | Swap the stub for CLAP (`laion/clap-htsat-fused`). Pin Python deps. Document `setup.md`. Sanity check: 10 hand-picked track pairs ("same artist", "same genre different artist", "totally different") have cosine ordering that a human agrees with. No production hookup yet. | Manual sanity check passes. Sidecar handles ≥ 100 tracks back-to-back without leaking memory. |
+| **3 — Production hookup** | Bump `EMBEDDING_VERSION` to 3. Change `computeAndSaveEmbedding` to call the sidecar. Adjust `EMBEDDING_DIM`. Add the mixed-version guard in the ranker. Backfill script + CLI hook. | All new uploads produce v3 sidecars. Backfill on the dev library completes. for-you still works (with embedding similarity skipped while mixed). |
+| **4 — Ranker rebalance** | Apply the §5 weight changes + relax `GENRE_JACCARD_FLOOR` and `YEAR_FALLBACK_WINDOW`. Regenerate playlists. | Author listens through 6 regenerated playlists and confirms they feel *broader but still coherent*. If not, weights/floors are tweaked before merge. |
+| **5 — Observability** | Surface the new feature in the existing trace UI (`/api/me/for-you/trace`). Add a comparison view: "tracks that ranked high under v2 but low under v3" so we understand the change in production. | Trace page renders the new column. |
+
+Estimated effort: phase 1 ≈ 1 day, phase 2 ≈ 1 day, phase 3 ≈ 1 day (plus overnight backfill), phase 4 ≈ ½ day plus listening, phase 5 ≈ ½ day. **Total: ~4 days of focused work**, plus the overnight backfill.
+
+---
+
+## 8. Risks & open questions
+
+- **Python runtime in the deployment** — flaque is currently Node + ffmpeg. Adding Python is a deployment-shape change. Mitigations: pin Python version in `setup.md`, ship a `requirements.txt` with explicit hashes, supervise via the same process manager already in use.
+- **CPU-only inference latency** — 0.5–1 s/track is fine for upload-time embedding and overnight backfill, less fine for "user uploads 200 tracks at once". The existing `MAX_CONCURRENT = 2` slot queue already handles this gracefully; backfill simply takes longer.
+- **Cold start** — sidecar takes ~10 s to load CLAP into memory. Keep it always-on; lifecycle managed by the host's process manager.
+- **Resident memory** — ~1 GB extra for the sidecar. Worth noting in the deployment doc; on a single-server setup this is fine, on a constrained VPS it may matter.
+- **Are we replacing or augmenting?** Proposal above replaces (v2 → v3, geometries don't mix). Alternative: keep both, give each its own weight. Costs disk + complexity; gains ablation visibility. *Recommend replace; revisit only if phase 4 shows the rebalance going wrong.*
+
+---
+
+## 9. Out of scope (deliberately) — and follow-ups CLAP unlocks
+
+Out of scope for this proposal:
+- **Free music recommendation APIs** (ListenBrainz, Last.fm). Different lever (candidate expansion, not ranker quality). Filed separately.
+- **Collaborative filtering / matrix factorization** on local play counts. Different lever still; useful for users with deep history. Filed separately.
+- **Eval harness.** Deliberately not building one. The proof is in the playlists the author listens to in phase 4. If a strategy doesn't survive that, no benchmark will save it.
+
+CLAP-specific follow-ups (cheap to add once the sidecar is live, since the text encoder is the same module):
+- **Natural-language playlist generation.** User types a mood ("jazzy mellow Sunday morning"); we encode it once into the 512-dim space and rank library tracks by cosine. No LLM, no per-call cost, fully deterministic.
+- **Smart radio seeding.** Encode the description of a station ("late-night driving") into the same space and use it as a seed instead of (or in addition to) an artist.
+- **Tag suggestion.** For a track with sparse tags, find the closest tag-vector text labels in CLAP space and suggest them. Cheap moderation/curation aid.

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -35,9 +35,11 @@ export {
   getArtists,
   getAlbums,
   getArtistAlbums,
-  getAlbumTracks
+  getAlbumTracks,
+  getLibrarySettings,
+  patchLibrarySettings
 } from "./library";
-export type { TracksResponse, RecentUploadAlbum, RecentUploadItem } from "./library";
+export type { TracksResponse, RecentUploadAlbum, RecentUploadItem, LibrarySettings } from "./library";
 
 export { coverPathUrl, coverUrl } from "./covers";
 export { streamUrl } from "./streaming";

--- a/frontend/src/api/library.ts
+++ b/frontend/src/api/library.ts
@@ -150,3 +150,19 @@ export async function getAlbumTracks(albumId: string): Promise<Track[]> {
   const payload = await requestJson<{ tracks: Track[] }>(`/api/album/${encodeURIComponent(albumId)}`);
   return payload.tracks;
 }
+
+export type LibrarySettings = {
+  aiRecommendation: boolean;
+};
+
+export async function getLibrarySettings(): Promise<LibrarySettings> {
+  return requestJson<LibrarySettings>("/api/library/settings");
+}
+
+export async function patchLibrarySettings(patch: Partial<LibrarySettings>): Promise<LibrarySettings> {
+  return requestJson<LibrarySettings>("/api/library/settings", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch)
+  });
+}

--- a/frontend/src/components/AdminLibraryView.tsx
+++ b/frontend/src/components/AdminLibraryView.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 
+import { AiRecommendationPanel } from "./adminLibrary/AiRecommendationPanel";
 import { AutoPlaylistConfigPanel } from "./adminLibrary/AutoPlaylistConfigPanel";
 import { EnrichmentLogPanel } from "./adminLibrary/EnrichmentLogPanel";
 import { EnrichmentPanel } from "./adminLibrary/EnrichmentPanel";
@@ -41,6 +42,8 @@ export function AdminLibraryView({ onAutoPlaylistsRegenerated }: AdminLibraryVie
       <EnrichmentLogPanel refreshKey={logRefreshKey} />
 
       <AutoPlaylistConfigPanel onAutoPlaylistsRegenerated={onAutoPlaylistsRegenerated} />
+
+      <AiRecommendationPanel />
     </div>
   );
 }

--- a/frontend/src/components/adminLibrary/AiRecommendationPanel.test.tsx
+++ b/frontend/src/components/adminLibrary/AiRecommendationPanel.test.tsx
@@ -1,0 +1,84 @@
+/* @vitest-environment happy-dom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const getSettings = vi.fn();
+const patchSettings = vi.fn();
+
+vi.mock("../../api", () => ({
+  getLibrarySettings: () => getSettings(),
+  patchLibrarySettings: (...args: unknown[]) => patchSettings(...args)
+}));
+
+import { AiRecommendationPanel } from "./AiRecommendationPanel";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AiRecommendationPanel", () => {
+  it("renders enabled state when the setting is true", async () => {
+    getSettings.mockResolvedValue({ aiRecommendation: true });
+    render(<AiRecommendationPanel />);
+    await waitFor(() => expect(screen.getByText("Enabled")).toBeTruthy());
+    expect(
+      (screen.getByLabelText("Enable AI recommendation") as HTMLInputElement).checked
+    ).toBe(true);
+    expect(screen.getByText(/Using CLAP/)).toBeTruthy();
+  });
+
+  it("renders disabled state when the setting is false", async () => {
+    getSettings.mockResolvedValue({ aiRecommendation: false });
+    render(<AiRecommendationPanel />);
+    await waitFor(() => expect(screen.getByText("Disabled")).toBeTruthy());
+    expect(
+      (screen.getByLabelText("Enable AI recommendation") as HTMLInputElement).checked
+    ).toBe(false);
+    expect(screen.getByText(/Using legacy MFCC/)).toBeTruthy();
+  });
+
+  it("toggles the setting and shows the disable message", async () => {
+    getSettings.mockResolvedValue({ aiRecommendation: true });
+    patchSettings.mockResolvedValue({ aiRecommendation: false });
+    render(<AiRecommendationPanel />);
+    await waitFor(() => expect(screen.getByText("Enabled")).toBeTruthy());
+
+    const checkbox = screen.getByLabelText("Enable AI recommendation") as HTMLInputElement;
+    fireEvent.click(checkbox);
+
+    await waitFor(() =>
+      expect(patchSettings).toHaveBeenCalledWith({ aiRecommendation: false })
+    );
+    await waitFor(() => expect(screen.getByText("Disabled")).toBeTruthy());
+    expect(screen.getByText(/AI recommendation disabled/)).toBeTruthy();
+  });
+
+  it("toggles the setting back on and shows the enable message", async () => {
+    getSettings.mockResolvedValue({ aiRecommendation: false });
+    patchSettings.mockResolvedValue({ aiRecommendation: true });
+    render(<AiRecommendationPanel />);
+    await waitFor(() => expect(screen.getByText("Disabled")).toBeTruthy());
+
+    const checkbox = screen.getByLabelText("Enable AI recommendation") as HTMLInputElement;
+    fireEvent.click(checkbox);
+
+    await waitFor(() =>
+      expect(patchSettings).toHaveBeenCalledWith({ aiRecommendation: true })
+    );
+    await waitFor(() => expect(screen.getByText("Enabled")).toBeTruthy());
+    expect(screen.getByText(/AI recommendation enabled/)).toBeTruthy();
+  });
+
+  it("surfaces an error message when the patch fails", async () => {
+    getSettings.mockResolvedValue({ aiRecommendation: true });
+    patchSettings.mockRejectedValue(new Error("server is down"));
+    render(<AiRecommendationPanel />);
+    await waitFor(() => expect(screen.getByText("Enabled")).toBeTruthy());
+
+    fireEvent.click(screen.getByLabelText("Enable AI recommendation"));
+
+    await waitFor(() => expect(screen.getByText(/server is down/)).toBeTruthy());
+  });
+});

--- a/frontend/src/components/adminLibrary/AiRecommendationPanel.tsx
+++ b/frontend/src/components/adminLibrary/AiRecommendationPanel.tsx
@@ -2,6 +2,15 @@ import { useEffect, useState } from "react";
 
 import { getLibrarySettings, patchLibrarySettings, type LibrarySettings } from "../../api";
 
+/**
+ * Admin-only library setting: switch the embedding backend between CLAP
+ * (Python sidecar, default) and the legacy in-process MFCC pipeline.
+ *
+ * Stateless — reads the current setting from `/api/library/settings` on
+ * mount and PATCHes back on toggle. Backfill of existing tracks happens
+ * automatically on the next regeneration; the panel does not trigger it
+ * directly.
+ */
 export function AiRecommendationPanel(): JSX.Element {
   const [settings, setSettings] = useState<LibrarySettings | null>(null);
   const [loading, setLoading] = useState(true);

--- a/frontend/src/components/adminLibrary/AiRecommendationPanel.tsx
+++ b/frontend/src/components/adminLibrary/AiRecommendationPanel.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+
+import { getLibrarySettings, patchLibrarySettings, type LibrarySettings } from "../../api";
+
+export function AiRecommendationPanel(): JSX.Element {
+  const [settings, setSettings] = useState<LibrarySettings | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function load(): Promise<void> {
+    setLoading(true);
+    try {
+      setSettings(await getLibrarySettings());
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "Failed to load library settings.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleToggle(next: boolean): Promise<void> {
+    setSaving(true);
+    setMessage(null);
+    try {
+      const updated = await patchLibrarySettings({ aiRecommendation: next });
+      setSettings(updated);
+      setMessage(
+        next
+          ? "AI recommendation enabled. New uploads will use CLAP; existing tracks will be re-embedded in the background."
+          : "AI recommendation disabled. The Python sidecar is no longer required; for-you reverts to the legacy MFCC engine."
+      );
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "Failed to update setting.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-flaque-clay/60 bg-white/85 p-5 shadow-panel backdrop-blur-sm">
+      <h3 className="font-display text-xl text-flaque-ink">AI recommendation</h3>
+      <p className="mt-1 text-sm text-flaque-steel">
+        Powers for-you playlists with the local CLAP audio model (~1 GB resident, runs in a Python sidecar).
+        Disable on light servers to fall back to the previous engine (32-dim MFCC embeddings via ffmpeg, tag-driven ranker).
+        Playlists are recomputed on the next regeneration in either case.
+      </p>
+      <p className="mt-1 text-xs text-flaque-steel">
+        Note: disabling requires <code className="font-mono">ffmpeg</code> on PATH for the MFCC backfill.
+        Until backfill completes, embedding similarity is treated as neutral and playlists are picked from genre + year + popularity signals only.
+      </p>
+
+      {loading || !settings ? (
+        <p className="mt-3 text-sm text-flaque-steel">Loading...</p>
+      ) : (
+        <div className="mt-4 flex flex-col gap-3">
+          <label className="flex cursor-pointer items-start gap-3">
+            <input
+              type="checkbox"
+              className="mt-1 h-4 w-4 cursor-pointer accent-flaque-ink"
+              checked={settings.aiRecommendation}
+              disabled={saving}
+              onChange={(e) => {
+                void handleToggle(e.target.checked);
+              }}
+              aria-label="Enable AI recommendation"
+            />
+            <span className="text-sm text-flaque-ink">
+              <span className="font-semibold">
+                {settings.aiRecommendation ? "Enabled" : "Disabled"}
+              </span>
+              <span className="block text-xs text-flaque-steel">
+                {settings.aiRecommendation
+                  ? "Using CLAP (laion/clap-htsat-fused, 512-dim). Requires the audio-embedder sidecar to be running."
+                  : "Using legacy MFCC (32-dim). No Python sidecar needed."}
+              </span>
+            </span>
+          </label>
+
+          {message ? <p className="text-sm text-flaque-steel">{message}</p> : null}
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the for-you ranker's hand-crafted 32-dim MFCC fingerprint with **CLAP** (`laion/clap-htsat-fused`, Apache-2.0, 512-dim) running locally in a Python sidecar. Raises `embeddingSimilarity` weight from 0.10 to 0.40 so the ranker can finally trust the audio signal, and loosens the tag-based pre-rank filters now that CLAP cosine is doing real work. No hosted-LLM dependency, no per-request cost, no telemetry.

Ships behind an **admin toggle** (`Library settings → AI recommendation`, default on). Disabling it rolls the embedding backend back to the legacy in-process MFCC pipeline and restores the pre-CLAP ranker weights + pre-rank filters, so operators on light servers can opt out of hosting the ~1 GB CLAP runtime.

Net effect on regenerated playlists for the local library (with AI on, after the post-evaluation tuning): visibly broader peer selection — metalcore-seeded mixes now pull in Pink Floyd and RHCP at the tail; RHCP-seeded pulls in the metalcore stack — without losing tight same-genre clustering at the top. Library coverage across the 5 for-you playlists jumped from 45% to 67%, same-album overflow dropped from 5 to 2 tracks per playlist, and the "tracks appearing in all 5 playlists" count fell from 6 to 3.

## Commits

1. **proposal** `docs/ai-playlist-spike.md` — diagnosis, model survey, integration shape, phased plan.
2. **phase 1** — Python sidecar skeleton (stdlib http.server, deterministic stub) + Node client + `npm run embed:probe` smoke test.
3. **phase 2** — swap stub for real CLAP via transformers; pinned deps (`torch 2.5.1+cpu`, `transformers 4.46.3`, `librosa 0.10.2`); `start.sh` manages a `.venv`; `setup.md` documents sanity-check + memory-leak procedure.
4. **phase 3** — bump `EMBEDDING_VERSION` 2→3 and `EMBEDDING_DIM` 32→512; rewrite `computeAndSaveEmbedding` to call the sidecar (drops ~300 lines of in-process DSP); bump default client timeout 10s→60s after Echoes (23 min) tripped it; add `npm run embed:backfill` CLI.
5. **phase 4** — ranker rebalance: `genreOverlap 0.40→0.25`, `yearProximity 0.20→0.10`, `embeddingSimilarity 0.10→0.40`; filter relaxation: `GENRE_JACCARD_FLOOR 0.2→0.1`, `YEAR_FALLBACK_WINDOW 7→12`; add `npm run for-you:regen` CLI.
6. **phase 5** — capture ranker snapshot (`weights`, `embeddingVersion`, `candidateFilters`) on every trace; add `npm run for-you:inspect` CLI that pretty-prints traces with per-track feature breakdowns.
7. **AI recommendation toggle** — admin setting that switches the embedding backend between CLAP and the restored MFCC pipeline. Default on (preserves new behavior). Symmetric version-gate so toggling either way auto-invalidates the other mode's sidecars and the backfill loop recomputes.
8. **cleanup pass** — pre-merge polish across everything this branch touched. Renames `EMBEDDING_*` → `CLAP_EMBEDDING_*` for symmetry with `MFCC_EMBEDDING_*`; extracts `rankerProfileFor(model)` helper; adds JSDoc to all key public types and functions across 11 files; adds 7 new dispatch tests (MFCC backfill path + `getActiveEmbeddingProfile` per-mode + toggle round-trip via `loadEmbedding`). No production behavior changes.
9. **diversity tuning** — addresses two issues surfaced by evaluating the post-phase-4 playlists. Adds a cross-playlist reuse penalty (`-0.12` on tracks already placed in earlier for-you playlists for this user in the same regen) so a handful of universal-cosine tracks don't appear in every mix. Adds `MAX_PER_ALBUM_SEED = 4` (separate from the peer-pick `MAX_PER_ALBUM = 2`) so single-album seed artists get ≥4 seed tracks in their playlist instead of 2. Both knobs captured in `RankerSnapshot.diversityKnobs` and printed by the inspector. +3 integration tests.
10. **collab cap consolidation** — closes the loophole where featured-artist tags (`X; Y`, `X feat. Y`, `X ft. Y`) bypassed both the per-artist and per-album caps. Each collab tag was previously creating its own cap key, so the same album could appear 5× in a single playlist. `Candidate.capKey` (primary artist via `extractPrimaryArtist`) now drives the per-artist cap; `albumKey()` now namespaces by primary artist. Seed-equality check still uses the full artist string so collab tracks are still included as peers in their primary's playlist — they just compete for the same cap budget as plain tracks. +2 integration tests.

## What changed

- **Backend (Node):** `audioEmbeddingService` orchestrates either the CLAP sidecar or the restored in-process MFCC pipeline based on a per-library setting. `mfccEmbedder.ts` is the legacy DSP pipeline (FFT + mel filterbank + MFCC + spectral features + ffmpeg decode) kept around for AI-off mode. `audioFeatures` is now just CLAP constants + `cosineSimilarity` + `meanVector`. Ranker exports `CLAP_WEIGHTS` and `MFCC_WEIGHTS` presets; `generate.ts` picks one + the matching candidate-filter profile per regeneration via the `rankerProfileFor(model)` helper. Cross-playlist reuse penalty + separate seed-album cap + primary-artist cap key + primary-artist album key all working together to keep playlists diverse and prevent collab tags from defeating the caps. Trace structure extended with a `ranker` snapshot (weights, embedding version, filters, diversity knobs). Public surfaces carry JSDoc explaining contracts, edge cases, and sign conventions.
- **Sidecar (Python):** New `backend/python-services/audio-embedder/`. Self-bootstrapping `start.sh`, stdlib HTTP server, CLAP via HuggingFace transformers. Long-running, warms model once at boot (~10 s), then ~1.5 s/track on CPU.
- **Library settings:** New admin-only API `GET / PATCH /api/library/settings` and a new `AiRecommendationPanel` mounted in `AdminLibraryView`. Persisted at `data/config/library-settings.json`.
- **CLIs:** `embed:sidecar`, `embed:probe`, `embed:backfill`, `for-you:regen`, `for-you:inspect`.
- **On-disk format:** v2 sidecars (MFCC, 32-dim) and v3 sidecars (CLAP, 512-dim) both supported. `loadEmbedding` rejects whichever doesn't match the currently active mode; backfill recomputes on every mode flip.

## Playlist evaluation — three iterations

Measured on the local 96-track library, 5 regenerated for-you playlists:

| Metric | Pre-tuning (phase 4) | After diversity tuning | After collab cap fix |
|---|---|---|---|
| Library coverage | 44/96 (45%) | 65/96 (67%) | 64/96 (66%) |
| Tracks in exactly 1 playlist | 16 | 45 | 47 |
| Tracks in all 5 playlists | 6 | 5 | **3** |
| Avg seed tracks per playlist | 2.0 | 3.6 | 4.0 |
| Max same-album in non-seed playlist | 5 | 5 | **2** |
| Max same-primary-artist in non-seed playlist | 5 | 5 | **2–3** |

## Validation done locally

- Backend suite: **541/541** tests green (incl. 81 playlist tests, 38 embeddings tests, 4 library-settings tests).
- Frontend suite: **225/225** tests green (incl. 5 `AiRecommendationPanel` tests).
- Python suite (inside venv): **13/13** tests green covering windowing math + path-reachability + contract.
- Live install: torch+transformers+librosa pinned, CLAP weights cached in `~/.cache/huggingface/` (~600 MB), ~1.2 GB venv.
- Sanity check (`sanity_check.py`): cosine matrix across 9 hand-picked tracks orders correctly (Pink Floyd vs metalcore −0.08 to +0.10, metalcore-internal +0.68 to +0.93, same-artist cross-album +0.52 to +0.72).
- Memory leak: 100 sequential `/embed` calls; RSS 1094 MB → 1103 MB (+9 MB drift, no leak).
- Backfill: 96/96 local tracks have v3 sidecars (one retry needed after the Echoes timeout led to the 60s default).
- **Toggle round-trip:** flipping off → trace shows MFCC weights (`emb=0.10 genre=0.40 year=0.20`), `v2/32-dim` embedding profile, stricter filters, 279-candidate pool. Flipping back on → CLAP weights, v3/512-dim, looser filters, 361-candidate pool. Graceful degradation when MFCC sidecars don't yet exist. Unit-tested via mocked `librarySettings` and `loadEmbedding` flip-then-reject.
- **Diversity tuning + collab caps:** post-regeneration evaluation confirmed library coverage 45% → 66%, tracks-in-1-playlist 16 → 47, tracks-in-all-5 6 → 3, max same-album-in-non-seed-playlist 5 → 2. New integration tests cover the seed-album cap, diversity knob recording, non-fully-overlapping peer sets between two seeded playlists, primary-artist cap consolidation across collabs, and primary-album cap consolidation across collabs.

## Test plan

- [ ] Pull the branch, run `./backend/python-services/audio-embedder/start.sh` and let it install deps + download CLAP weights on first run
- [ ] Confirm `npm run embed:probe -- <some-track>` returns a 512-dim L2-normalised vector
- [ ] `npm run embed:backfill` recomputes any v2 sidecars on disk
- [ ] Hit the regenerate button in the app (or `npm run for-you:regen`) and listen to the new playlists
- [ ] If the playlists feel broader-but-coherent, merge. If too chaotic, pull weights back (e.g. `embeddingSimilarity 0.30`). If still too narrow, push further (`embeddingSimilarity 0.50`).
- [ ] `npm run for-you:inspect` to verify the trace records the new ranker snapshot + diversity knobs
- [ ] In Admin → Library, flip the AI recommendation toggle off. Confirm the panel re-renders to "Disabled" and (with `ffmpeg` on PATH) the next backfill produces 32-dim v2 sidecars. Run `for-you:inspect` again and confirm the trace switches to MFCC weights + tight filters.
- [ ] Flip back on, run the same checks — confirm the trace switches back to CLAP weights + loose filters.

## Risks & known constraints

- **Python runtime added to the deployment** (when AI is on). Self-bootstrapping `start.sh`, pinned deps, supervised same way as the Node process. ~1 GB resident with CLAP loaded.
- **Cold start ~10 s** to load CLAP. Warmup runs at sidecar boot; first POST doesn't pay it.
- **CPU-only inference ~1.5 s/track** typical, up to ~12 s for multi-minute tracks (Pink Floyd "Echoes" was the proof). Fine for upload + overnight backfill; not OK as a synchronous request blocker (it isn't one — `computeAndSaveEmbedding` is fire-and-forget).
- **AI-off mode needs `ffmpeg` on PATH** for the MFCC backfill (same dependency the original pipeline always had). Without it, the ranker degrades to neutral embeddings — no crash, just less signal, identical to how the original pipeline behaved when a sidecar was missing.
- **Toggling the AI setting orphans sidecars in the inactive mode on disk.** Each is ~4 kB (MFCC) or ~6 kB (CLAP); harmless to leave. A future cleanup CLI can prune them if disk pressure matters.
- **Diversity penalty is flat, not proportional.** A track scoring high enough above alternatives can still survive `-0.12` in every regen. 3 of 100 picks in the local library still appear in all 5 playlists (was 6, after collab caps was 5). A future iteration could make the penalty proportional to prior-playlist-count; for now the diversity-knobs snapshot records the exact value so the next tune can be data-driven.
- **Primary-artist consolidation uses `extractPrimaryArtist` from `utils/music.ts`** — strips `; X`, `feat. X`, `ft. X`. Other collab notations (`&`, `with`, etc.) are not currently recognised, but those forms are rare in well-tagged libraries.
- **Out of scope:** v2-vs-v3 comparison view (impossible post-cutover); text-to-audio search (CLAP has a free text encoder in the same space — filed as a follow-up); free music recommendation APIs (ListenBrainz/Last.fm) and collaborative filtering — different levers, separate tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
