### PR TITLE
refactor(frontend): extract library navigation from AuthenticatedApp (+ first tests for it)

### DIFF
--- a/frontend/src/AuthenticatedApp.test.tsx
+++ b/frontend/src/AuthenticatedApp.test.tsx
@@ -1,0 +1,325 @@
+/* @vitest-environment happy-dom */
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Track, User } from "./types";
+
+/**
+ * AuthenticatedApp is the composition root: its job is to wire ~18 hooks into
+ * the prop bundles AppShell consumes. Rendering the whole tree would test the
+ * children instead, so AppShell is mocked to capture exactly what the root
+ * assembles. That makes the wiring itself the unit under test, and lets a
+ * refactor prove it kept the assembled shape intact.
+ */
+
+const capturedProps: { current: Record<string, any> | null } = { current: null };
+
+vi.mock("./components/AppShell", () => ({
+  AppShell: (props: Record<string, unknown>) => {
+    capturedProps.current = props;
+    return <div data-testid="app-shell" />;
+  }
+}));
+
+const track = (id: string, title: string): Track =>
+  ({
+    id,
+    owner: "user-1",
+    path: `music/${id}.flac`,
+    duration: 100,
+    mimeType: "audio/flac",
+    codec: "flac",
+    tags: { title, artist: "Artist A", album: "Album A" }
+  }) as unknown as Track;
+
+const trackA = track("t1", "Track A");
+const trackB = track("t2", "Track B");
+
+vi.mock("./api", () => ({
+  logout: vi.fn().mockResolvedValue(undefined),
+  myProfilePhotoUrl: ({ version }: { version: number }) => `/photo?v=${version}`
+}));
+
+vi.mock("./hooks/useLibraryData", () => ({
+  useLibraryData: () => ({
+    filters: {},
+    setFilters: vi.fn(),
+    library: {
+      tracks: [trackA, trackB],
+      artists: [{ name: "Artist A", normalizedName: "artist a" }],
+      albums: [{ name: "Album A", artist: "Artist A" }],
+      owners: ["user-1"],
+      ownerNamesById: { "user-1": "alice" }
+    },
+    allTracksLibrary: { tracks: [trackA, trackB] },
+    availablePlaylists: [
+      { id: "p1", name: "Mine", authorId: "user-1", collaborators: [] },
+      { id: "p2", name: "Someone else", authorId: "user-9", collaborators: [] }
+    ],
+    libraryArtists: [{ name: "Artist A", normalizedName: "artist a" }],
+    selectedArtist: null,
+    artistAlbums: [],
+    selectedArtistAlbum: null,
+    libraryAlbums: [{ name: "Album A", artist: "Artist A" }],
+    selectedArtistAlbumTracks: [],
+    selectedArtistAlbumTracksError: null,
+    selectedAlbum: null,
+    selectedAlbumTracks: [],
+    selectedAlbumTracksError: null,
+    loadingLibrary: false,
+    loadingAllTracks: false,
+    loadingLibraryArtists: false,
+    loadingArtistAlbums: false,
+    loadingSelectedArtistAlbumTracks: false,
+    loadingLibraryAlbums: false,
+    loadingSelectedAlbumTracks: false,
+    libraryError: null,
+    setLibraryError: vi.fn(),
+    allTracksError: null,
+    setAllTracksError: vi.fn(),
+    libraryMetadataError: null,
+    refreshCurrentLibrary: vi.fn(),
+    refreshAllTracks: vi.fn(),
+    selectArtist: vi.fn(),
+    clearSelectedArtist: vi.fn(),
+    selectArtistAlbum: vi.fn(),
+    clearSelectedArtistAlbum: vi.fn(),
+    selectAlbum: vi.fn(),
+    clearSelectedAlbum: vi.fn()
+  })
+}));
+
+vi.mock("./hooks/useRecentlyUploaded", () => ({
+  useRecentlyUploaded: () => ({
+    items: [],
+    loading: false,
+    period: "7d",
+    setPeriod: vi.fn(),
+    refresh: vi.fn()
+  })
+}));
+
+vi.mock("./hooks/useInfiniteLibrary", () => ({
+  useInfiniteLibrary: () => ({
+    tracks: [trackA],
+    loading: false,
+    loadingMore: false,
+    hasMore: false,
+    total: 1,
+    sentinelRef: { current: null },
+    refresh: vi.fn()
+  })
+}));
+
+vi.mock("./hooks/useAutoPlaylists", () => ({
+  useAutoPlaylists: () => ({ autoPlaylists: [], loading: false, refresh: vi.fn() })
+}));
+
+vi.mock("./hooks/useForYouPlaylists", () => ({
+  useForYouPlaylists: () => ({
+    forYouPlaylists: [],
+    loading: false,
+    dismiss: vi.fn(),
+    regenerate: vi.fn()
+  })
+}));
+
+vi.mock("./hooks/usePersonalPlaylists", () => ({
+  usePersonalPlaylists: () => ({
+    personalPlaylists: [],
+    loading: false,
+    regenerate: vi.fn()
+  })
+}));
+
+vi.mock("./hooks/usePlaybackState", () => ({
+  usePlaybackState: () => ({
+    selectedTrackRefreshed: trackA,
+    refreshedQueue: [trackA, trackB],
+    playRequestNonce: 0,
+    playRequestOffsetSec: 0,
+    transcodeMode: "off",
+    setTranscodeMode: vi.fn(),
+    repeatMode: "off",
+    setRepeatMode: vi.fn(),
+    shuffleEnabled: false,
+    setShuffleEnabled: vi.fn(),
+    recentTracks: [],
+    requestTrackPlayback: vi.fn(),
+    replayRecentTrack: vi.fn(),
+    recordTrackPlayed: vi.fn(),
+    recordTrackSkipped: vi.fn(),
+    removeTrackFromPlayback: vi.fn(),
+    setSelectedTrack: vi.fn(),
+    resetAfterLogout: vi.fn()
+  })
+}));
+
+vi.mock("./hooks/useResumeState", () => ({
+  useResumeState: () => ({ resumeState: null, dismiss: vi.fn() })
+}));
+
+vi.mock("./hooks/useRadioStation", () => ({
+  useRadioStation: () => ({
+    loading: false,
+    stationId: null,
+    currentTrack: null,
+    nextTrack: null,
+    isRadioPlaybackActive: false,
+    startRadioPlayback: vi.fn(),
+    stopRadioPlayback: vi.fn()
+  })
+}));
+
+vi.mock("./hooks/useAdminUsers", () => ({
+  useAdminUsers: () => ({
+    adminUsers: [{ id: "user-2", username: "bob" }],
+    clearAdminState: vi.fn()
+  })
+}));
+
+vi.mock("./hooks/useLibraryCommands", () => ({
+  useLibraryCommands: () => ({
+    handleUpload: vi.fn(),
+    handleInspectUploadFile: vi.fn(),
+    handleRebuildIndex: vi.fn(),
+    handleDeleteTrack: vi.fn(),
+    handleUpdateTrackMetadata: vi.fn(),
+    handleReEnrichTrack: vi.fn(),
+    handleBulkDeleteTracks: vi.fn(),
+    handleBulkUpdateTrackMetadata: vi.fn(),
+    handleCreatePlaylist: vi.fn(),
+    handleAddTrackToPlaylist: vi.fn(),
+    handlePatchPlaylist: vi.fn(),
+    handleDeletePlaylist: vi.fn(),
+    handleHeartPlaylist: vi.fn(),
+    handleReportPlaylistListen: vi.fn()
+  })
+}));
+
+vi.mock("./hooks/usePlaybackCommands", () => ({
+  usePlaybackCommands: () => ({
+    requestTrackPlaybackWithStatus: vi.fn(),
+    handleReplayRecentTrack: vi.fn(),
+    handlePlayPlaylist: vi.fn(),
+    handlePlayAlbum: vi.fn(),
+    handleNavigateTrack: vi.fn()
+  })
+}));
+
+vi.mock("./hooks/useAppNotice", () => ({
+  useAppNotice: () => ({ appNotice: null, setAppNotice: vi.fn() })
+}));
+
+vi.mock("./hooks/useDocumentTitle", () => ({ useDocumentTitle: vi.fn() }));
+vi.mock("./hooks/useLanguageSync", () => ({ useLanguageSync: vi.fn() }));
+
+const user: User = {
+  id: "user-1",
+  username: "alice",
+  email: "alice@test.local",
+  role: "admin",
+  language: "en"
+};
+
+async function renderRoot() {
+  const { AuthenticatedApp } = await import("./AuthenticatedApp");
+  return render(
+    <AuthenticatedApp
+      user={user}
+      setUser={vi.fn()}
+      activeView="library"
+      setActiveView={vi.fn()}
+      activeLibrarySection="home"
+      setActiveLibrarySection={vi.fn()}
+      activeConfigSection="index"
+      setActiveConfigSection={vi.fn()}
+      playlistDetailId={null}
+      setPlaylistDetailId={vi.fn()}
+      notifyAuthStateChanged={vi.fn()}
+    />
+  );
+}
+
+beforeEach(() => {
+  capturedProps.current = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AuthenticatedApp composition", () => {
+  it("renders the shell without throwing", async () => {
+    const { getByTestId } = await renderRoot();
+    expect(getByTestId("app-shell")).toBeTruthy();
+    expect(capturedProps.current).not.toBeNull();
+  });
+
+  it("passes through the top-level shell props", async () => {
+    await renderRoot();
+    const props = capturedProps.current!;
+
+    expect(props.activeView).toBe("library");
+    expect(props.user).toEqual(user);
+    expect(props.avatarUrl).toBe("/photo?v=0");
+    expect(props.loadingLibrary).toBe(false);
+    expect(props.libraryError).toBeNull();
+    expect(typeof props.onViewChange).toBe("function");
+    expect(typeof props.onLogout).toBe("function");
+    expect(typeof props.onPlayerCollapse).toBe("function");
+  });
+
+  it("assembles every library workspace sub-bundle", async () => {
+    await renderRoot();
+    const workspace = capturedProps.current!.libraryWorkspaceProps;
+
+    expect(Object.keys(workspace).sort()).toEqual(
+      ["activeLibrarySection", "albumsProps", "artistsProps", "homeProps", "musicProps", "playlistsProps"].sort()
+    );
+    expect(workspace.activeLibrarySection).toBe("home");
+  });
+
+  it("derives manageablePlaylists from ownership and collaborators", async () => {
+    await renderRoot();
+    const { playlistsProps } = capturedProps.current!.libraryWorkspaceProps;
+
+    // p1 is authored by the current user, p2 belongs to someone else.
+    expect(playlistsProps.manageablePlaylists.map((p: { id: string }) => p.id)).toEqual(["p1"]);
+    expect(playlistsProps.availablePlaylists).toHaveLength(2);
+  });
+
+  it("merges owner names from the library, the current user and admin users", async () => {
+    await renderRoot();
+    const { ownerNameById } = capturedProps.current!.libraryWorkspaceProps.musicProps;
+
+    expect(ownerNameById).toMatchObject({
+      "user-1": "alice",
+      "user-2": "bob"
+    });
+  });
+
+  it("wires the audio player bundle to the current track and queue", async () => {
+    await renderRoot();
+    const audio = capturedProps.current!.audioPlayerProps;
+
+    expect(audio.track).toEqual(trackA);
+    expect(audio.queueTracks).toEqual([trackA, trackB]);
+    expect(audio.currentQueueTrackId).toBe("t1");
+    expect(audio.seekLocked).toBe(false);
+    expect(typeof audio.onOpenTrackArtist).toBe("function");
+    expect(typeof audio.onOpenTrackAlbum).toBe("function");
+  });
+
+  it("assembles the upload and config bundles", async () => {
+    await renderRoot();
+    const props = capturedProps.current!;
+
+    expect(typeof props.uploadViewProps.onUpload).toBe("function");
+    expect(typeof props.uploadViewProps.onInspectFile).toBe("function");
+    expect(props.configViewProps.activeSection).toBe("index");
+    expect(props.configViewProps.currentUser).toEqual(user);
+    expect(props.configViewProps.tracks).toEqual([trackA, trackB]);
+  });
+});

