### PR TITLE
perf(frontend): coalesce in-flight GETs (P2-8 outcome: react-query not adopted)

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getCurrentUser, getMySessions, setUnauthorizedHandler } from "./api";
+import { requestJson } from "./api/client";
 
 type MockResponseInit = {
   status: number;
@@ -63,5 +64,68 @@ describe("api unauthorized handler", () => {
     mockFetchOnce({ status: 403, body: { error: "forbidden" } });
     await expect(getMySessions()).rejects.toThrow("forbidden");
     expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("in-flight GET coalescing", () => {
+  it("shares one round-trip between concurrent identical GETs", async () => {
+    mockFetchOnce({ status: 200, body: { value: 42 } });
+
+    const [first, second] = await Promise.all([
+      requestJson<{ value: number }>("/api/library"),
+      requestJson<{ value: number }>("/api/library")
+    ]);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(first).toEqual({ value: 42 });
+    // Same resolved object, which is why payloads must stay treated as immutable.
+    expect(second).toBe(first);
+  });
+
+  it("does not cache: a later identical GET hits the network again", async () => {
+    mockFetchOnce({ status: 200, body: { value: 1 } });
+    await requestJson("/api/library");
+
+    mockFetchOnce({ status: 200, body: { value: 2 } });
+    const second = await requestJson("/api/library");
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(second).toEqual({ value: 2 });
+  });
+
+  it("keeps distinct paths independent", async () => {
+    mockFetchOnce({ status: 200, body: { a: true } });
+    mockFetchOnce({ status: 200, body: { b: true } });
+
+    const [a, b] = await Promise.all([
+      requestJson("/api/library"),
+      requestJson("/api/artists")
+    ]);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(a).toEqual({ a: true });
+    expect(b).toEqual({ b: true });
+  });
+
+  it("never shares mutations", async () => {
+    mockFetchOnce({ status: 200, body: { ok: 1 } });
+    mockFetchOnce({ status: 200, body: { ok: 2 } });
+
+    await Promise.all([
+      requestJson("/api/radio/create", { method: "POST" }),
+      requestJson("/api/radio/create", { method: "POST" })
+    ]);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the entry when the shared request fails", async () => {
+    mockFetchOnce({ status: 500, body: { error: "boom" } });
+    await expect(requestJson("/api/library")).rejects.toThrow("boom");
+
+    // A failed request must not leave a poisoned entry behind.
+    mockFetchOnce({ status: 200, body: { recovered: true } });
+    await expect(requestJson("/api/library")).resolves.toEqual({ recovered: true });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -42,7 +42,51 @@ export function withApiBase(path: string): string {
   return `${API_BASE}${path}`;
 }
 
+/**
+ * Identical GETs already in flight, keyed by path.
+ *
+ * Independent hooks legitimately ask for the same resource at the same moment —
+ * `useLibraryData` runs one effect keyed on `filters` and another keyed on
+ * `user`, and with no filters applied both request `/api/library` on mount.
+ * They share the single round-trip instead of racing two.
+ *
+ * This is coalescing, not caching: an entry lives only until its request
+ * settles, so every new call still hits the network. Callers do receive the
+ * same resolved object, which is safe here because API payloads are treated as
+ * immutable state.
+ */
+const inFlightGets = new Map<string, Promise<unknown>>();
+
 export async function requestJson<T>(path: string, options: RequestOptions = {}): Promise<T> {
+  const method = (options.method ?? "GET").toUpperCase();
+  // Only plain reads are shared: anything carrying a body, custom headers or a
+  // non-GET method may not be interchangeable between callers.
+  const coalescable =
+    method === "GET" && !options.body && !options.headers && !options.skipJson;
+
+  if (coalescable) {
+    const existing = inFlightGets.get(path) as Promise<T> | undefined;
+    if (existing) {
+      return existing;
+    }
+  }
+
+  const request = performRequest<T>(path, options);
+
+  if (coalescable) {
+    inFlightGets.set(path, request);
+    const release = (): void => {
+      inFlightGets.delete(path);
+    };
+    // Both branches are handled, so this never surfaces as an unhandled
+    // rejection; the caller still sees the original promise's failure.
+    request.then(release, release);
+  }
+
+  return request;
+}
+
+async function performRequest<T>(path: string, options: RequestOptions): Promise<T> {
   const response = await fetch(withApiBase(path), {
     credentials: "include",
     ...options,


### PR DESCRIPTION
## Contexte

Cette PR est le **résultat de l'enquête P2-8** (adoption de `@tanstack/react-query`) — et sa conclusion est de **ne pas l'adopter**, avec les mesures à l'appui.

## Ce que la mesure a montré

Instrumentation de l'app réelle via l'API Performance, sur un chargement propre :

| Scénario | Résultat |
|---|---|
| Chargement initial | 40 requêtes API, 28 endpoints distincts |
| Quasi tous les doublons | exactement **2×** → double-invoke `React.StrictMode`, **dev uniquement** |
| `/api/library` | **4×** → soit **2 fetches réels**, la seule anomalie |
| Changement de section | **1 requête**, exactement la donnée manquante — aucune cascade |
| Retour sur section visitée | 1 refetch (pas de cache) |

**Le data layer est sain.** Je m'attendais à des cascades ; il n'y en a pas. Les hooks conservent leurs données et ne chargent que le manquant. Le seul apport net de react-query aurait été le cache au retour de section — environ 1 requête, sur une app self-hosted.

Le roadmap avait déjà tranché en D3 avec le bon critère (*« no concrete demand »*). Les mesures lui donnent raison. Le coût — réécrire ~15 hooks, toucher tous les chemins de données, préserver le point unique de gestion du 401, avec 1 seul spec e2e comme filet — était sans commune mesure avec le gain constaté.

## Le vrai défaut, et sa correction

`useLibraryData` lance deux effets indépendants : l'un cadencé par `filters` (ligne 165, `getLibrary(filters)`), l'autre par `user` (ligne 469, `getLibrary({})`). Sans filtre initial, ce sont **deux requêtes strictement identiques**.

Coupler les deux effets était l'alternative, mais leurs cycles de vie diffèrent légitimement. La fusion se fait donc à la **frontière transport** : plus petit, et général.

### Fusion, pas cache

Une entrée ne vit **que jusqu'à la résolution** de sa requête — rien n'est jamais servi périmé, et la décision D3 contre une couche de cache reste valable. Seules les lectures simples sont partagées : tout ce qui porte un corps, des en-têtes personnalisés ou une méthode non-GET est laissé intact, **les mutations ne sont jamais fusionnées**.

## Résultat mesuré

| | Avant | Après |
|---|---|---|
| Requêtes API au chargement | **40** | **29** (−27 %) |
| `/api/library` | **4×** | **1×** |
| Endpoints dupliqués | 10 | **1** |

Le dernier restant est `POST /api/radio/create` ×2 : volontairement non fusionné, et c'est du doublage StrictMode qui disparaît en production.

## Vérification

- Vérifié **dans l'app en marche** : comptage des requêtes, rendu correct, 0 erreur console
- **259/259** tests frontend, type-check et lint à 0 erreur
- 5 nouveaux tests verrouillent le contrat : partage des GET concurrents, **absence de cache**, indépendance des chemins, isolation des mutations, libération de l'entrée après échec

🤖 Generated with [Claude Code](https://claude.com/claude-code)
