### PR TITLE
P2 quick wins: constant-time login check + roadmap doc fix

### DIFF
--- a/REFACTORING_ROADMAP.md
+++ b/REFACTORING_ROADMAP.md
@@ -47,13 +47,15 @@ The audit found that both pieces of Phase D had already shipped between the
 2026-04-19 snapshot and the start of this round:
 
 - **D1. Backend error handling.** `backend/src/utils/AppError.ts` defines
-  `AppError(message, statusCode, details?)`. `backend/src/middleware/errorHandler.ts`
-  is mounted in both `app.ts:37` and `api/router.ts:39`, emits
-  `{ error, details? }`, and special-cases `multer.MulterError`. Routes
+  `AppError(message, statusCode, code?, details?)`. `backend/src/middleware/errorHandler.ts`
+  is mounted in both `app.ts` and `api/router.ts`, emits
+  `{ error, code?, details? }`, and special-cases `multer.MulterError`. Routes
   consistently use `next(err)`. The two remaining ad-hoc 4xx responses are
   intentional: `radioRoutes.ts` returns a domain-specific envelope and
-  `authRoutes.ts:120` needs a `Retry-After` header alongside the JSON.
-  The speculative `code` field is omitted — no consumer discriminates on it.
+  `authRoutes.ts` needs a `Retry-After` header alongside the JSON.
+  The stable `code` field is consumed by the frontend
+  (`frontend/src/api/client.ts`) to localise errors through the `errors` i18n
+  namespace.
 - **D2. Frontend 401 entry point.** `useSessionRoutingState.ts:95-103`
   registers exactly one `setUnauthorizedHandler` callback that clears the user
   and broadcasts a logout event. The bypass list for normal-login-flow paths

--- a/backend/src/api/authRoutes.test.ts
+++ b/backend/src/api/authRoutes.test.ts
@@ -54,6 +54,22 @@ describe("authRoutes", () => {
     expect(byEmail.status).toBe(200);
   });
 
+  it("returns an identical 401 for an unknown user and a wrong password", async () => {
+    const unknownUser = await apiRequest("/api/auth/login", {
+      method: "POST",
+      body: JSON.stringify({ login: "nobody-here", password: "some-password-123" })
+    });
+    expect(unknownUser.status).toBe(401);
+    expect((unknownUser.payload as { code?: string }).code).toBe("invalidCredentials");
+
+    const wrongPassword = await apiRequest("/api/auth/login", {
+      method: "POST",
+      body: JSON.stringify({ login: "admin", password: "definitely-not-the-password" })
+    });
+    expect(wrongPassword.status).toBe(401);
+    expect((wrongPassword.payload as { code?: string }).code).toBe("invalidCredentials");
+  });
+
   it("rate limits repeated failed login attempts", async () => {
     process.env.AUTH_RATE_LIMIT_WINDOW_MS = "60000";
     process.env.AUTH_LOGIN_RATE_LIMIT_MAX = "2";

--- a/backend/src/api/authRoutes.ts
+++ b/backend/src/api/authRoutes.ts
@@ -7,7 +7,7 @@ import { AppError } from "../utils/AppError";
 
 import { findUserByLogin, updateUserPassword } from "../auth/db";
 import { requireAuth } from "../auth/middleware";
-import { verifyPassword } from "../auth/password";
+import { hashPassword, verifyPassword } from "../auth/password";
 import { consumePasswordResetToken, createPasswordResetToken } from "../auth/passwordResetDb";
 import { sendPasswordResetEmail } from "../auth/passwordResetEmail";
 import {
@@ -41,6 +41,18 @@ type RateLimitBucket = {
 };
 
 const rateLimitBuckets = new Map<string, RateLimitBucket>();
+
+// Comparing the submitted password against a real bcrypt hash even when no
+// account matches keeps the login response time roughly constant, so an
+// attacker cannot enumerate valid usernames from a fast "user not found" path.
+// Computed lazily and once.
+let dummyPasswordHash: string | null = null;
+function getDummyPasswordHash(): string {
+  if (dummyPasswordHash === null) {
+    dummyPasswordHash = hashPassword("flaque-nonexistent-account-timing-guard");
+  }
+  return dummyPasswordHash;
+}
 
 function parseDeviceLabel(value: unknown): string | undefined {
   const label = normalizeOptionalString(value);
@@ -234,7 +246,10 @@ export function createAuthRouter(): Router {
     }
 
     const user = findUserByLogin(login);
-    if (!user || !verifyPassword(password, user.password_hash)) {
+    // Always run the comparison (against a dummy hash when the user is unknown)
+    // so the response timing does not depend on whether the account exists.
+    const passwordMatches = verifyPassword(password, user?.password_hash ?? getDummyPasswordHash());
+    if (!user || !passwordMatches) {
       emitAuthAuditLog("warn", "login-failed", {
         ip,
         loginFingerprint,


### PR DESCRIPTION
## Contexte

Deux « quick wins » de la liste P2 : un durcissement de sécurité et une correction de doc. Petit périmètre, faible risque.

## 1. Timing au login → énumération d'utilisateurs (`fix(auth)`)

`bcrypt` n'était exécuté **que** si le compte existait : une tentative « utilisateur inconnu » répondait nettement plus vite qu'un « mauvais mot de passe », révélant l'existence d'un compte par mesure du temps de réponse.

Correctif : la comparaison bcrypt tourne **toujours** — contre un hash factice fixe quand l'utilisateur est inconnu — donc le temps de réponse ne dépend plus de l'existence du compte. Les deux chemins renvoyaient déjà un 401 identique ; un test le verrouille désormais.

## 2. Doc drift (`docs`)

La note D1 de `REFACTORING_ROADMAP.md` affirmait que le champ `code` était « omis ». En réalité `AppError` est `(message, statusCode, code?, details?)`, le handler émet `{ error, code?, details? }`, et le frontend consomme `code` pour localiser les erreurs. Corrigé (et suppression des numéros de ligne qui avaient dérivé).

## Vérification

- Type-check backend + lint : **OK** (0 erreur).
- `authRoutes` : **9/9** verts, dont le nouveau test « 401 identique pour utilisateur inconnu et mauvais mot de passe ».

## Différé (suivi)

- `noUncheckedIndexedAccess` sur le frontend : jaugé à **28 erreurs** sur ~14 fichiers (Coverflow en concentre 9) — pas un quick win, mérite sa propre PR (certaines pourraient être de vrais trous de null-safety).
- `npm audit` bloquant en CI : à faire **après** le merge de la migration multer 2.x (#191), sinon le vuln multer 1.x ferait échouer le job.
- `bcryptjs` → `bcrypt` natif : gain de perf mais ajoute une dépendance native (node-gyp) au build Docker — à évaluer séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