--- a/frontend/src/AuthenticatedApp.tsx
+++ b/frontend/src/AuthenticatedApp.tsx
@@ -13,6 +13,7 @@ import { useDocumentTitle } from "./hooks/useDocumentTitle";
 import { useInfiniteLibrary } from "./hooks/useInfiniteLibrary";
 import { useLibraryCommands } from "./hooks/useLibraryCommands";
 import { useLibraryData } from "./hooks/useLibraryData";
+import { useLibraryNavigation } from "./hooks/useLibraryNavigation";
 import { usePlaybackCommands } from "./hooks/usePlaybackCommands";
 import { usePlaybackState } from "./hooks/usePlaybackState";
 import { useRecentlyUploaded } from "./hooks/useRecentlyUploaded";
@@ -73,6 +74,18 @@ export function AuthenticatedApp({
     selectArtist, clearSelectedArtist, selectArtistAlbum, clearSelectedArtistAlbum,
     selectAlbum, clearSelectedAlbum
   } = useLibraryData({ user, activeView, activeLibrarySection });
+
+  // ── Library navigation ───────────────────────────────────────────────
+  const { goToSection, openPlaylists, openArtist, openAlbum, resetSelections } = useLibraryNavigation({
+    setActiveView,
+    setActiveLibrarySection,
+    setPlaylistDetailId,
+    selectArtist,
+    clearSelectedArtist,
+    clearSelectedArtistAlbum,
+    selectAlbum,
+    clearSelectedAlbum
+  });
 
   // ── Recently uploaded ────────────────────────────────────────────────
   const {
@@ -250,9 +263,7 @@ export function AuthenticatedApp({
     }
     setActiveView(nextView);
     setPlaylistDetailId(null);
-    clearSelectedArtist();
-    clearSelectedArtistAlbum();
-    clearSelectedAlbum();
+    resetSelections();
   }
 
   function handleCollapsePlayer(): void {
@@ -283,24 +294,8 @@ export function AuthenticatedApp({
       previewTrackId: selectedTrackRefreshed.id
     };
 
-    navigateTo("library", "artists");
-    setActiveView("library");
-    setActiveLibrarySection("artists");
-    setPlaylistDetailId(null);
-    clearSelectedAlbum();
-    clearSelectedArtistAlbum();
-    selectArtist(artistEntry);
-  }, [
-    clearSelectedAlbum,
-    clearSelectedArtistAlbum,
-    library.artists,
-    libraryArtists,
-    selectArtist,
-    selectedTrackRefreshed,
-    setActiveLibrarySection,
-    setActiveView,
-    setPlaylistDetailId
-  ]);
+    openArtist(artistEntry);
+  }, [library.artists, libraryArtists, openArtist, selectedTrackRefreshed]);
 
   const handleOpenCurrentTrackAlbum = useCallback((): void => {
     if (!selectedTrackRefreshed) {
@@ -338,24 +333,8 @@ export function AuthenticatedApp({
       previewTrackId: selectedTrackRefreshed.id
     };
 
-    navigateTo("library", "albums");
-    setActiveView("library");
-    setActiveLibrarySection("albums");
-    setPlaylistDetailId(null);
-    clearSelectedArtist();
-    clearSelectedArtistAlbum();
-    selectAlbum(albumEntry);
-  }, [
-    clearSelectedArtist,
-    clearSelectedArtistAlbum,
-    library.albums,
-    libraryAlbums,
-    selectAlbum,
-    selectedTrackRefreshed,
-    setActiveLibrarySection,
-    setActiveView,
-    setPlaylistDetailId
-  ]);
+    openAlbum(albumEntry);
+  }, [library.albums, libraryAlbums, openAlbum, selectedTrackRefreshed]);
 
   async function handleLogout(): Promise<void> {
     await logout();
@@ -484,12 +463,8 @@ export function AuthenticatedApp({
               trackCount: album.trackCount,
               cover: album.coverTrackId
             };
-            navigateTo("library", "albums");
-            setActiveLibrarySection("albums");
-            setPlaylistDetailId(null);
-            clearSelectedArtist();
-            clearSelectedArtistAlbum();
-            selectAlbum(albumEntry);
+            // Already inside the library view here, so the view stays put.
+            openAlbum(albumEntry, { setView: false });
           },
           ownerNameById,
           radioLoading: loadingRadio,
@@ -500,14 +475,7 @@ export function AuthenticatedApp({
             setActiveView("player");
             startRadioPlayback();
           },
-          onNavigateToLibrary: () => {
-            navigateTo("library", "music");
-            setActiveLibrarySection("music");
-            setPlaylistDetailId(null);
-            clearSelectedArtist();
-            clearSelectedArtistAlbum();
-            clearSelectedAlbum();
-          },
+          onNavigateToLibrary: () => goToSection("music"),
           resumeState,
           onResume: (track, positionSec) => {
             setPlayerStatusMessage(null);
@@ -519,22 +487,8 @@ export function AuthenticatedApp({
             void dismissResume();
           },
           forYouPlaylists,
-          onSelectForYouPlaylist: (playlistId: string) => {
-            navigateTo("library", "playlists");
-            setActiveLibrarySection("playlists");
-            setPlaylistDetailId(playlistId);
-            clearSelectedArtist();
-            clearSelectedArtistAlbum();
-            clearSelectedAlbum();
-          },
-          onNavigateToPlaylists: () => {
-            navigateTo("library", "playlists");
-            setActiveLibrarySection("playlists");
-            setPlaylistDetailId(null);
-            clearSelectedArtist();
-            clearSelectedArtistAlbum();
-            clearSelectedAlbum();
-          }
+          onSelectForYouPlaylist: (playlistId: string) => openPlaylists(playlistId),
+          onNavigateToPlaylists: () => openPlaylists()
         },
         musicProps: {
           owners: library.owners,

--- a/frontend/src/hooks/useLibraryNavigation.ts
+++ b/frontend/src/hooks/useLibraryNavigation.ts
@@ -1,0 +1,129 @@
+import { useCallback, type Dispatch, type SetStateAction } from "react";
+
+import type { AlbumEntry, ArtistEntry } from "../types";
+import type { LibrarySection } from "../types/library";
+import { navigateTo, type ViewName } from "../utils/appUtils";
+
+type UseLibraryNavigationArgs = {
+  setActiveView: Dispatch<SetStateAction<ViewName>>;
+  setActiveLibrarySection: Dispatch<SetStateAction<LibrarySection>>;
+  setPlaylistDetailId: Dispatch<SetStateAction<string | null>>;
+  selectArtist: (artist: ArtistEntry) => void;
+  clearSelectedArtist: () => void;
+  clearSelectedArtistAlbum: () => void;
+  selectAlbum: (album: AlbumEntry) => void;
+  clearSelectedAlbum: () => void;
+};
+
+export type UseLibraryNavigationResult = {
+  /** Move to a library section, dropping every drill-down selection. */
+  goToSection: (section: LibrarySection) => void;
+  /** Open the playlists section, optionally focused on one playlist. */
+  openPlaylists: (playlistDetailId?: string | null) => void;
+  /** Open the artists section focused on `artist`. */
+  openArtist: (artist: ArtistEntry) => void;
+  /**
+   * Open the albums section focused on `album`. Pass `setView: false` when the
+   * caller is already inside the library view and only changes section.
+   */
+  openAlbum: (album: AlbumEntry, options?: { setView?: boolean }) => void;
+  /** Drop every drill-down selection without changing section. */
+  resetSelections: () => void;
+};
+
+/**
+ * Library navigation in one place.
+ *
+ * Moving between library sections always meant the same dance — push the route,
+ * set the section, drop the playlist detail id, and clear the artist/album
+ * drill-down state — repeated at six call sites in `AuthenticatedApp` with
+ * slightly different subsets each time.
+ *
+ * One subtlety is deliberately preserved: when navigating *in order to* select
+ * an album, the previously selected album is NOT cleared first. `selectAlbum`
+ * short-circuits when the same album is selected again, which keeps its already
+ * loaded tracks; clearing first would defeat that guard and force a refetch.
+ * `selectArtist` resets its own sub-state, so it has no such constraint.
+ */
+export function useLibraryNavigation({
+  setActiveView,
+  setActiveLibrarySection,
+  setPlaylistDetailId,
+  selectArtist,
+  clearSelectedArtist,
+  clearSelectedArtistAlbum,
+  selectAlbum,
+  clearSelectedAlbum
+}: UseLibraryNavigationArgs): UseLibraryNavigationResult {
+  const resetSelections = useCallback((): void => {
+    clearSelectedArtist();
+    clearSelectedArtistAlbum();
+    clearSelectedAlbum();
+  }, [clearSelectedArtist, clearSelectedArtistAlbum, clearSelectedAlbum]);
+
+  const goToSection = useCallback(
+    (section: LibrarySection): void => {
+      navigateTo("library", section);
+      setActiveLibrarySection(section);
+      setPlaylistDetailId(null);
+      resetSelections();
+    },
+    [resetSelections, setActiveLibrarySection, setPlaylistDetailId]
+  );
+
+  const openPlaylists = useCallback(
+    (playlistDetailId: string | null = null): void => {
+      navigateTo("library", "playlists");
+      setActiveLibrarySection("playlists");
+      setPlaylistDetailId(playlistDetailId);
+      resetSelections();
+    },
+    [resetSelections, setActiveLibrarySection, setPlaylistDetailId]
+  );
+
+  const openArtist = useCallback(
+    (artist: ArtistEntry): void => {
+      navigateTo("library", "artists");
+      setActiveView("library");
+      setActiveLibrarySection("artists");
+      setPlaylistDetailId(null);
+      // No clearSelectedArtist: selectArtist resets its own sub-state below.
+      clearSelectedAlbum();
+      clearSelectedArtistAlbum();
+      selectArtist(artist);
+    },
+    [
+      clearSelectedAlbum,
+      clearSelectedArtistAlbum,
+      selectArtist,
+      setActiveLibrarySection,
+      setActiveView,
+      setPlaylistDetailId
+    ]
+  );
+
+  const openAlbum = useCallback(
+    (album: AlbumEntry, options?: { setView?: boolean }): void => {
+      navigateTo("library", "albums");
+      if (options?.setView !== false) {
+        setActiveView("library");
+      }
+      setActiveLibrarySection("albums");
+      setPlaylistDetailId(null);
+      // No clearSelectedAlbum: that would defeat selectAlbum's identity guard.
+      clearSelectedArtist();
+      clearSelectedArtistAlbum();
+      selectAlbum(album);
+    },
+    [
+      clearSelectedArtist,
+      clearSelectedArtistAlbum,
+      selectAlbum,
+      setActiveLibrarySection,
+      setActiveView,
+      setPlaylistDetailId
+    ]
+  );
+
+  return { goToSection, openPlaylists, openArtist, openAlbum, resetSelections };
+}


### PR DESCRIPTION
## Contexte

Item **P2-7** de la revue. En mesurant avant d'agir, deux constats ont recadré le travail :

1. **Le diagnostic initial était partiellement faux.** `AppShell` expose 22 props avec 4 bundles groupés — pas des « dizaines de props » à plat. Et les 18 hooks personnalisés montrent que la décomposition a déjà été largement faite. `AuthenticatedApp` est un **composition root**, et un composition root est légitimement large.
2. **Le vrai problème n'était pas la taille, mais une duplication.** Le combo `navigateTo` + `setActiveLibrarySection` + `setPlaylistDetailId(null)` + les trois `clearSelected*` était réécrit à la main **sur six sites**, avec un sous-ensemble différent à chaque fois.

## 1. Un filet, d'abord (`test`)

`AuthenticatedApp` et `AppShell` n'avaient **aucun test** : sur 247 tests frontend, zéro ne touchait le fichier qui câble tout. Refactorer ça à l'aveugle aurait été imprudent.

Plutôt que de rendre tout l'arbre (ce qui testerait les enfants), **`AppShell` est mocké pour capturer ce que la racine assemble**. Le câblage devient l'unité sous test : props de haut niveau, chaque sous-bundle, la dérivation de `manageablePlaylists`, la fusion de la map des noms de propriétaires, le bundle du lecteur audio.

## 2. Le refactor (`refactor`)

`useLibraryNavigation` expose `goToSection` / `openPlaylists` / `openArtist` / `openAlbum` / `resetSelections`.

- **640 → 594 lignes** dans `AuthenticatedApp`
- **0 séquence de clear écrite à la main** restante (contre 6)

### Une subtilité préservée volontairement

`selectAlbum` a une **garde d'identité** :

```ts
if (selectedAlbum && getAlbumKey(album) === getAlbumKey(selectedAlbum)) return;
```

Rouvrir l'album déjà ouvert ne recharge donc pas ses pistes. « Tout nettoyer puis sélectionner » — la factorisation naïve — aurait annulé cette garde et provoqué un rechargement inutile. `openAlbum` ne nettoie donc **pas** l'album courant, et le commentaire explique pourquoi. `selectArtist` réinitialise son propre sous-état et n'a pas cette contrainte.

## Vérification

- Type-check frontend et lint : **0 erreur**
- **254/254** tests frontend (247 + 7 nouveaux)
- **Conduit dans l'app réelle** : les trois chemins refactorés (`/library/music`, `/library/artists`, `/library/playlists`), **0 erreur console**

## Volontairement pas fait

Les ~183 lignes de `libraryWorkspaceProps` restent inline dans le JSX. Les déplacer en constante au-dessus du `return` est **purement cosmétique** : aucune duplication supprimée, aucune ligne gagnée, et 130 lignes à recopier — donc un risque de transcription pour un bénéfice de lisibilité seul. À faire dans une passe dédiée si tu le souhaites, mais ça ne méritait pas d'être mélangé à un changement de comportement vérifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
