### PR TITLE
chore(frontend): enable noUncheckedIndexedAccess (align with backend)

### DIFF
--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -464,7 +464,7 @@ export function AuthenticatedApp({
           onRecentlyUploadedAlbumPlay: (album) => {
             const sortedTracks = sortAlbumTracksByNumber(album.tracks);
             if (sortedTracks.length === 0) return;
-            requestTrackPlaybackWithStatus(sortedTracks[0], sortedTracks);
+            requestTrackPlaybackWithStatus(sortedTracks[0]!, sortedTracks);
           },
           onRecentlyUploadedAlbumOpen: (album) => {
             const targetName = normalizeText(album.albumName);

--- a/frontend/src/components/AccountView.test.tsx
+++ b/frontend/src/components/AccountView.test.tsx
@@ -116,7 +116,7 @@ describe("AccountView", () => {
     const revokeButtons = screen.getAllByRole("button", { name: "Revoke" });
     expect(revokeButtons.length).toBe(2);
 
-    fireEvent.click(revokeButtons[1]);
+    fireEvent.click(revokeButtons[1]!);
 
     await waitFor(() => {
       expect(mockHandleRevokeMySession).toHaveBeenCalledWith("session-other");

--- a/frontend/src/components/Coverflow.tsx
+++ b/frontend/src/components/Coverflow.tsx
@@ -82,7 +82,7 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect }: CoverflowPro
     let closestDist = Infinity;
 
     for (let i = 0; i < items.length; i++) {
-      const li = items[i];
+      const li = items[i]!;
       const cover = li.querySelector<HTMLElement>(".cover-transform");
       if (!cover) continue;
 
@@ -102,8 +102,8 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect }: CoverflowPro
 
     // Update the label with the centered album info
     const label = labelRef.current;
-    if (label && albums[closestIdx]) {
-      const album = albums[closestIdx];
+    const album = albums[closestIdx];
+    if (label && album) {
       const titleEl = label.querySelector<HTMLElement>(".coverflow-title");
       const artistEl = label.querySelector<HTMLElement>(".coverflow-artist");
       if (titleEl) titleEl.textContent = album.name;
@@ -136,9 +136,10 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect }: CoverflowPro
 
     const items = wrapper.querySelectorAll<HTMLElement>(".cards li");
     for (let i = 0; i < items.length; i++) {
-      if (items[i].classList.contains("selected")) {
+      const item = items[i]!;
+      if (item.classList.contains("selected")) {
         wrapper.scrollTo({
-          left: items[i].offsetLeft - wrapper.clientWidth / 2 + items[i].offsetWidth / 2,
+          left: item.offsetLeft - wrapper.clientWidth / 2 + item.offsetWidth / 2,
           behavior: "instant"
         });
         break;

--- a/frontend/src/components/Coverflow.tsx
+++ b/frontend/src/components/Coverflow.tsx
@@ -135,8 +135,7 @@ export function Coverflow({ albums, selectedAlbum, onAlbumSelect }: CoverflowPro
     if (!wrapper || !selectedKey) return;
 
     const items = wrapper.querySelectorAll<HTMLElement>(".cards li");
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i]!;
+    for (const item of items) {
       if (item.classList.contains("selected")) {
         wrapper.scrollTo({
           left: item.offsetLeft - wrapper.clientWidth / 2 + item.offsetWidth / 2,

--- a/frontend/src/components/HeaderAcronym.tsx
+++ b/frontend/src/components/HeaderAcronym.tsx
@@ -24,7 +24,7 @@ function tokenize(text: string, expansions: Record<string, string>) {
         }
 
         if (!matched) {
-            tokens.push(text[i]);
+            tokens.push(text.charAt(i));
             i++;
         }
     }

--- a/frontend/src/components/LibraryAlbumsSection.test.tsx
+++ b/frontend/src/components/LibraryAlbumsSection.test.tsx
@@ -207,11 +207,11 @@ describe("LibraryAlbumsSection", () => {
     );
 
     const addTrackButtons = screen.getAllByRole("button", { name: "Add Trouble's Coming to playlist" });
-    fireEvent.click(addTrackButtons[0]);
+    fireEvent.click(addTrackButtons[0]!);
     expect(onTrackSelect).not.toHaveBeenCalled();
 
     const confirmAddButtons = screen.getAllByRole("button", { name: "Add" });
-    fireEvent.click(confirmAddButtons[0]);
+    fireEvent.click(confirmAddButtons[0]!);
 
     await waitFor(() => {
       expect(onAddTrackToPlaylist).toHaveBeenCalledWith({

--- a/frontend/src/components/SyncedLyricsOverlay.tsx
+++ b/frontend/src/components/SyncedLyricsOverlay.tsx
@@ -13,7 +13,7 @@ export function SyncedLyricsOverlay({ lines, currentTime }: SyncedLyricsOverlayP
 
   const activeIndex = useMemo(() => {
     for (let i = lines.length - 1; i >= 0; i--) {
-      if (currentTime >= lines[i].t) return i;
+      if (currentTime >= lines[i]!.t) return i;
     }
     return -1;
   }, [lines, currentTime]);

--- a/frontend/src/components/config/FilesSection.tsx
+++ b/frontend/src/components/config/FilesSection.tsx
@@ -31,7 +31,7 @@ function normalizeSearch(value: string): string {
 
 function computeCommonField(tracks: Track[], getter: (t: Track) => string | undefined): string | undefined {
   if (tracks.length === 0) return undefined;
-  const first = getter(tracks[0]);
+  const first = getter(tracks[0]!);
   return tracks.every((t) => getter(t) === first) ? first : undefined;
 }
 

--- a/frontend/src/hooks/useAdminServer.ts
+++ b/frontend/src/hooks/useAdminServer.ts
@@ -107,7 +107,7 @@ export function useAdminServer({ user }: UseAdminServerArgs): UseAdminServerResu
       .then((files) => {
         setLogFiles(files);
         if (files.length > 0 && !selectedFile) {
-          setSelectedFile(files[0].name);
+          setSelectedFile(files[0]!.name);
         }
       })
       .catch((error) => {

--- a/frontend/src/hooks/usePlaybackCommands.ts
+++ b/frontend/src/hooks/usePlaybackCommands.ts
@@ -80,11 +80,11 @@ export function usePlaybackCommands({
     if (options?.shuffle) {
       setShuffleEnabled(true);
       const startIndex = Math.floor(Math.random() * playlistTracks.length);
-      requestTrackPlaybackWithStatus(playlistTracks[startIndex], playlistTracks);
+      requestTrackPlaybackWithStatus(playlistTracks[startIndex]!, playlistTracks);
       return;
     }
 
-    requestTrackPlaybackWithStatus(playlistTracks[0], playlistTracks);
+    requestTrackPlaybackWithStatus(playlistTracks[0]!, playlistTracks);
   }, [allTracksById, requestTrackPlaybackWithStatus, setLibraryError, setShuffleEnabled]);
 
   const handlePlayAlbum = useCallback(async (album: AlbumEntry): Promise<void> => {
@@ -104,7 +104,7 @@ export function usePlaybackCommands({
       }
 
       setLibraryError(null);
-      requestTrackPlaybackWithStatus(sorted[0], sorted);
+      requestTrackPlaybackWithStatus(sorted[0]!, sorted);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unable to play album";
       setLibraryError(message);

--- a/frontend/src/hooks/useSessionRoutingState.test.tsx
+++ b/frontend/src/hooks/useSessionRoutingState.test.tsx
@@ -123,7 +123,7 @@ describe("useSessionRoutingState", () => {
       expect(screen.getByTestId("user").textContent).toBe("alice");
     });
 
-    const channel = MockBroadcastChannel.instances[0];
+    const channel = MockBroadcastChannel.instances[0]!;
     channel.emit({
       sourceId: "other-tab",
       kind: "logout",
@@ -147,7 +147,7 @@ describe("useSessionRoutingState", () => {
       expect(MockBroadcastChannel.instances.length).toBe(1);
     });
 
-    const channel = MockBroadcastChannel.instances[0];
+    const channel = MockBroadcastChannel.instances[0]!;
 
     fireEvent.click(screen.getByRole("button", { name: "Notify" }));
     await waitFor(() => {

--- a/frontend/src/utils/albumSort.test.ts
+++ b/frontend/src/utils/albumSort.test.ts
@@ -129,8 +129,8 @@ describe("sortAndGroupAlbums", () => {
       "album-asc"
     );
     expect(groups.map((g) => g.label)).toEqual(["A", "B", "#"]);
-    expect(groups[0].albums.map((a) => a.name)).toEqual(["Alpha", "Apple"]);
-    expect(groups[2].albums.map((a) => a.name)).toEqual(["1999"]);
+    expect(groups[0]!.albums.map((a) => a.name)).toEqual(["Alpha", "Apple"]);
+    expect(groups[2]!.albums.map((a) => a.name)).toEqual(["1999"]);
   });
 
   it("groups artist sort by artist first letter (ignoring leading The)", () => {
@@ -156,8 +156,8 @@ describe("sortAndGroupAlbums", () => {
       "year-desc"
     );
     expect(groups.map((g) => g.label)).toEqual(["2020", "1999", "Unknown"]);
-    expect(groups[0].albums.map((a) => a.name)).toEqual(["A", "B"]);
-    expect(groups[2].albums).toHaveLength(1);
+    expect(groups[0]!.albums.map((a) => a.name)).toEqual(["A", "B"]);
+    expect(groups[2]!.albums).toHaveLength(1);
   });
 
   it("returns an empty list for empty input", () => {

--- a/frontend/src/utils/inspectAudioFile.ts
+++ b/frontend/src/utils/inspectAudioFile.ts
@@ -155,8 +155,8 @@ function pictureToDataUrl(picture?: IPicture): string | undefined {
   const mime = picture.format || "image/jpeg";
   const bytes = picture.data instanceof Uint8Array ? picture.data : new Uint8Array(picture.data);
   let binary = "";
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]!);
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
   }
   return `data:${mime};base64,${btoa(binary)}`;
 }

--- a/frontend/src/utils/inspectAudioFile.ts
+++ b/frontend/src/utils/inspectAudioFile.ts
@@ -156,7 +156,7 @@ function pictureToDataUrl(picture?: IPicture): string | undefined {
   const bytes = picture.data instanceof Uint8Array ? picture.data : new Uint8Array(picture.data);
   let binary = "";
   for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
+    binary += String.fromCharCode(bytes[i]!);
   }
   return `data:${mime};base64,${btoa(binary)}`;
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,6 +10,7 @@
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Contexte

Le backend tourne déjà avec `noUncheckedIndexedAccess` ; le frontend non. Cette PR aligne les deux — un item de durcissement signalé dans la revue. `noUncheckedIndexedAccess` fait remonter le `T | undefined` réel de chaque accès indexé (tableaux/records), transformant des `undefined` silencieux potentiels en erreurs de compilation.

## Changement

- `frontend/tsconfig.json` : ajout de `noUncheckedIndexedAccess: true`.
- **28 sites** d'accès indexé rendus explicites sur ~14 fichiers :
  - **capture + guard** là où la valeur peut réellement manquer (ex. `Coverflow` : l'album centré est capturé dans le `if`) ;
  - **assertion `!` / `charAt`** là où une vérification de longueur ou une boucle bornée prouve déjà la présence (ex. `arr[i]` dans `for (i < arr.length)`, ou `arr[0]` après `if (arr.length === 0) return`).

Comportement **inchangé** : ça ne fait que resserrer les types (aucune logique modifiée).

## Vérification

- Type-check frontend (avec le nouveau flag) : **0 erreur**.
- Lint : **0 erreur**.
- Suite frontend : **247/247** verts.

Le build CI (`tsc -p tsconfig.json && vite build`) valide le flag de bout en bout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
