### PR TITLE
fix(http): prevent truncated login responses behind the reverse proxy

### DIFF
--- a/backend/src/middleware/errorHandler.test.ts
+++ b/backend/src/middleware/errorHandler.test.ts
@@ -56,8 +56,7 @@ describe("errorHandler middleware", () => {
     expect(mockNext).not.toHaveBeenCalled();
   });
 
-  it("should call next if response headers already sent? (optional)", () => {
-    // Simulate headers sent
+  it("delegates to next without writing a body when headers were already sent", () => {
     const mockResWithSent = {
       ...mockRes,
       headersSent: true,
@@ -66,10 +65,11 @@ describe("errorHandler middleware", () => {
 
     errorHandler(err as any, mockReq as any, mockResWithSent, mockNext);
 
-    // In Express, if headers already sent, you should call next
-    // Our implementation does not check headersSent; but we can note that.
-    // For now, we just expect that it still tries to json (which may fail in real Express)
-    // We'll just ensure it doesn't crash.
-    expect(mockRes.json).toHaveBeenCalled();
+    // Writing on top of an in-flight response would corrupt it (body shorter
+    // than the advertised Content-Length), so we must hand off to Express's
+    // default handler instead of calling res.status()/res.json().
+    expect(mockRes.status).not.toHaveBeenCalled();
+    expect(mockRes.json).not.toHaveBeenCalled();
+    expect(mockNext).toHaveBeenCalledWith(err);
   });
 });

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -9,9 +9,18 @@ export function errorHandler(
   err: unknown,
   _req: Request,
   res: Response,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   next: NextFunction
 ): void {
+  // If the response already started streaming (e.g. a file send that failed
+  // mid-flight), we cannot write a JSON error body on top of it — doing so
+  // throws "Cannot set headers after they are sent" and leaves the socket with
+  // a body shorter than its advertised Content-Length. Hand off to Express's
+  // default handler, which aborts the connection cleanly.
+  if (res.headersSent) {
+    next(err);
+    return;
+  }
+
   if (err instanceof AppError) {
     res.status(err.statusCode).json({
       error: err.message,

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -79,6 +79,23 @@ async function bootstrap(): Promise<void> {
   server.requestTimeout = readNonNegativeIntEnv("HTTP_REQUEST_TIMEOUT_MS", 0);
   server.timeout = readNonNegativeIntEnv("HTTP_SOCKET_TIMEOUT_MS", 0);
 
+  // Keep-alive lifetime must outlive the reverse proxy's idle timeout so the
+  // proxy — not the backend — decides when to retire a pooled connection. With
+  // Node's short 5s default, nginx can pick an idle keep-alive socket to reuse
+  // at the exact moment Node is closing it; the in-flight response is then
+  // truncated and the browser surfaces a "Content-Length header of network
+  // response exceeds response Body" error. Default to 65s, comfortably above
+  // nginx's 60s upstream keepalive_timeout.
+  const keepAliveTimeoutMs = readNonNegativeIntEnv("HTTP_KEEP_ALIVE_TIMEOUT_MS", 65_000);
+  server.keepAliveTimeout = keepAliveTimeoutMs;
+  // headersTimeout must stay strictly greater than keepAliveTimeout, otherwise
+  // Node can time out the next request on a reused connection while the current
+  // response is still being written. Clamp up if the env override breaks that.
+  server.headersTimeout = Math.max(
+    readNonNegativeIntEnv("HTTP_HEADERS_TIMEOUT_MS", 70_000),
+    keepAliveTimeoutMs + 5_000
+  );
+
   server.listen(port, () => {
     log.info(`flaque backend listening on http://localhost:${port}`);
   });

--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -1,3 +1,16 @@
+# Pool keep-alive connections to the backend instead of opening (and tearing
+# down) a fresh one per request. Reused connections are what make the backend's
+# keepAliveTimeout matter: as long as the backend keeps idle sockets alive
+# longer than this upstream does, nginx never reuses a socket the backend is
+# concurrently closing — which is what produced intermittent truncated
+# responses ("Content-Length exceeds response Body") at login.
+upstream flaque_backend {
+  server ${BACKEND_HOST}:${BACKEND_PORT};
+  keepalive 32;
+  keepalive_timeout 60s;
+  keepalive_requests 1000;
+}
+
 server {
   listen 80;
   server_name _;
@@ -11,12 +24,15 @@ server {
   include /etc/nginx/mime.types;
 
   location /api/ {
-    proxy_pass http://${BACKEND_HOST}:${BACKEND_PORT}/api/;
+    proxy_pass http://flaque_backend/api/;
     proxy_http_version 1.1;
     proxy_connect_timeout 30s;
     proxy_send_timeout 600s;
     proxy_read_timeout 600s;
 
+    # Required for upstream keep-alive: strip the per-request close directive so
+    # nginx reuses pooled connections to flaque_backend.
+    proxy_set_header Connection "";
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Problem

At login, users intermittently see the browser error:

> Content-Length header of network response exceeds response Body

This means a response reached the browser with fewer bytes than its advertised `Content-Length` — the connection was cut mid-response. It is intermittent and tied to connection lifecycle, not to any single endpoint's payload.

## Root cause

A keep-alive lifecycle mismatch between the frontend nginx proxy and the Node backend:

- `backend/src/server.ts` set `requestTimeout` and the socket `timeout`, but left **`keepAliveTimeout` at Node's 5s default**. With the socket timeout disabled (`0`), idle keep-alive sockets are retired aggressively by Node.
- `frontend/nginx/default.conf` proxied over HTTP/1.1 but **did not pool upstream connections** (no `upstream` block, no cleared `Connection` header).

Behind a reverse proxy this is the classic cause of truncated responses: the proxy can write a request onto — or read a response from — a socket the backend is concurrently closing, so the body is cut short while `Content-Length` still advertises the full size.

## Fix

- **`server.ts`** — set `keepAliveTimeout` (default **65s**, override `HTTP_KEEP_ALIVE_TIMEOUT_MS`) above nginx's 60s upstream idle timeout, so the proxy — not Node — decides when to retire a pooled connection. `headersTimeout` (default 70s, override `HTTP_HEADERS_TIMEOUT_MS`) is clamped to always stay strictly greater than `keepAliveTimeout`, so a reused connection is never torn down mid-response.
- **`frontend/nginx/default.conf`** — pool connections to the backend via an `upstream` block (`keepalive 32`, `keepalive_timeout 60s`) and clear the per-request `Connection` header (`proxy_set_header Connection ""`). This makes connection reuse deterministic, which is what lets the backend's `keepAliveTimeout` actually govern socket lifetime.
- **`errorHandler`** — when `res.headersSent` is already true (e.g. a file send that failed mid-flight), delegate to Express's default handler instead of writing a JSON body on top of the in-flight response — doing so would itself create a `Content-Length`/body mismatch and throw "Cannot set headers after they are sent".

## Validation

- Backend + frontend type-check clean.
- Full unit suite green (backend + frontend), including an updated `errorHandler` test asserting the `headersSent` delegation.
- e2e (login / forgot-password) green — backend boots and serves correctly with the new timeouts.
- nginx config rendered through the official template `envsubst` and validated with `nginx -t` (passes; upstream host resolution stays deferred to startup, same as the previous `proxy_pass`, so no startup regression).

## Notes for reviewer

The three changes are coordinated: the backend timeout change only takes effect because nginx now pools upstream connections, and the ordering invariant (`keepAliveTimeout` > proxy idle, `headersTimeout` > `keepAliveTimeout`) is enforced in code. If a separate edge proxy (CDN / tunnel) sits in front of the frontend container, its idle timeout should likewise be kept below the backend's 65s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
