### PR TITLE
feat(player): restart on previous past 5s, restore queue on resume

### DIFF
--- a/backend/src/api/playCountRoutes.ts
+++ b/backend/src/api/playCountRoutes.ts
@@ -110,12 +110,20 @@ export function createPlayCountRouter(indexStore: IndexStore): Router {
         return next(new AppError("Authentication required", 401));
       }
 
-      const body = req.body as { trackId?: unknown; positionSec?: unknown } | undefined;
+      const body = req.body as { trackId?: unknown; positionSec?: unknown; queue?: unknown } | undefined;
       const trackId = typeof body?.trackId === "string" ? body.trackId.trim() : "";
       const positionSec =
         typeof body?.positionSec === "number" && Number.isFinite(body.positionSec)
           ? body.positionSec
           : null;
+      // Only persist queue entries that still exist in the index. `undefined`
+      // (queue omitted) leaves the previously stored queue untouched.
+      const queue = Array.isArray(body?.queue)
+        ? body.queue
+            .filter((entry): entry is string => typeof entry === "string")
+            .map((entry) => entry.trim())
+            .filter((entry) => entry.length > 0 && indexStore.hasTrack(entry))
+        : undefined;
 
       if (!trackId) {
         return next(new AppError("trackId is required", 400));
@@ -127,7 +135,7 @@ export function createPlayCountRouter(indexStore: IndexStore): Router {
         return next(new AppError("Track not found", 404));
       }
 
-      const state = await setPlaybackState(userId, { trackId, positionSec });
+      const state = await setPlaybackState(userId, { trackId, positionSec, queue });
       res.json({ state });
     } catch (error) {
       next(error);

--- a/backend/src/services/activity/playbackStateStore.test.ts
+++ b/backend/src/services/activity/playbackStateStore.test.ts
@@ -75,6 +75,61 @@ describe("playbackStateStore", () => {
     expect((await getPlaybackState("user-2"))?.trackId).toBe("track-b");
   });
 
+  it("stores and retrieves the playback queue", async () => {
+    const result = await setPlaybackState("user-1", {
+      trackId: "track-a",
+      positionSec: 5,
+      queue: ["track-a", "track-b", "track-c"]
+    });
+
+    expect(result.queue).toEqual(["track-a", "track-b", "track-c"]);
+    expect((await getPlaybackState("user-1"))?.queue).toEqual([
+      "track-a",
+      "track-b",
+      "track-c"
+    ]);
+  });
+
+  it("preserves the existing queue when a position-only update omits it", async () => {
+    await setPlaybackState("user-1", {
+      trackId: "track-a",
+      positionSec: 5,
+      queue: ["track-a", "track-b", "track-c"]
+    });
+
+    const updated = await setPlaybackState("user-1", { trackId: "track-b", positionSec: 42 });
+
+    expect(updated.trackId).toBe("track-b");
+    expect(updated.positionSec).toBe(42);
+    expect(updated.queue).toEqual(["track-a", "track-b", "track-c"]);
+  });
+
+  it("replaces the queue when a new one is provided", async () => {
+    await setPlaybackState("user-1", {
+      trackId: "track-a",
+      positionSec: 5,
+      queue: ["track-a", "track-b"]
+    });
+
+    const updated = await setPlaybackState("user-1", {
+      trackId: "track-x",
+      positionSec: 0,
+      queue: ["track-x", "track-y"]
+    });
+
+    expect(updated.queue).toEqual(["track-x", "track-y"]);
+  });
+
+  it("drops an empty queue rather than storing it", async () => {
+    const result = await setPlaybackState("user-1", {
+      trackId: "track-a",
+      positionSec: 5,
+      queue: []
+    });
+
+    expect(result.queue).toBeUndefined();
+  });
+
   it("clearPlaybackState removes the stored state", async () => {
     await setPlaybackState("user-1", { trackId: "track-a", positionSec: 10 });
     await clearPlaybackState("user-1");

--- a/backend/src/services/activity/playbackStateStore.ts
+++ b/backend/src/services/activity/playbackStateStore.ts
@@ -7,6 +7,8 @@ export type PlaybackState = {
   trackId: string;
   positionSec: number;
   updatedAt: string;
+  /** Ordered track IDs of the queue that was playing, so a resume can continue past the current track. */
+  queue?: string[];
 };
 
 type PlaybackStateFile = {
@@ -15,6 +17,15 @@ type PlaybackStateFile = {
 
 function playbackStatePath(userId: string): string {
   return path.join(usersStorageRoot, userId, "playback-state.json");
+}
+
+function sanitizeQueue(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const ids = value
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  return ids;
 }
 
 function isValidState(value: unknown): value is PlaybackState {
@@ -38,23 +49,35 @@ export async function getPlaybackState(userId: string): Promise<PlaybackState | 
 
 export async function setPlaybackState(
   userId: string,
-  input: { trackId: string; positionSec: number }
+  input: { trackId: string; positionSec: number; queue?: string[] }
 ): Promise<PlaybackState> {
   const trackId = input.trackId.trim();
   const positionSec = Math.max(0, Number.isFinite(input.positionSec) ? input.positionSec : 0);
-  const next: PlaybackState = {
+  // An explicit (even empty) queue replaces the stored one; omitting it preserves
+  // the existing queue so frequent position-only updates don't drop it.
+  const incomingQueue = sanitizeQueue(input.queue);
+
+  const result = await updateJsonFile<PlaybackStateFile>(
+    playbackStatePath(userId),
+    { state: null },
+    (current) => {
+      const existingQueue = isValidState(current.state) ? current.state.queue : undefined;
+      const queue = incomingQueue ?? existingQueue;
+      const next: PlaybackState = {
+        trackId,
+        positionSec,
+        updatedAt: new Date().toISOString(),
+        ...(queue && queue.length > 0 ? { queue } : {})
+      };
+      return { state: next };
+    }
+  );
+
+  return result.state ?? {
     trackId,
     positionSec,
     updatedAt: new Date().toISOString()
   };
-
-  await updateJsonFile<PlaybackStateFile>(
-    playbackStatePath(userId),
-    { state: null },
-    () => ({ state: next })
-  );
-
-  return next;
 }
 
 export async function clearPlaybackState(userId: string): Promise<void> {

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -121,7 +121,12 @@ export function AuthenticatedApp({
     if (selectedTrackRefreshed?.id === resumeStateData.trackId) return null;
     const track = allTracksById.get(resumeStateData.trackId);
     if (!track) return null;
-    return { track, positionSec: resumeStateData.positionSec };
+    // Resolve the persisted queue against the current index so resuming keeps
+    // playing past the current track rather than stopping at its end.
+    const queue = (resumeStateData.queue ?? [])
+      .map((trackId) => allTracksById.get(trackId))
+      .filter((queueTrack): queueTrack is Track => Boolean(queueTrack));
+    return { track, positionSec: resumeStateData.positionSec, queue };
   }, [resumeStateData, allTracksById, selectedTrackRefreshed?.id]);
 
   const handlePlayRadioTrack = useCallback((track: Track, startOffsetSec: number): void => {
@@ -504,7 +509,9 @@ export function AuthenticatedApp({
           resumeState,
           onResume: (track, positionSec) => {
             setPlayerStatusMessage(null);
-            requestTrackPlayback(track, [track], { startOffsetSec: positionSec });
+            const queueSource =
+              resumeState?.queue && resumeState.queue.length > 0 ? resumeState.queue : [track];
+            requestTrackPlayback(track, queueSource, { startOffsetSec: positionSec });
           },
           onDismissResume: () => {
             void dismissResume();

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -122,6 +122,8 @@ export type PlaybackState = {
   trackId: string;
   positionSec: number;
   updatedAt: string;
+  /** Ordered track IDs of the queue that was playing, so a resume can continue past the current track. */
+  queue?: string[];
 };
 
 export async function getMyPlaybackState(): Promise<PlaybackState | null> {
@@ -132,6 +134,7 @@ export async function getMyPlaybackState(): Promise<PlaybackState | null> {
 export async function setMyPlaybackState(input: {
   trackId: string;
   positionSec: number;
+  queue?: string[];
 }): Promise<PlaybackState> {
   const { state } = await requestJson<{ state: PlaybackState }>("/api/me/playback-state", {
     method: "PUT",

--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -108,7 +108,7 @@ export function AudioPlayer({
     audioRef, streamSource,
     isPlaying, currentTime, duration, volume, muted,
     canTranscode, effectiveTranscode,
-    pausePlayback, onTogglePlayback, onSeek, onEnded,
+    pausePlayback, onTogglePlayback, onSeek, handlePrevious, onEnded,
     onCycleRepeatMode, onToggleShuffle,
     handleTranscodeModeChange, handleVolumeChange, setMuted,
     handleAudioPlay, handleAudioPause, handleAudioTimeUpdate, handleAudioLoadedMetadata
@@ -119,7 +119,7 @@ export function AudioPlayer({
     playRequestNonce, playRequestOffsetSec, onNext, onPrevious, onTrackPlayed, onTrackSkipped
   });
 
-  usePlaybackPositionPersistence({ track, currentTime, isPlaying });
+  usePlaybackPositionPersistence({ track, currentTime, isPlaying, queue: queueTracks });
 
   const [showPlaylistPicker, setShowPlaylistPicker] = useState(false);
   const [showQueuePanel, setShowQueuePanel] = useState(false);
@@ -265,11 +265,7 @@ export function AudioPlayer({
                   type="button"
                   aria-label="Previous track"
                   title="Previous"
-                  onClick={() => {
-                    if (onPrevious) {
-                      void onPrevious({ wrap: false });
-                    }
-                  }}
+                  onClick={() => handlePrevious({ wrap: false })}
                   disabled={!onPrevious || seekLocked}
                 >
                   <PrevIcon />

--- a/frontend/src/hooks/useAudioPlayback.test.tsx
+++ b/frontend/src/hooks/useAudioPlayback.test.tsx
@@ -86,3 +86,57 @@ describe("useAudioPlayback skip detection", () => {
     expect(onTrackSkipped).not.toHaveBeenCalled();
   });
 });
+
+describe("useAudioPlayback previous-track behavior", () => {
+  function mountWithPrevious(track: Track, onPrevious: () => void, currentTime: number) {
+    const rendered = renderHook(() =>
+      useAudioPlayback({
+        track,
+        transcodeMode: "original",
+        repeatMode: "off",
+        shuffleEnabled: false,
+        playRequestNonce: 0,
+        onPrevious
+      })
+    );
+
+    const fakeAudio = {
+      load: vi.fn(),
+      play: vi.fn().mockResolvedValue(undefined),
+      pause: vi.fn(),
+      paused: true,
+      currentTime,
+      duration: 200,
+      volume: 1,
+      muted: false
+    };
+    rendered.result.current.audioRef.current = fakeAudio as unknown as HTMLAudioElement;
+    return { result: rendered.result, fakeAudio };
+  }
+
+  it("restarts the current track when more than 5s have elapsed", async () => {
+    const onPrevious = vi.fn();
+    const track = makeTrack({ id: "a", duration: 200 });
+    const { result, fakeAudio } = mountWithPrevious(track, onPrevious, 12);
+
+    await act(async () => {
+      result.current.handlePrevious({ wrap: false });
+    });
+
+    expect(onPrevious).not.toHaveBeenCalled();
+    expect(fakeAudio.currentTime).toBe(0);
+    expect(result.current.currentTime).toBe(0);
+  });
+
+  it("skips to the previous track when within the first 5s", async () => {
+    const onPrevious = vi.fn();
+    const track = makeTrack({ id: "a", duration: 200 });
+    const { result } = mountWithPrevious(track, onPrevious, 3);
+
+    await act(async () => {
+      result.current.handlePrevious({ wrap: false });
+    });
+
+    expect(onPrevious).toHaveBeenCalledWith({ wrap: false });
+  });
+});

--- a/frontend/src/hooks/useAudioPlayback.ts
+++ b/frontend/src/hooks/useAudioPlayback.ts
@@ -18,6 +18,9 @@ type NavigateOptions = {
 const PLAYER_VOLUME_STORAGE_KEY = "flaque_player_volume_v1";
 const SKIP_TIME_THRESHOLD_SECONDS = 30;
 const SKIP_RATIO_THRESHOLD = 0.5;
+// Pressing "previous" past this point restarts the current track instead of
+// jumping to the previous one (matches the convention used by most players).
+const PREVIOUS_RESTART_THRESHOLD_SECONDS = 5;
 
 function isFlacTrack(track: Track): boolean {
   return (
@@ -74,6 +77,7 @@ export type AudioPlaybackState = {
   pausePlayback: () => void;
   onTogglePlayback: () => void;
   onSeek: (seconds: number) => void;
+  handlePrevious: (options?: NavigateOptions) => void;
   onEnded: () => void;
   onCycleRepeatMode: () => void;
   onToggleShuffle: () => void;
@@ -321,9 +325,7 @@ export function useAudioPlayback({
     bindAction("pause", () => pausePlayback());
     bindAction("stop", () => pausePlayback());
     bindAction("previoustrack", () => {
-      if (onPrevious) {
-        void onPrevious({ wrap: false });
-      }
+      handlePrevious({ wrap: false });
     });
     bindAction("nexttrack", () => {
       if (onNext) {
@@ -456,6 +458,22 @@ export function useAudioPlayback({
     audioElement.currentTime = nextSeconds;
     currentTimeRef.current = nextSeconds;
     setCurrentTime(nextSeconds);
+  }
+
+  function handlePrevious(options?: NavigateOptions): void {
+    const audioElement = audioRef.current;
+    // If we're already a few seconds into the track, "previous" restarts it
+    // rather than skipping back to the prior track.
+    if (audioElement && audioElement.currentTime > PREVIOUS_RESTART_THRESHOLD_SECONDS) {
+      audioElement.currentTime = 0;
+      currentTimeRef.current = 0;
+      setCurrentTime(0);
+      return;
+    }
+
+    if (onPrevious) {
+      void onPrevious(options);
+    }
   }
 
   function onEnded(): void {
@@ -609,6 +627,7 @@ export function useAudioPlayback({
     pausePlayback,
     onTogglePlayback,
     onSeek,
+    handlePrevious,
     onEnded,
     onCycleRepeatMode,
     onToggleShuffle,

--- a/frontend/src/hooks/usePlaybackPositionPersistence.ts
+++ b/frontend/src/hooks/usePlaybackPositionPersistence.ts
@@ -9,19 +9,24 @@ type UsePlaybackPositionPersistenceInput = {
   track: Track | null;
   currentTime: number;
   isPlaying: boolean;
+  queue: Track[];
 };
 
 /**
  * Periodically persists the user's current track + position to the backend so
- * the Home view can offer a cross-device "Resume" affordance. Skips radio
- * tracks (owner === "radio") since they aren't resumable.
+ * the Home view can offer a cross-device "Resume" affordance. The current queue
+ * is persisted alongside it (on track/queue changes only) so resuming continues
+ * playback past the current track. Skips radio tracks (owner === "radio") since
+ * they aren't resumable.
  */
 export function usePlaybackPositionPersistence({
   track,
   currentTime,
-  isPlaying
+  isPlaying,
+  queue
 }: UsePlaybackPositionPersistenceInput): void {
   const lastPersistedTrackIdRef = useRef<string | null>(null);
+  const lastPersistedQueueSigRef = useRef<string | null>(null);
   const lastPersistedAtRef = useRef(0);
   const inFlightRef = useRef(false);
 
@@ -30,13 +35,23 @@ export function usePlaybackPositionPersistence({
       return;
     }
 
-    const persist = (positionSec: number): void => {
+    const queueIds = queue
+      .filter((entry) => entry.owner !== "radio")
+      .map((entry) => entry.id);
+    const queueSig = queueIds.join(",");
+
+    const persist = (positionSec: number, includeQueue: boolean): void => {
       if (inFlightRef.current) return;
       inFlightRef.current = true;
       lastPersistedAtRef.current = Date.now();
       lastPersistedTrackIdRef.current = track.id;
+      lastPersistedQueueSigRef.current = queueSig;
 
-      setMyPlaybackState({ trackId: track.id, positionSec })
+      setMyPlaybackState({
+        trackId: track.id,
+        positionSec,
+        ...(includeQueue ? { queue: queueIds } : {})
+      })
         .catch(() => {
           // ignore: persistence is best-effort
         })
@@ -45,10 +60,13 @@ export function usePlaybackPositionPersistence({
         });
     };
 
-    // On a fresh track, write the starting position right away so a resume on
-    // another device knows what's loaded even if the user immediately closes.
-    if (lastPersistedTrackIdRef.current !== track.id) {
-      persist(Math.max(0, currentTime));
+    // On a fresh track or a changed queue, write right away (including the queue)
+    // so a resume on another device knows what's loaded and can play on past the
+    // current track, even if the user immediately closes.
+    const trackChanged = lastPersistedTrackIdRef.current !== track.id;
+    const queueChanged = lastPersistedQueueSigRef.current !== queueSig;
+    if (trackChanged || queueChanged) {
+      persist(Math.max(0, currentTime), true);
       return;
     }
 
@@ -61,6 +79,7 @@ export function usePlaybackPositionPersistence({
       return;
     }
 
-    persist(Math.max(0, currentTime));
-  }, [track, isPlaying, currentTime]);
+    // Position-only update; the queue is left untouched server-side.
+    persist(Math.max(0, currentTime), false);
+  }, [track, isPlaying, currentTime, queue]);
 }


### PR DESCRIPTION
## Summary

Two small playback refinements:

1. **"Previous" restarts the track past 5s.** If the track has been playing for more than 5 seconds, pressing "previous" restarts it instead of skipping to the previous track. Applied to both the player button and the Media Session control (headset/Bluetooth/OS).
2. **"Resume" restores the play queue.** Previously, resuming started with a single-track queue and stopped at its end. The queue is now persisted with the playback state and restored on resume, so playback continues past the resumed track.

## Technical details

- `useAudioPlayback`: new `handlePrevious` function (threshold `PREVIOUS_RESTART_THRESHOLD_SECONDS = 5`), used by both the button and the Media Session.
- `PlaybackState` gains an optional `queue: string[]` field (backend store + `PUT /me/playback-state` route, frontend API). The route filters out IDs no longer present in the index. Server-side merge: an explicit queue replaces the stored one; a position-only update preserves it.
- `usePlaybackPositionPersistence`: sends the queue only on track/queue changes (detected via a signature), not on every position tick.
- `AuthenticatedApp`: the persisted queue is resolved against the current index and passed to `requestTrackPlayback` on resume.

## Tests

- Backend: 4 new cases (queue storage, merge on position-only update, replacement, empty queue dropped).
- Frontend: 2 new cases (`handlePrevious` restarts > 5s / skips < 5s).
- Full suites green: backend 545, frontend 227. Typecheck passes on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
